### PR TITLE
Fix: styling issues in the patch notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and handles physics, networking, and UI without any Mojang code.
 The goal is a lightweight, performant alternative to the official Java client.
 
 <p align="center">
-  <img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/7c6bf87e-2b28-4497-97c0-766b1525cdb5" />
+    TODO: place
 </p>
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and handles physics, networking, and UI without any Mojang code.
 The goal is a lightweight, performant alternative to the official Java client.
 
 <p align="center">
-    TODO: place
+  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b8353f51-a23b-45c5-9f3d-457e498a5253" />
 </p>
 
 ## Features

--- a/launcher/src/App.tsx
+++ b/launcher/src/App.tsx
@@ -96,7 +96,7 @@ function App() {
         loadSkin(accs[0].uuid);
       }
     });
-    invoke<PatchNote[]>("get_patch_notes", { count: 6 })
+    invoke<PatchNote[]>("get_patch_notes", { count: 15 })
       .then(setNews)
       .catch((e) => console.error("Failed to fetch news:", e));
     invoke<GameVersion[]>("get_versions", { showSnapshots: false })

--- a/launcher/src/pages/News.tsx
+++ b/launcher/src/pages/News.tsx
@@ -1,3 +1,4 @@
+import { HiExternalLink } from "react-icons/hi";
 import { HiArrowLeft } from "react-icons/hi2";
 import { useAppStateContext } from "../lib/state";
 import { PatchNote } from "../lib/types";
@@ -25,8 +26,11 @@ export default function NewsPage({
               />
             </div>
             <div className="note-header-content">
-              <span className="news-type-badge">{selectedNote.entry_type}</span>
-              <span className="note-header-date">{selectedNote.date?.replace(/-/g, ".")}</span>
+              <div className="note-header-meta">
+                <span className="note-header-date">{selectedNote.date?.replace(/-/g, ".")}</span>
+                <span className="note-header-meta-divider" />
+                <span className="note-header-type">{selectedNote.entry_type}</span>
+              </div>
               <h2 className="note-header-title">{selectedNote.title}</h2>
             </div>
           </div>
@@ -60,6 +64,15 @@ export default function NewsPage({
             ))}
             {news.length === 0 && <p className="news-loading">Loading patch notes...</p>}
           </div>
+
+          <a
+            className="news-more-link"
+            href="https://aka.ms/MorePatchNotes"
+            target="_blank"
+            rel="noreferrer"
+          >
+            More patch notes <HiExternalLink />
+          </a>
         </>
       )}
     </div>

--- a/launcher/src/pages/News.tsx
+++ b/launcher/src/pages/News.tsx
@@ -1,7 +1,9 @@
-import { HiExternalLink } from "react-icons/hi";
-import { HiArrowLeft } from "react-icons/hi2";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { HiArrowLeft, HiArrowTopRightOnSquare } from "react-icons/hi2";
 import { useAppStateContext } from "../lib/state";
 import { PatchNote } from "../lib/types";
+
+const MORE_PATCH_NOTES_URL = "https://aka.ms/MorePatchNotes";
 
 export default function NewsPage({
   openPatchNote,
@@ -67,11 +69,13 @@ export default function NewsPage({
 
           <a
             className="news-more-link"
-            href="https://aka.ms/MorePatchNotes"
-            target="_blank"
-            rel="noreferrer"
+            href={MORE_PATCH_NOTES_URL}
+            onClick={(e) => {
+              e.preventDefault();
+              openUrl(MORE_PATCH_NOTES_URL);
+            }}
           >
-            More patch notes <HiExternalLink />
+            More patch notes <HiArrowTopRightOnSquare />
           </a>
         </>
       )}

--- a/launcher/src/styles.css
+++ b/launcher/src/styles.css
@@ -1812,6 +1812,24 @@ body {
   color: var(--text-muted);
 }
 
+.news-more-link {
+  display: block;
+  margin-top: 16px;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.news-more-link:hover {
+  color: var(--accent);
+}
+
 /* ═══ Note Viewer ═══ */
 
 .note-viewer {
@@ -1856,7 +1874,6 @@ body {
   width: 100%;
   max-height: 110px;
   min-height: 80px;
-  aspect-ratio: 90 / 9;
   margin-bottom: 20px;
   background: var(--glass);
   border: 1px solid var(--border);
@@ -1884,12 +1901,35 @@ body {
   padding: 20px 24px;
 }
 
-.note-header-content .news-type-badge {
-  position: relative;
-  top: unset;
-  left: unset;
-  z-index: unset;
-  align-self: flex-start;
+.note-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.note-header-type {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.note-header-meta-divider {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 50%, transparent);
+  flex-shrink: 0;
+}
+
+.note-header-date {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  color: var(--accent);
+  opacity: 0.8;
 }
 
 .note-header-title {
@@ -1902,14 +1942,6 @@ body {
   margin: 0;
 }
 
-.note-header-date {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--accent);
-  letter-spacing: 1.5px;
-  opacity: 0.8;
-}
-
 .note-body {
   background: var(--glass);
   backdrop-filter: blur(var(--glass-blur));
@@ -1919,6 +1951,10 @@ body {
   font-size: 13px;
   color: var(--text-dim);
   line-height: 1.8;
+}
+
+.note-body > *:last-child {
+  margin-bottom: 0;
 }
 
 .note-body h1,


### PR DESCRIPTION
## Summary
- Increase patch notes count in News page to `15`
- "More patch notes" link that redirects to https://aka.ms/MorePatchNotes

| normal | hovered |
| --- | --- |
| ![normal](https://github.com/user-attachments/assets/d631f997-db26-4e6a-886b-f6fb31e9b1f7) | ![hovered](https://github.com/user-attachments/assets/c407e8d1-60b1-4aa0-93b2-45ae1f74910b) |

- Style fixes:

| before | after |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/ae4aae43-1358-4828-a6a9-0b85a87f3ce7) | ![after](https://github.com/user-attachments/assets/20334f6d-88f3-4cc6-b483-3a789a784a4e) |

| normal screen (1080p) |
| --- |
| ![normal-screen](https://github.com/user-attachments/assets/b87d22dd-e30e-46d8-a2cd-e564ada5fd75) |
