### PR TITLE
Create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-analyzer", "rust-src"]


### PR DESCRIPTION
Adds a rust-toolchain.toml to prevent needing to switch toolchains manually