### PR TITLE
Load user skin from Mojang API for menu preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ dependencies = [
  "azalea-protocol",
  "azalea-registry",
  "azalea-world",
+ "base64",
  "bytemuck",
  "clap",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ sha1_smol = "1"
 zip = { version = "8.3.0", default-features = false, features = ["deflate"] }
 fontdue = "0.9.3"
 open = "5"
+base64 = "0.22"
 
 [build-dependencies]
 shaderc = "0.10"

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -612,6 +612,32 @@ impl Renderer {
         self.skin_preview.trigger_swing();
     }
 
+    pub fn load_player_skin(&mut self, uuid: &uuid::Uuid, rt: &tokio::runtime::Runtime) {
+        let uuid_str = uuid.to_string().replace('-', "");
+        let skin_pixels = rt.block_on(async { fetch_skin_texture(&uuid_str).await });
+        match skin_pixels {
+            Ok((pixels, w, h)) => {
+                self.hand_pipeline.reload_skin(
+                    &self.ctx.device,
+                    self.ctx.graphics_queue,
+                    self.ctx.command_pool,
+                    &self.ctx.allocator,
+                    &pixels,
+                    w,
+                    h,
+                );
+                self.skin_preview = SkinPreviewPipeline::new(
+                    &self.ctx.device,
+                    self.swapchain.render_pass,
+                    &self.ctx.allocator,
+                    self.hand_pipeline.skin_view(),
+                    self.hand_pipeline.skin_sampler(),
+                );
+            }
+            Err(e) => log::warn!("Failed to load player skin: {e}"),
+        }
+    }
+
     pub fn menu_text_width(&self, text: &str, scale: f32) -> f32 {
         self.menu_pipeline.text_width(text, scale)
     }
@@ -926,6 +952,65 @@ impl Renderer {
         self.ctx.advance_frame();
         Ok(())
     }
+}
+
+async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32), String> {
+    #[derive(serde::Deserialize)]
+    struct SessionProfile {
+        properties: Vec<ProfileProperty>,
+    }
+    #[derive(serde::Deserialize)]
+    struct ProfileProperty {
+        value: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct TexturesPayload {
+        textures: Textures,
+    }
+    #[derive(serde::Deserialize)]
+    struct Textures {
+        #[serde(rename = "SKIN")]
+        skin: Option<SkinTexture>,
+    }
+    #[derive(serde::Deserialize)]
+    struct SkinTexture {
+        url: String,
+    }
+
+    let url = format!("https://sessionserver.mojang.com/session/minecraft/profile/{uuid}");
+    let profile: SessionProfile = reqwest::get(&url)
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let value = &profile.properties.first().ok_or("No properties")?.value;
+
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|e| e.to_string())?;
+    let payload: TexturesPayload = serde_json::from_slice(&decoded).map_err(|e| e.to_string())?;
+
+    let skin_url = payload
+        .textures
+        .skin
+        .map(|s| s.url)
+        .ok_or("No skin texture")?;
+
+    let skin_bytes = reqwest::get(&skin_url)
+        .await
+        .map_err(|e| e.to_string())?
+        .bytes()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let img = image::load_from_memory(&skin_bytes).map_err(|e| e.to_string())?;
+    let rgba = img.to_rgba8();
+    let w = rgba.width();
+    let h = rgba.height();
+    Ok((rgba.into_raw(), w, h))
 }
 
 impl Drop for Renderer {

--- a/src/renderer/pipelines/hand.rs
+++ b/src/renderer/pipelines/hand.rs
@@ -140,17 +140,7 @@ impl HandPipeline {
 
         let skin_sampler = unsafe { util::create_nearest_sampler(device) };
 
-        let image_info = [vk::DescriptorImageInfo {
-            sampler: skin_sampler,
-            image_view: skin_view,
-            image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
-        }];
-        let skin_write = vk::WriteDescriptorSet::default()
-            .dst_set(skin_set)
-            .dst_binding(0)
-            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-            .image_info(&image_info);
-        unsafe { device.update_descriptor_sets(&[skin_write], &[]) };
+        update_skin_descriptor(device, skin_set, skin_view, skin_sampler);
 
         let vertices = build_arm_vertices(skin_w, skin_h);
         let vertex_count = vertices.len() as u32;
@@ -249,6 +239,47 @@ impl HandPipeline {
 
     pub fn skin_sampler(&self) -> vk::Sampler {
         self.skin_sampler
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn reload_skin(
+        &mut self,
+        device: &ash::Device,
+        queue: vk::Queue,
+        command_pool: vk::CommandPool,
+        allocator: &Arc<Mutex<Allocator>>,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+    ) {
+        let (image, view, allocation) = upload_skin_to_gpu(
+            device,
+            queue,
+            command_pool,
+            allocator,
+            pixels,
+            width,
+            height,
+        );
+
+        unsafe {
+            device.destroy_image_view(self.skin_view, None);
+            device.destroy_image(self.skin_image, None);
+        }
+        allocator
+            .lock()
+            .unwrap()
+            .free(std::mem::replace(&mut self.skin_allocation, unsafe {
+                std::mem::zeroed()
+            }))
+            .ok();
+
+        self.skin_image = image;
+        self.skin_view = view;
+        self.skin_allocation = allocation;
+        update_skin_descriptor(device, self.skin_set, self.skin_view, self.skin_sampler);
+
+        log::info!("Skin reloaded: {width}x{height}");
     }
 
     pub fn recreate_pipeline(&mut self, device: &ash::Device, render_pass: vk::RenderPass) {
@@ -402,11 +433,31 @@ fn load_skin_texture(
         fallback_skin()
     });
 
-    let (image, view, allocation) =
-        util::create_gpu_image(device, allocator, width, height, "hand_skin");
-    let (staging_buf, staging_alloc) =
-        util::create_staging_buffer(device, allocator, &pixels, "hand_skin_staging");
+    let (image, view, allocation) = upload_skin_to_gpu(
+        device,
+        queue,
+        command_pool,
+        allocator,
+        &pixels,
+        width,
+        height,
+    );
+    (image, view, allocation, width, height)
+}
 
+fn upload_skin_to_gpu(
+    device: &ash::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    allocator: &Arc<Mutex<Allocator>>,
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+) -> (vk::Image, vk::ImageView, Allocation) {
+    let (image, view, allocation) =
+        util::create_gpu_image(device, allocator, width, height, "skin");
+    let (staging_buf, staging_alloc) =
+        util::create_staging_buffer(device, allocator, pixels, "skin_staging");
     util::upload_image(
         device,
         queue,
@@ -416,11 +467,28 @@ fn load_skin_texture(
         width,
         height,
     );
-
     unsafe { device.destroy_buffer(staging_buf, None) };
     allocator.lock().unwrap().free(staging_alloc).ok();
+    (image, view, allocation)
+}
 
-    (image, view, allocation, width, height)
+fn update_skin_descriptor(
+    device: &ash::Device,
+    set: vk::DescriptorSet,
+    view: vk::ImageView,
+    sampler: vk::Sampler,
+) {
+    let image_info = [vk::DescriptorImageInfo {
+        sampler,
+        image_view: view,
+        image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+    }];
+    let write = vk::WriteDescriptorSet::default()
+        .dst_set(set)
+        .dst_binding(0)
+        .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+        .image_info(&image_info);
+    unsafe { device.update_descriptor_sets(&[write], &[]) };
 }
 
 fn fallback_skin() -> (Vec<u8>, u32, u32) {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -101,6 +101,7 @@ struct App {
     last_render_distance: u32,
     server_render_distance: u32,
     server_simulation_distance: u32,
+    pending_skin_uuid: Option<uuid::Uuid>,
 }
 
 struct FpsCounter {
@@ -170,6 +171,7 @@ impl App {
             last_render_distance: DEFAULT_RENDER_DISTANCE,
             server_render_distance: 0,
             server_simulation_distance: 0,
+            pending_skin_uuid: None,
             player: LocalPlayer::new(),
             tick_accumulator: 0.0,
             prev_player_pos: glam::Vec3::ZERO,
@@ -635,7 +637,7 @@ impl ApplicationHandler for App {
             }
         };
 
-        let renderer = match Renderer::new(
+        let mut renderer = match Renderer::new(
             Arc::clone(&window),
             &self.assets_dir,
             &self.asset_index,
@@ -650,6 +652,9 @@ impl ApplicationHandler for App {
         };
 
         self.mesh_dispatcher = Some(renderer.create_mesh_dispatcher());
+        if let Some(uuid) = self.pending_skin_uuid.take() {
+            renderer.load_player_skin(&uuid, &self.tokio_rt);
+        }
         self.renderer = Some(renderer);
         self.window = Some(window);
         self.apply_cursor_grab();
@@ -1183,6 +1188,7 @@ pub fn run(
     let event_loop = EventLoop::new()?;
     let mut app = App::new(connection, assets_dir, game_dir, tokio_rt);
     if let Some(auth) = auth {
+        app.pending_skin_uuid = Some(auth.uuid);
         app.menu
             .set_launch_auth(auth.username, auth.uuid, auth.access_token);
     }


### PR DESCRIPTION
## Summary
- Fetches signed-in user's skin from Mojang session server API
- Reloads skin texture on HandPipeline and SkinPreviewPipeline at runtime
- UUID stored from launcher auth, skin loaded after renderer creation

## Test plan
- [x] Sign in and verify player skin appears on main menu preview
- [x] Verify Steve fallback still works when not signed in