### PR TITLE
fix: macOS chunk rendering and present mode

### DIFF
--- a/src/renderer/chunk/buffer.rs
+++ b/src/renderer/chunk/buffer.rs
@@ -487,15 +487,25 @@ impl ChunkBufferStore {
         unsafe {
             device.cmd_bind_vertex_buffers(cmd, 0, &[self.vertex_buffer], &[0]);
             device.cmd_bind_index_buffer(cmd, self.index_buffer, 0, vk::IndexType::UINT32);
-            device.cmd_draw_indexed_indirect_count(
-                cmd,
-                self.indirect_buffers[frame],
-                0,
-                self.count_buffers[frame],
-                0,
-                max_draws,
-                std::mem::size_of::<DrawCommand>() as u32,
-            );
+            if cfg!(target_os = "macos") {
+                device.cmd_draw_indexed_indirect(
+                    cmd,
+                    self.indirect_buffers[frame],
+                    0,
+                    max_draws,
+                    std::mem::size_of::<DrawCommand>() as u32,
+                );
+            } else {
+                device.cmd_draw_indexed_indirect_count(
+                    cmd,
+                    self.indirect_buffers[frame],
+                    0,
+                    self.count_buffers[frame],
+                    0,
+                    max_draws,
+                    std::mem::size_of::<DrawCommand>() as u32,
+                );
+            }
         }
     }
 

--- a/src/renderer/swapchain.rs
+++ b/src/renderer/swapchain.rs
@@ -61,6 +61,8 @@ impl SwapchainState {
 
         let present_mode = if present_modes.contains(&vk::PresentModeKHR::MAILBOX) {
             vk::PresentModeKHR::MAILBOX
+        } else if present_modes.contains(&vk::PresentModeKHR::IMMEDIATE) {
+            vk::PresentModeKHR::IMMEDIATE
         } else {
             vk::PresentModeKHR::FIFO
         };


### PR DESCRIPTION
## Summary
- Fall back to `cmd_draw_indexed_indirect` on macOS since MoltenVK does not support `drawIndirectCount`
- Prefer `IMMEDIATE` present mode when `MAILBOX` is unavailable to avoid VSync lock on macOS

## Test plan
- [x] Verify chunks render on macOS (previously showed void)
- [x] Verify FPS is uncapped on macOS
- [x] Verify no regression on Windows (still uses MAILBOX + indirect count)