### PR TITLE
fix: recover poisoned allocator mutex in VulkanContext Drop

### DIFF
--- a/src/renderer/context.rs
+++ b/src/renderer/context.rs
@@ -261,7 +261,9 @@ impl Drop for VulkanContext {
             self.device.destroy_command_pool(self.command_pool, None);
 
             // Allocator must be dropped before the device
-            drop(self.allocator.lock().unwrap());
+            // unwrap_or_else recovers the allocator from a poisoned mutex so a
+            // panic during init (e.g. OOM) doesn't cause a second panic here.
+            drop(self.allocator.lock().unwrap_or_else(|e| e.into_inner()));
 
             self.device.destroy_device(None);
 


### PR DESCRIPTION
When the app crashes during startup (e.g running out of memory in ChunkBufferStore) Rust tries to clean up and runs Drop on VulkanContext and The problem is the allocator mutex was already poisoned by the first crash, so .unwrap() triggered a second panic during cleanup which causing an immediate abort on Windows with zero useful error output.
Swapping to unwrap_or_else(|e| e.into_inner()) grabs the inner allocator from the poisoned mutex and drops it cleanly, so the original error message actually shows up instead of just dying silently. 