### PR TITLE
Add per-stage frame profiler to F3 debug overlay

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -62,6 +62,15 @@ enum RenderMode {
     },
 }
 
+#[derive(Default, Clone)]
+pub struct RenderTimings {
+    pub mesh_upload_ms: f32,
+    pub cull_ms: f32,
+    pub draw_ms: f32,
+    pub overlay_ms: f32,
+    pub frame_ms: f32,
+}
+
 pub struct Renderer {
     ctx: VulkanContext,
     swapchain: SwapchainState,
@@ -80,6 +89,7 @@ pub struct Renderer {
     swapchain_dirty: bool,
     width: u32,
     height: u32,
+    pub last_timings: RenderTimings,
 }
 
 impl Renderer {
@@ -240,6 +250,7 @@ impl Renderer {
             swapchain_dirty: false,
             width: size.width.max(1),
             height: size.height.max(1),
+            last_timings: RenderTimings::default(),
         })
     }
 
@@ -735,6 +746,8 @@ impl Renderer {
             let sw = self.swapchain.extent.width as f32;
             let sh = self.swapchain.extent.height as f32;
 
+            let frame_start = std::time::Instant::now();
+
             match &mode {
                 RenderMode::World {
                     overlay,
@@ -750,9 +763,11 @@ impl Renderer {
                         sky,
                     );
 
+                    let t_cull = std::time::Instant::now();
                     self.chunk_pipeline.bind(&self.ctx.device, cmd, frame);
                     self.chunk_buffers
                         .draw_indirect(&self.ctx.device, cmd, frame);
+                    let cull_ms = t_cull.elapsed().as_secs_f32() * 1000.0;
 
                     if let Some((block_pos, stage)) = destroy_info {
                         self.block_overlay_pipeline.draw(
@@ -792,8 +807,18 @@ impl Renderer {
                         *swing_progress,
                     );
 
+                    let t_overlay = std::time::Instant::now();
                     self.menu_pipeline
                         .draw(&self.ctx.device, cmd, sw, sh, overlay);
+                    let overlay_ms = t_overlay.elapsed().as_secs_f32() * 1000.0;
+
+                    self.last_timings = RenderTimings {
+                        mesh_upload_ms: 0.0,
+                        cull_ms,
+                        draw_ms: 0.0,
+                        overlay_ms,
+                        frame_ms: frame_start.elapsed().as_secs_f32() * 1000.0,
+                    };
                 }
                 RenderMode::MainMenu {
                     scroll,

--- a/src/ui/hud.rs
+++ b/src/ui/hud.rs
@@ -3,6 +3,14 @@ use azalea_core::position::BlockPos;
 use super::common::WHITE;
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
 
+pub struct FrameTimings {
+    pub mesh_upload_ms: f32,
+    pub cull_ms: f32,
+    pub draw_ms: f32,
+    pub overlay_ms: f32,
+    pub frame_ms: f32,
+}
+
 pub struct DebugInfo<'a> {
     pub fps: u32,
     pub position: glam::Vec3,
@@ -14,6 +22,7 @@ pub struct DebugInfo<'a> {
     pub vulkan_version: &'a str,
     pub screen_w: u32,
     pub screen_h: u32,
+    pub timings: Option<FrameTimings>,
 }
 
 const CROSSHAIR_SIZE: f32 = 10.0;
@@ -256,11 +265,20 @@ fn build_debug_overlay(elements: &mut Vec<MenuElement>, info: &DebugInfo<'_>, gs
 
     push_debug_lines(elements, &left_lines, pad, pad, fs, true);
 
-    let right_lines: Vec<String> = vec![
+    let mut right_lines: Vec<String> = vec![
         info.vulkan_version.to_string(),
         format!("GPU: {}", info.gpu_name),
         format!("Display: {}x{}", info.screen_w, info.screen_h),
     ];
+
+    if let Some(t) = &info.timings {
+        right_lines.push(String::new());
+        right_lines.push(format!("Frame: {:.2}ms", t.frame_ms));
+        right_lines.push(format!("  Mesh: {:.2}ms", t.mesh_upload_ms));
+        right_lines.push(format!("  Cull: {:.2}ms", t.cull_ms));
+        right_lines.push(format!("  Draw: {:.2}ms", t.draw_ms));
+        right_lines.push(format!("  Overlay: {:.2}ms", t.overlay_ms));
+    }
     let right_x = info.screen_w as f32 - pad;
     push_debug_lines(elements, &right_lines, right_x, pad, fs, false);
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -930,12 +930,17 @@ impl ApplicationHandler for App {
                                 break 'redraw;
                             }
 
+                            let t_mesh = std::time::Instant::now();
                             if let (Some(dispatcher), Some(renderer)) =
                                 (&self.mesh_dispatcher, &mut self.renderer)
                             {
                                 for mesh in dispatcher.drain_results() {
                                     renderer.upload_chunk_mesh(&mesh);
                                 }
+                            }
+                            let mesh_upload_ms = t_mesh.elapsed().as_secs_f32() * 1000.0;
+                            if let Some(renderer) = &mut self.renderer {
+                                renderer.last_timings.mesh_upload_ms = mesh_upload_ms;
                             }
 
                             if !self.paused && !self.inventory_open && !self.chat.is_open() {
@@ -1020,6 +1025,13 @@ impl ApplicationHandler for App {
                                         vulkan_version: renderer.vulkan_version(),
                                         screen_w: renderer.screen_width(),
                                         screen_h: renderer.screen_height(),
+                                        timings: Some(hud::FrameTimings {
+                                            mesh_upload_ms: renderer.last_timings.mesh_upload_ms,
+                                            cull_ms: renderer.last_timings.cull_ms,
+                                            draw_ms: renderer.last_timings.draw_ms,
+                                            overlay_ms: renderer.last_timings.overlay_ms,
+                                            frame_ms: renderer.last_timings.frame_ms,
+                                        }),
                                     })
                                 } else {
                                     None


### PR DESCRIPTION
## Summary
- Adds CPU-side timing measurements for each render stage
- Displayed on the right side of the F3 debug overlay
- Shows: Frame total, Mesh upload, Cull/Draw, Overlay times in milliseconds

## Test plan
- [ ] Join server, press F3
- [ ] Verify timing values appear on right side below GPU info
- [ ] Check values update each frame and are reasonable