### PR TITLE
Fix auth on Firefox by URL-decoding OAuth code

### DIFF
--- a/launcher/src-tauri/src/auth.rs
+++ b/launcher/src-tauri/src/auth.rs
@@ -274,7 +274,10 @@ async fn listen_for_callback(expected_state: &str) -> Result<String, String> {
         return Err("State mismatch".to_string());
     }
 
-    let code = params.get("code").ok_or("Missing auth code")?.to_string();
+    let raw_code = params.get("code").ok_or("Missing auth code")?;
+    let code = urlencoding::decode(raw_code)
+        .map_err(|e| format!("Failed to decode auth code: {e}"))?
+        .into_owned();
 
     send_http_response(
         &mut stream,


### PR DESCRIPTION
## Summary
- URL-decode the authorization code from the browser redirect callback
- Firefox URL-encodes redirect query parameters more aggressively than Chrome/Edge
- Without decoding, the token exchange fails with "invalid_grant" on Firefox/Linux

## Test plan
- [x] Sign in on Firefox — should work now
- [x] Sign in on Chrome/Edge — still works (decoding a clean string is a no-op)