### PR TITLE
fix(issue-#24): detach client process from launcher on Unix systems

### DIFF
--- a/launcher/src-tauri/src/commands.rs
+++ b/launcher/src-tauri/src/commands.rs
@@ -255,6 +255,9 @@ pub async fn launch_game(uuid: Option<String>, server: Option<String>) -> Result
         cmd.arg("--server").arg(server);
     }
 
+    #[cfg(unix)]
+    cmd.process_group(0);
+
     cmd.spawn().map_err(|e| e.to_string())?;
 
     Ok(format!("Launched as {username}"))


### PR DESCRIPTION
Fix for issue #24  

## Summary
- On Unix systems, sets the process group ID (PGID) of the client process to 0, creating a new isolated process group so that it doesn't receive a `SIGHUP` signal when the launcher closes.
- Shouldn't change any behavior on Windows.