### PR TITLE
Add player entity rendering

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -219,7 +219,8 @@ fn lerp_angle(from: f32, to: f32, alpha: f32) -> f32 {
 pub fn is_living_mob(kind: &EntityKind) -> bool {
     matches!(
         kind,
-        EntityKind::Pig
+        EntityKind::Player
+            | EntityKind::Pig
             | EntityKind::Cow
             | EntityKind::Sheep
             | EntityKind::Chicken

--- a/src/renderer/entity_model.rs
+++ b/src/renderer/entity_model.rs
@@ -235,6 +235,111 @@ pub fn bake_baby_pig_model() -> BakedEntityModel {
     bake_model(parts, 32, 32)
 }
 
+pub fn bake_player_model() -> BakedEntityModel {
+    let parts = vec![
+        EntityPart {
+            name: "head".into(),
+            offset: Vec3::new(0.0, 0.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-4.0, -8.0, -4.0),
+                size: Vec3::new(8.0, 8.0, 8.0),
+                tex_offset: (0, 0),
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "body".into(),
+            offset: Vec3::new(0.0, 0.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-4.0, 0.0, -2.0),
+                size: Vec3::new(8.0, 12.0, 4.0),
+                tex_offset: (16, 16),
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "right_arm".into(),
+            offset: Vec3::new(-5.0, 2.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-3.0, -2.0, -2.0),
+                size: Vec3::new(4.0, 12.0, 4.0),
+                tex_offset: (40, 16),
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "left_arm".into(),
+            offset: Vec3::new(5.0, 2.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-1.0, -2.0, -2.0),
+                size: Vec3::new(4.0, 12.0, 4.0),
+                tex_offset: (32, 48),
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "right_leg".into(),
+            offset: Vec3::new(-1.9, 12.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-2.0, 0.0, -2.0),
+                size: Vec3::new(4.0, 12.0, 4.0),
+                tex_offset: (0, 16),
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "left_leg".into(),
+            offset: Vec3::new(1.9, 12.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-2.0, 0.0, -2.0),
+                size: Vec3::new(4.0, 12.0, 4.0),
+                tex_offset: (16, 48),
+            }],
+            parent: None,
+        },
+    ];
+
+    bake_model(parts, 64, 64)
+}
+
+pub fn compute_humanoid_anim(
+    model: &BakedEntityModel,
+    head_pitch: f32,
+    head_yaw: f32,
+    walk_pos: f32,
+    walk_speed: f32,
+) -> Vec<(usize, Vec3)> {
+    let mut rotations = Vec::new();
+
+    for (i, part) in model.parts.iter().enumerate() {
+        let rot = match part.name.as_str() {
+            "head" => Vec3::new(head_pitch.to_radians(), head_yaw.to_radians(), 0.0),
+            "right_arm" => Vec3::new(
+                (walk_pos * 0.6662 + std::f32::consts::PI).cos() * 2.0 * walk_speed * 0.5,
+                0.0,
+                0.0,
+            ),
+            "left_arm" => Vec3::new((walk_pos * 0.6662).cos() * 2.0 * walk_speed * 0.5, 0.0, 0.0),
+            "right_leg" => Vec3::new((walk_pos * 0.6662).cos() * 1.4 * walk_speed, 0.0, 0.0),
+            "left_leg" => Vec3::new(
+                (walk_pos * 0.6662 + std::f32::consts::PI).cos() * 1.4 * walk_speed,
+                0.0,
+                0.0,
+            ),
+            _ => continue,
+        };
+        rotations.push((i, rot));
+    }
+
+    rotations
+}
+
 pub fn compute_quadruped_anim(
     model: &BakedEntityModel,
     head_pitch: f32,

--- a/src/renderer/pipelines/entity_renderer.rs
+++ b/src/renderer/pipelines/entity_renderer.rs
@@ -40,6 +40,7 @@ struct MobVariant {
 struct MobEntry {
     adult: MobVariant,
     baby: Option<MobVariant>,
+    anim: AnimationType,
 }
 
 impl MobEntry {
@@ -65,8 +66,15 @@ pub struct EntityRenderer {
     mobs: HashMap<EntityKind, MobEntry>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AnimationType {
+    Quadruped,
+    Humanoid,
+}
+
 struct MobDef {
     kind: EntityKind,
+    anim: AnimationType,
     adult_model: BakedEntityModel,
     adult_tex_keys: &'static [&'static str],
     adult_tex_size: u32,
@@ -76,18 +84,31 @@ struct MobDef {
 }
 
 fn mob_definitions() -> Vec<MobDef> {
-    vec![MobDef {
-        kind: EntityKind::Pig,
-        adult_model: entity_model::bake_pig_model(),
-        adult_tex_keys: &[
-            "minecraft/textures/entity/pig/pig_temperate.png",
-            "minecraft/textures/entity/pig/temperate_pig.png",
-        ],
-        adult_tex_size: 64,
-        baby_model: Some(entity_model::bake_baby_pig_model()),
-        baby_tex_keys: Some(&["minecraft/textures/entity/pig/pig_temperate_baby.png"]),
-        baby_tex_size: 32,
-    }]
+    vec![
+        MobDef {
+            kind: EntityKind::Pig,
+            anim: AnimationType::Quadruped,
+            adult_model: entity_model::bake_pig_model(),
+            adult_tex_keys: &[
+                "minecraft/textures/entity/pig/pig_temperate.png",
+                "minecraft/textures/entity/pig/temperate_pig.png",
+            ],
+            adult_tex_size: 64,
+            baby_model: Some(entity_model::bake_baby_pig_model()),
+            baby_tex_keys: Some(&["minecraft/textures/entity/pig/pig_temperate_baby.png"]),
+            baby_tex_size: 32,
+        },
+        MobDef {
+            kind: EntityKind::Player,
+            anim: AnimationType::Humanoid,
+            adult_model: entity_model::bake_player_model(),
+            adult_tex_keys: &["minecraft/textures/entity/player/wide/steve.png"],
+            adult_tex_size: 64,
+            baby_model: None,
+            baby_tex_keys: None,
+            baby_tex_size: 64,
+        },
+    ]
 }
 
 impl EntityRenderer {
@@ -222,7 +243,14 @@ impl EntityRenderer {
                 _ => None,
             };
 
-            mobs.insert(def.kind, MobEntry { adult, baby });
+            mobs.insert(
+                def.kind,
+                MobEntry {
+                    adult,
+                    baby,
+                    anim: def.anim,
+                },
+            );
         }
 
         Self {
@@ -280,20 +308,29 @@ impl EntityRenderer {
                     last_variant = variant_ptr;
                 }
 
-                let entity_mat =
-                    glam::Mat4::from_translation(glam::Vec3::new(
-                        info.x as f32,
-                        info.y as f32,
-                        info.z as f32,
-                    )) * glam::Mat4::from_rotation_y((180.0f32 - info.yaw).to_radians());
+                let entity_mat = glam::Mat4::from_translation(glam::Vec3::new(
+                    info.x as f32,
+                    info.y as f32,
+                    info.z as f32,
+                )) * glam::Mat4::from_scale(glam::Vec3::new(-1.0, -1.0, 1.0))
+                    * glam::Mat4::from_rotation_y((180.0f32 - info.yaw).to_radians());
 
-                let anim_rotations = entity_model::compute_quadruped_anim(
-                    &variant.model,
-                    info.pitch,
-                    info.head_yaw - info.yaw,
-                    info.walk_anim_pos,
-                    info.walk_anim_speed,
-                );
+                let anim_rotations = match entry.anim {
+                    AnimationType::Quadruped => entity_model::compute_quadruped_anim(
+                        &variant.model,
+                        info.pitch,
+                        info.head_yaw - info.yaw,
+                        info.walk_anim_pos,
+                        info.walk_anim_speed,
+                    ),
+                    AnimationType::Humanoid => entity_model::compute_humanoid_anim(
+                        &variant.model,
+                        info.pitch,
+                        info.head_yaw - info.yaw,
+                        info.walk_anim_pos,
+                        info.walk_anim_speed,
+                    ),
+                };
 
                 let part_transforms = variant.model.compute_part_transforms(&anim_rotations);
 


### PR DESCRIPTION
## Summary
- Player model with vanilla HumanoidModel geometry (head, body, 2 arms, 2 legs)
- Humanoid biped walk animation (arms swing opposite to legs)
- AnimationType enum for quadruped vs humanoid animation dispatch
- Scale(-1,-1,1) flip matching vanilla LivingEntityRenderer
- Default Steve texture, dynamic skins to follow

## Test plan
- [ ] Join server with another player — they render as Steve
- [ ] Player arms swing opposite to legs when walking
- [ ] Player faces correct direction (face visible when looking at them)
- [ ] Existing mob rendering (pigs) still works correctly
- [ ] Pigs face correct direction with scale flip applied