### PR TITLE
Fix entity spawn delay at login

### DIFF
--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -230,12 +230,26 @@ async fn config_sequence(
     view_distance: u8,
     event_tx: &Sender<NetworkEvent>,
 ) -> Result<azalea_core::registry_holder::RegistryHolder, ConnectionError> {
+    use azalea_core::delta::AzBuf;
     use azalea_core::registry_holder::RegistryHolder;
     use azalea_entity::HumanoidArm;
     use azalea_protocol::common::client_information::*;
     use azalea_protocol::packets::config::*;
 
     let mut registry_holder = RegistryHolder::default();
+
+    // Vanilla announces its brand in the config phase; some servers key off it.
+    let mut brand_payload = Vec::new();
+    String::from("pomme")
+        .azalea_write(&mut brand_payload)
+        .unwrap();
+    conn.write(ServerboundConfigPacket::CustomPayload(
+        s_custom_payload::ServerboundCustomPayload {
+            identifier: "minecraft:brand".into(),
+            data: brand_payload.into(),
+        },
+    ))
+    .await?;
 
     conn.write(ServerboundConfigPacket::ClientInformation(
         s_client_information::ServerboundClientInformation {

--- a/src/net/handler.rs
+++ b/src/net/handler.rs
@@ -63,6 +63,18 @@ pub fn handle_game_packet(
                     id: p.id,
                 },
             ));
+            // Vanilla echoes the position after every teleport; servers gate
+            // per-player entity tracking on it.
+            sender.send(ServerboundGamePacket::MovePlayerPosRot(
+                azalea_protocol::packets::game::s_move_player_pos_rot::ServerboundMovePlayerPosRot {
+                    pos: p.change.pos,
+                    look_direction: p.change.look_direction,
+                    flags: azalea_protocol::common::movements::MoveFlags {
+                        on_ground: false,
+                        horizontal_collision: false,
+                    },
+                },
+            ));
         }
         ClientboundGamePacket::KeepAlive(p) => {
             sender.send(ServerboundGamePacket::KeepAlive(

--- a/src/net/handler.rs
+++ b/src/net/handler.rs
@@ -70,7 +70,7 @@ pub fn handle_game_packet(
                     pos: p.change.pos,
                     look_direction: p.change.look_direction,
                     flags: azalea_protocol::common::movements::MoveFlags {
-                        on_ground: false,
+                        on_ground: true,
                         horizontal_collision: false,
                     },
                 },

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -98,6 +98,7 @@ struct App {
     data_dirs: DataDirs,
     asset_index: Option<AssetIndex>,
     position_set: bool,
+    player_loaded_sent: bool,
     state: GameState,
     menu: MainMenu,
     version: String,
@@ -222,6 +223,7 @@ impl App {
             entity_store: EntityStore::new(),
             asset_index: AssetIndex::load(&data_dirs.indexes_dir, &data_dirs.objects_dir, &version),
             position_set: false,
+            player_loaded_sent: false,
             state,
             menu: MainMenu::new(&data_dirs.game_dir, Arc::clone(&tokio_rt)),
             tokio_rt,
@@ -400,6 +402,7 @@ impl App {
         self.dead = false;
         self.death_message = String::new();
         self.position_set = false;
+        self.player_loaded_sent = false;
         self.chunk_store = ChunkStore::new(self.menu.render_distance);
         self.entity_store.clear();
         self.item_entity_store.clear();
@@ -451,6 +454,7 @@ impl App {
                     self.chunk_store =
                         ChunkStore::new_with_dimension(self.menu.render_distance, height, min_y);
                     self.position_set = false;
+                    self.player_loaded_sent = false;
                     if let Some(renderer) = &mut self.renderer {
                         renderer.clear_chunk_meshes();
                         self.mesh_dispatcher =
@@ -1373,6 +1377,18 @@ impl ApplicationHandler for App {
                                             .renderer
                                             .as_ref()
                                             .is_some_and(|r| r.loaded_chunk_count() > 0));
+
+                                // Mirror vanilla's `notifyPlayerLoaded`; servers gate
+                                // per-player entity tracking on it.
+                                if ready
+                                    && !self.player_loaded_sent
+                                    && let Some(sender) = &self.packet_sender
+                                {
+                                    sender.send(ServerboundGamePacket::PlayerLoaded(
+                                        azalea_protocol::packets::game::s_player_loaded::ServerboundPlayerLoaded,
+                                    ));
+                                    self.player_loaded_sent = true;
+                                }
 
                                 if ready {
                                     if let Some(p) = &mut self.presence {


### PR DESCRIPTION
## Summary

Three packets the server expects were missing. Without them, it holds back per-player entity tracking and mobs trickle in over several seconds while the player stands in an empty world.

- Echo `MovePlayerPosRot` after `AcceptTeleportation`.
- Send `ServerboundPlayerLoaded` once terrain is ready.
- Announce the client brand in the config phase.