### PR TITLE
Fix floating-point precision at large coordinates

### DIFF
--- a/src/renderer/camera.rs
+++ b/src/renderer/camera.rs
@@ -1,4 +1,4 @@
-use glam::{Mat4, Vec3};
+use glam::{DVec3, Mat4, Vec3};
 
 use crate::window::input::InputState;
 
@@ -11,6 +11,7 @@ const PITCH_LIMIT: f32 = std::f32::consts::FRAC_PI_2 - 0.01;
 
 pub struct Camera {
     pub position: Vec3,
+    pub position_f64: DVec3,
     pub yaw: f32,
     pub pitch: f32,
     aspect_ratio: f32,
@@ -21,6 +22,7 @@ impl Camera {
     pub fn new(aspect_ratio: f32) -> Self {
         Self {
             position: Vec3::new(0.0, 2.0, 5.0),
+            position_f64: DVec3::new(0.0, 2.0, 5.0),
             yaw: 0.0,
             pitch: 0.0,
             aspect_ratio,
@@ -46,8 +48,19 @@ impl Camera {
 
     pub fn set_position(&mut self, position: Vec3, yaw_degrees: f32, pitch_degrees: f32) {
         self.position = position;
+        self.position_f64 = DVec3::new(position.x as f64, position.y as f64, position.z as f64);
         self.yaw = yaw_degrees.to_radians();
         self.pitch = pitch_degrees.to_radians();
+    }
+
+    pub fn set_position_f64(&mut self, pos: DVec3) {
+        self.position_f64 = pos;
+        self.position = pos.as_vec3();
+    }
+
+    #[allow(dead_code)]
+    pub fn camera_relative_f32(&self, world_pos: DVec3) -> Vec3 {
+        (world_pos - self.position_f64).as_vec3()
     }
 
     pub fn update_fov_modifier(&mut self, sprinting: bool) {
@@ -81,7 +94,7 @@ impl Camera {
             self.pitch.sin(),
             -self.yaw.cos() * self.pitch.cos(),
         );
-        let view = Mat4::look_to_rh(self.position, forward, UP);
+        let view = Mat4::look_to_rh(Vec3::ZERO, forward, UP);
         let fov = DEFAULT_FOV * self.fov_modifier;
         let mut proj = Mat4::perspective_rh(fov, self.aspect_ratio, NEAR, FAR);
         proj.y_axis.y *= -1.0;
@@ -93,12 +106,15 @@ impl Camera {
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct CameraUniform {
     view_proj: [[f32; 4]; 4],
+    camera_pos: [f32; 4],
 }
 
 impl CameraUniform {
     pub fn from_camera(camera: &Camera) -> Self {
+        let pos = camera.position;
         Self {
             view_proj: camera.view_projection().to_cols_array_2d(),
+            camera_pos: [pos.x, pos.y, pos.z, 0.0],
         }
     }
 }

--- a/src/renderer/chunk/buffer.rs
+++ b/src/renderer/chunk/buffer.rs
@@ -49,7 +49,7 @@ struct DrawCommand {
 struct FrustumData {
     planes: [[f32; 4]; 6],
     chunk_count: u32,
-    _pad: [u32; 3],
+    camera_pos: [f32; 3],
 }
 
 struct ChunkAlloc {
@@ -406,7 +406,7 @@ impl ChunkBufferStore {
         cmd: vk::CommandBuffer,
         frame: usize,
         frustum: &[[f32; 4]; 6],
-        _camera_pos: [f32; 3],
+        camera_pos: [f32; 3],
     ) {
         if self.chunks.is_empty() {
             return;
@@ -437,7 +437,7 @@ impl ChunkBufferStore {
         let frustum_data = FrustumData {
             planes: *frustum,
             chunk_count: count,
-            _pad: [0; 3],
+            camera_pos,
         };
         let frustum_bytes = bytemuck::bytes_of(&frustum_data);
         self.frustum_allocs[frame].mapped_slice_mut().unwrap()[..frustum_bytes.len()]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -490,8 +490,8 @@ impl Renderer {
         self.camera.update_look(input);
     }
 
-    pub fn sync_camera_to_player(&mut self, eye_pos: glam::Vec3, yaw: f32, pitch: f32) {
-        self.camera.position = eye_pos;
+    pub fn sync_camera_to_player(&mut self, eye_pos: glam::DVec3, yaw: f32, pitch: f32) {
+        self.camera.set_position_f64(eye_pos);
         self.camera.yaw = yaw;
         self.camera.pitch = pitch;
     }
@@ -523,6 +523,7 @@ impl Renderer {
     pub fn set_camera_position(&mut self, x: f64, y: f64, z: f64, yaw: f32, pitch: f32) {
         self.camera
             .set_position(glam::Vec3::new(x as f32, y as f32, z as f32), yaw, pitch);
+        self.camera.position_f64 = glam::DVec3::new(x, y, z);
     }
 
     pub fn wait_for_all_frames(&self) {

--- a/src/renderer/shaders/block_overlay.vert
+++ b/src/renderer/shaders/block_overlay.vert
@@ -2,6 +2,7 @@
 
 layout(set = 0, binding = 0) uniform CameraUniform {
     mat4 view_proj;
+    vec4 camera_pos;
 };
 
 layout(location = 0) in vec3 position;
@@ -10,6 +11,6 @@ layout(location = 1) in vec2 tex_coords;
 layout(location = 0) out vec2 v_uv;
 
 void main() {
-    gl_Position = view_proj * vec4(position, 1.0);
+    gl_Position = view_proj * vec4(position - camera_pos.xyz, 1.0);
     v_uv = tex_coords;
 }

--- a/src/renderer/shaders/chunk.vert
+++ b/src/renderer/shaders/chunk.vert
@@ -2,6 +2,7 @@
 
 layout(set = 0, binding = 0) uniform CameraUniform {
     mat4 view_proj;
+    vec4 camera_pos;
 };
 
 layout(location = 0) in vec3 position;
@@ -14,7 +15,7 @@ layout(location = 1) out float v_light;
 layout(location = 2) out vec3 v_tint;
 
 void main() {
-    gl_Position = view_proj * vec4(position, 1.0);
+    gl_Position = view_proj * vec4(position - camera_pos.xyz, 1.0);
     v_tex_coords = tex_coords;
     v_light = light;
     v_tint = tint;

--- a/src/renderer/shaders/cube.vert
+++ b/src/renderer/shaders/cube.vert
@@ -2,6 +2,7 @@
 
 layout(set = 0, binding = 0) uniform CameraUniform {
     mat4 view_proj;
+    vec4 camera_pos;
 };
 
 layout(location = 0) in vec3 position;
@@ -10,6 +11,6 @@ layout(location = 1) in vec3 color;
 layout(location = 0) out vec3 v_color;
 
 void main() {
-    gl_Position = view_proj * vec4(position, 1.0);
+    gl_Position = view_proj * vec4(position - camera_pos.xyz, 1.0);
     v_color = color;
 }

--- a/src/renderer/shaders/cull.comp
+++ b/src/renderer/shaders/cull.comp
@@ -26,6 +26,9 @@ layout(set = 0, binding = 0) readonly buffer MetaBuf {
 layout(set = 0, binding = 1) uniform FrustumBuf {
     vec4 planes[6];
     uint chunk_count;
+    float cam_x;
+    float cam_y;
+    float cam_z;
 };
 
 layout(set = 0, binding = 2) writeonly buffer IndirectBuf {
@@ -43,8 +46,9 @@ void main() {
     ChunkMeta m = chunks[idx];
     if (m.index_count == 0u) return;
 
-    vec3 mn = m.aabb_min.xyz;
-    vec3 mx = m.aabb_max.xyz;
+    vec3 cam = vec3(cam_x, cam_y, cam_z);
+    vec3 mn = m.aabb_min.xyz - cam;
+    vec3 mx = m.aabb_max.xyz - cam;
 
     for (int i = 0; i < 6; i++) {
         vec4 p = planes[i];

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1012,6 +1012,11 @@ impl ApplicationHandler for App {
                             let alpha = self.tick_accumulator / TICK_RATE;
                             let interp_pos = self.prev_player_pos.lerp(self.player.position, alpha);
                             let eye_pos = interp_pos + glam::Vec3::new(0.0, 1.62, 0.0);
+                            let eye_pos_f64 = glam::DVec3::new(
+                                eye_pos.x as f64,
+                                eye_pos.y as f64,
+                                eye_pos.z as f64,
+                            );
 
                             if !self.paused && !self.inventory_open && !self.chat.is_open() {
                                 let (yaw, pitch) = if let Some(r) = &self.renderer {
@@ -1043,7 +1048,7 @@ impl ApplicationHandler for App {
                                 (&mut self.renderer, &self.window)
                             {
                                 renderer.sync_camera_to_player(
-                                    eye_pos,
+                                    eye_pos_f64,
                                     renderer.camera_yaw(),
                                     renderer.camera_pitch(),
                                 );


### PR DESCRIPTION
## Summary
- Camera view matrix now renders at origin instead of absolute world position
- All vertex shaders subtract camera position for camera-relative coordinates
- Cull shader operates in camera-relative space for correct frustum culling
- Camera stores f64 position for precise subtraction before f32 cast

## Test plan
- [ ] Spawn at origin - rendering looks identical to before
- [ ] Teleport to X=100000 Z=100000 - blocks render at correct scale, no distortion
- [ ] Block breaking overlay renders at correct position at large coords
- [ ] Frustum culling still works (chunks behind camera not drawn)