### PR TITLE
chore: Speed up CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: client
-          cache-on-failure: false
+          cache-on-failure: true
 
       - name: Format check
         run: cargo fmt -- --check
 
       - name: Clippy
         run: cargo clippy --release --all-targets --all-features -- -D warnings
-
-      - name: Build
-        run: cargo build --release
 
   launcher-backend:
     runs-on: windows-latest
@@ -46,7 +43,7 @@ jobs:
         with:
           workspaces: launcher/src-tauri
           shared-key: launcher
-          cache-on-failure: false
+          cache-on-failure: true
 
       - name: Format check
         working-directory: launcher/src-tauri


### PR DESCRIPTION
## Summary
- Remove redundant `cargo build --release` step — clippy already compiles everything in release mode
- Set `cache-on-failure: true` so dependency caches are preserved even when checks fail

## Test plan
- [x] Verify CI still passes
- [x] Confirm faster subsequent runs with warm cache