### PR TITLE
Use vanilla UI buttons and MC bitmap font

### DIFF
--- a/src/renderer/pipelines/menu_overlay.rs
+++ b/src/renderer/pipelines/menu_overlay.rs
@@ -47,9 +47,6 @@ struct GlyphEntry {
     v1: f32,
     width_px: f32,
     height_px: f32,
-    x_offset: f32,
-    y_offset: f32,
-    advance: f32,
 }
 
 struct FontAtlas {
@@ -121,9 +118,6 @@ fn build_font_atlas() -> FontAtlas {
                 v1: (cursor_y + metrics.height as u32) as f32 * inv,
                 width_px: metrics.width as f32,
                 height_px: metrics.height as f32,
-                x_offset: metrics.xmin as f32,
-                y_offset: metrics.ymin as f32,
-                advance: metrics.advance_width,
             },
         );
 
@@ -510,20 +504,22 @@ impl MenuOverlayPipeline {
                     color,
                     centered,
                 } => {
-                    let start_x = if *centered {
-                        *x - self.text_width(text, *scale) / 2.0
-                    } else {
-                        *x
-                    };
-                    push_text_glyphs(
-                        &mut vertices,
-                        &self.atlas,
-                        start_x,
-                        *y,
-                        text,
-                        *scale,
-                        *color,
-                    );
+                    if let Some(ref gm) = self.mc_glyph_map {
+                        let start_x = if *centered {
+                            *x - self.mc_text_width(text, *scale) / 2.0
+                        } else {
+                            *x
+                        };
+                        let span = MotdSpan {
+                            text: text.clone(),
+                            color: *color,
+                            bold: false,
+                            italic: false,
+                            strikethrough: false,
+                            underline: false,
+                        };
+                        push_mc_text(&mut vertices, gm, start_x, *y, &[span], *scale);
+                    }
                 }
                 MenuElement::Icon {
                     x,
@@ -546,6 +542,19 @@ impl MenuOverlayPipeline {
                         push_textured_quad(&mut vertices, *x, *y, *w, *h, region, *tint, 2.0);
                     }
                 }
+                MenuElement::NineSlice {
+                    x,
+                    y,
+                    w,
+                    h,
+                    sprite,
+                    border,
+                    tint,
+                } => {
+                    if let Some(region) = self.sprite_atlas.regions.get(sprite) {
+                        push_nine_slice(&mut vertices, *x, *y, *w, *h, region, *border, *tint);
+                    }
+                }
                 MenuElement::ItemIcon {
                     x,
                     y,
@@ -558,9 +567,24 @@ impl MenuOverlayPipeline {
                         push_textured_quad(&mut vertices, *x, *y, *w, *h, region, *tint, 3.0);
                     }
                 }
-                MenuElement::McText { x, y, spans, scale } => {
+                MenuElement::McText {
+                    x,
+                    y,
+                    spans,
+                    scale,
+                    centered,
+                } => {
                     if let Some(ref gm) = self.mc_glyph_map {
-                        push_mc_text(&mut vertices, gm, *x, *y, spans, *scale);
+                        let start_x = if *centered {
+                            let total: f32 = spans
+                                .iter()
+                                .map(|s| self.mc_text_width(&s.text, *scale))
+                                .sum();
+                            *x - total / 2.0
+                        } else {
+                            *x
+                        };
+                        push_mc_text(&mut vertices, gm, start_x, *y, spans, *scale);
                     }
                 }
                 MenuElement::GradientRect {
@@ -658,14 +682,9 @@ impl MenuOverlayPipeline {
     }
 
     pub fn text_width(&self, text: &str, scale: f32) -> f32 {
-        let s = scale / RASTER_PX;
-        text.chars()
-            .filter_map(|ch| self.atlas.glyphs.get(&ch))
-            .map(|g| g.advance * s)
-            .sum()
+        self.mc_text_width(text, scale)
     }
 
-    #[allow(dead_code)]
     pub fn mc_text_width(&self, text: &str, scale: f32) -> f32 {
         let Some(ref gm) = self.mc_glyph_map else {
             return 0.0;
@@ -791,6 +810,15 @@ pub enum MenuElement {
         sprite: SpriteId,
         tint: [f32; 4],
     },
+    NineSlice {
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        sprite: SpriteId,
+        border: f32,
+        tint: [f32; 4],
+    },
     ItemIcon {
         x: f32,
         y: f32,
@@ -804,6 +832,7 @@ pub enum MenuElement {
         y: f32,
         spans: Vec<MotdSpan>,
         scale: f32,
+        centered: bool,
     },
     GradientRect {
         x: f32,
@@ -840,6 +869,9 @@ pub enum SpriteId {
     EmptyLeggings,
     EmptyBoots,
     EmptyShield,
+    ButtonNormal,
+    ButtonHover,
+    ButtonDisabled,
 }
 
 struct SpriteRegion {
@@ -927,6 +959,18 @@ fn build_sprite_atlas(
         (
             SpriteId::EmptyShield,
             "minecraft/textures/gui/sprites/container/slot/shield.png",
+        ),
+        (
+            SpriteId::ButtonNormal,
+            "minecraft/textures/gui/sprites/widget/button.png",
+        ),
+        (
+            SpriteId::ButtonHover,
+            "minecraft/textures/gui/sprites/widget/button_highlighted.png",
+        ),
+        (
+            SpriteId::ButtonDisabled,
+            "minecraft/textures/gui/sprites/widget/button_disabled.png",
         ),
     ];
 
@@ -1347,45 +1391,6 @@ fn push_gradient_rect(
     }
 }
 
-fn push_text_glyphs(
-    verts: &mut Vec<Vertex>,
-    atlas: &FontAtlas,
-    mut x: f32,
-    y: f32,
-    text: &str,
-    scale: f32,
-    color: [f32; 4],
-) {
-    let s = scale / RASTER_PX;
-    for ch in text.chars() {
-        let Some(g) = atlas.glyphs.get(&ch) else {
-            continue;
-        };
-        if g.width_px > 0.0 && g.height_px > 0.0 {
-            let gw = g.width_px * s;
-            let gh = g.height_px * s;
-            let gx = x + g.x_offset * s;
-            let gy = y + scale - g.y_offset * s - gh;
-            push_quad(
-                verts,
-                gx,
-                gy,
-                gw,
-                gh,
-                g.u0,
-                g.v0,
-                g.u1,
-                g.v1,
-                color,
-                1.0,
-                [0.0, 0.0],
-                0.0,
-            );
-        }
-        x += g.advance * s;
-    }
-}
-
 fn push_icon_glyph(
     verts: &mut Vec<Vertex>,
     atlas: &FontAtlas,
@@ -1444,6 +1449,57 @@ fn push_textured_quad(
         [0.0, 0.0],
         0.0,
     );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_nine_slice(
+    verts: &mut Vec<Vertex>,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    region: &SpriteRegion,
+    border: f32,
+    tint: [f32; 4],
+) {
+    let tex_w = region.u1 - region.u0;
+    let tex_h = region.v1 - region.v0;
+    let frac_x = 3.0 / 200.0;
+    let frac_y = 3.0 / 20.0;
+    let bu = frac_x * tex_w;
+    let bv = frac_y * tex_h;
+
+    let xs = [x, x + border, x + w - border, x + w];
+    let ys = [y, y + border, y + h - border, y + h];
+    let us = [region.u0, region.u0 + bu, region.u1 - bu, region.u1];
+    let vs = [region.v0, region.v0 + bv, region.v1 - bv, region.v1];
+
+    for row in 0..3 {
+        for col in 0..3 {
+            let qx = xs[col];
+            let qy = ys[row];
+            let qw = xs[col + 1] - xs[col];
+            let qh = ys[row + 1] - ys[row];
+            if qw <= 0.0 || qh <= 0.0 {
+                continue;
+            }
+            push_quad(
+                verts,
+                qx,
+                qy,
+                qw,
+                qh,
+                us[col],
+                vs[row],
+                us[col + 1],
+                vs[row + 1],
+                tint,
+                2.0,
+                [0.0, 0.0],
+                0.0,
+            );
+        }
+    }
 }
 
 fn push_mc_text(

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -1,12 +1,11 @@
-use crate::renderer::pipelines::menu_overlay::MenuElement;
+use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
 
 pub const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 pub const FONT_SIZE: f32 = 8.0;
 pub const BTN_H: f32 = 20.0;
 pub const BTN_NORMAL: [f32; 4] = [0.12, 0.13, 0.22, 0.7];
-pub const BTN_HOVER: [f32; 4] = [0.18, 0.20, 0.35, 0.85];
-pub const BTN_DISABLED: [f32; 4] = [0.08, 0.08, 0.14, 0.6];
 pub const COL_DISABLED: [f32; 4] = [0.35, 0.36, 0.45, 1.0];
+const BTN_BORDER: f32 = 3.0;
 
 pub fn push_overlay(elements: &mut Vec<MenuElement>, screen_w: f32, screen_h: f32, alpha: f32) {
     elements.push(MenuElement::Rect {
@@ -41,25 +40,27 @@ pub fn push_button(
 ) -> bool {
     let hovered = enabled && hit_test(cursor, [x, y, w, h]);
 
-    let (bg, text_col) = if !enabled {
-        (BTN_DISABLED, COL_DISABLED)
+    let (sprite, text_col) = if !enabled {
+        (SpriteId::ButtonDisabled, COL_DISABLED)
     } else if hovered {
-        (BTN_HOVER, WHITE)
+        (SpriteId::ButtonHover, WHITE)
     } else {
-        (BTN_NORMAL, WHITE)
+        (SpriteId::ButtonNormal, WHITE)
     };
 
-    elements.push(MenuElement::Rect {
+    elements.push(MenuElement::NineSlice {
         x,
         y,
         w,
         h,
-        corner_radius: 4.0 * gs,
-        color: bg,
+        sprite,
+        border: BTN_BORDER * gs,
+        tint: WHITE,
     });
+
     elements.push(MenuElement::Text {
         x: x + w / 2.0,
-        y: y + (h - fs) / 2.0,
+        y: y + (h - fs) / 2.0 + 1.0,
         text: label.into(),
         scale: fs,
         color: text_col,

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -678,7 +678,7 @@ impl MainMenu {
                         }
                     }
                     ICON_GEAR => {
-                        self.screen = Screen::Options;
+                        self.open_options();
                     }
                     ICON_PAINTBRUSH => {
                         self.theme_open = !self.theme_open;
@@ -2481,6 +2481,7 @@ fn push_server_status(
                 y: motd_y,
                 spans: motd.clone(),
                 scale: fs,
+                centered: false,
             });
 
             let player_text = format!("{online}/{max}");

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -881,14 +881,6 @@ impl ApplicationHandler for App {
                                     self.apply_display_mode();
                                 }
 
-                                if self.options_from_game && !self.menu.is_options_screen() {
-                                    self.state = GameState::InGame;
-                                    self.paused = true;
-                                    self.options_from_game = false;
-                                    self.apply_cursor_grab();
-                                    break 'redraw;
-                                }
-
                                 if result.clicked_button {
                                     if let Some(renderer) = &mut self.renderer {
                                         renderer.trigger_skin_swing();
@@ -1110,7 +1102,26 @@ impl ApplicationHandler for App {
                                     self.menu.gui_scale_setting,
                                 );
 
-                                if self.paused {
+                                if self.options_from_game {
+                                    let menu_input = MenuInput {
+                                        cursor: self.input.cursor_pos(),
+                                        clicked: self.input.left_just_pressed(),
+                                        mouse_held: self.input.left_held(),
+                                        typed_chars: self.input.drain_typed_chars(),
+                                        backspace: self.input.backspace_pressed(),
+                                        enter: self.input.enter_pressed(),
+                                        escape: self.input.escape_pressed(),
+                                        tab: self.input.tab_pressed(),
+                                        f5: self.input.f5_pressed(),
+                                        scroll_delta: self.input.consume_menu_scroll(),
+                                    };
+                                    let r = &*renderer;
+                                    let result = self
+                                        .menu
+                                        .build(sw, sh, &menu_input, |t, s| r.menu_text_width(t, s));
+                                    elements.extend(result.elements);
+                                    self.input.clear_click_events();
+                                } else if self.paused {
                                     let cursor = self.input.cursor_pos();
                                     let clicked = self.input.left_just_pressed();
                                     pause_action = pause::build_pause_menu(
@@ -1177,14 +1188,25 @@ impl ApplicationHandler for App {
                                 }
                                 PauseAction::Options => {
                                     self.menu.open_options();
-                                    self.state = GameState::Menu;
                                     self.options_from_game = true;
+                                    self.paused = false;
                                     self.apply_cursor_grab();
                                 }
                                 PauseAction::Disconnect => {
                                     self.disconnect_to_menu(None);
                                 }
                                 PauseAction::None => {}
+                            }
+
+                            if self.options_from_game {
+                                if self.menu.render_distance != self.last_render_distance {
+                                    self.sync_render_distance();
+                                }
+                                if !self.menu.is_options_screen() {
+                                    self.options_from_game = false;
+                                    self.paused = true;
+                                    self.apply_cursor_grab();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Load vanilla button textures (normal, hover, disabled) into sprite atlas
- Implement nine-slice rendering for buttons that stretch correctly at any width
- Switch all text rendering from Montserrat to Minecraft's ascii.png bitmap font
- In-game options now render as overlay on game world instead of showing panorama
- Remove unused Montserrat text rendering code

## Test plan
- [ ] Press Escape in-game, verify buttons match vanilla style
- [ ] Click Options, verify game world visible behind options overlay
- [ ] Verify button hover/disabled states show correct textures
- [ ] Verify text is MC bitmap font everywhere
- [ ] Resize window, verify buttons and text scale correctly