### PR TITLE
Apply relative-move flags on teleport

### DIFF
--- a/src/net/handler.rs
+++ b/src/net/handler.rs
@@ -51,30 +51,15 @@ pub fn handle_game_packet(
             let _ = event_tx.try_send(NetworkEvent::ChunkCacheCenter { x: p.x, z: p.z });
         }
         ClientboundGamePacket::PlayerPosition(p) => {
-            let _ = event_tx.try_send(NetworkEvent::PlayerPosition {
-                x: p.change.pos.x,
-                y: p.change.pos.y,
-                z: p.change.pos.z,
-                yaw: p.change.look_direction.y_rot(),
-                pitch: p.change.look_direction.x_rot(),
-            });
             sender.send(ServerboundGamePacket::AcceptTeleportation(
                 azalea_protocol::packets::game::s_accept_teleportation::ServerboundAcceptTeleportation {
                     id: p.id,
                 },
             ));
-            // Vanilla echoes the position after every teleport; servers gate
-            // per-player entity tracking on it.
-            sender.send(ServerboundGamePacket::MovePlayerPosRot(
-                azalea_protocol::packets::game::s_move_player_pos_rot::ServerboundMovePlayerPosRot {
-                    pos: p.change.pos,
-                    look_direction: p.change.look_direction,
-                    flags: azalea_protocol::common::movements::MoveFlags {
-                        on_ground: true,
-                        horizontal_collision: false,
-                    },
-                },
-            ));
+            let _ = event_tx.try_send(NetworkEvent::PlayerPosition {
+                change: p.change.clone(),
+                relative: p.relative.clone(),
+            });
         }
         ClientboundGamePacket::KeepAlive(p) => {
             sender.send(ServerboundGamePacket::KeepAlive(

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -36,11 +36,8 @@ pub enum NetworkEvent {
         z: i32,
     },
     PlayerPosition {
-        x: f64,
-        y: f64,
-        z: f64,
-        yaw: f32,
-        pitch: f32,
+        change: azalea_protocol::common::movements::PositionMoveRotation,
+        relative: azalea_protocol::common::movements::RelativeMovements,
     },
     PlayerHealth {
         health: f32,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -495,29 +495,89 @@ impl App {
                     self.chunk_store
                         .set_center(azalea_core::position::ChunkPos::new(x, z));
                 }
-                NetworkEvent::PlayerPosition {
-                    x,
-                    y,
-                    z,
-                    yaw,
-                    pitch,
-                    ..
-                } => {
+                NetworkEvent::PlayerPosition { change, relative } => {
+                    let apply = |rel: bool, base: f64, change: f64| {
+                        if rel { base + change } else { change }
+                    };
+                    let new_pos = azalea_core::position::Vec3 {
+                        x: apply(relative.x, self.player.position.x as f64, change.pos.x),
+                        y: apply(relative.y, self.player.position.y as f64, change.pos.y),
+                        z: apply(relative.z, self.player.position.z as f64, change.pos.z),
+                    };
+                    let new_look = azalea_entity::LookDirection::new(
+                        apply(
+                            relative.y_rot,
+                            self.player.yaw.to_degrees() as f64,
+                            change.look_direction.y_rot() as f64,
+                        ) as f32,
+                        apply(
+                            relative.x_rot,
+                            self.player.pitch.to_degrees() as f64,
+                            change.look_direction.x_rot() as f64,
+                        ) as f32,
+                    );
+                    let new_vel = glam::Vec3::new(
+                        apply(
+                            relative.delta_x,
+                            self.player.velocity.x as f64,
+                            change.delta.x,
+                        ) as f32,
+                        apply(
+                            relative.delta_y,
+                            self.player.velocity.y as f64,
+                            change.delta.y,
+                        ) as f32,
+                        apply(
+                            relative.delta_z,
+                            self.player.velocity.z as f64,
+                            change.delta.z,
+                        ) as f32,
+                    );
+
+                    self.player.position =
+                        glam::Vec3::new(new_pos.x as f32, new_pos.y as f32, new_pos.z as f32);
+                    self.player.velocity = new_vel;
+                    self.player.yaw = new_look.y_rot().to_radians();
+                    self.player.pitch = new_look.x_rot().to_radians();
+                    self.prev_player_pos = self.player.position;
+
                     self.chunk_store
                         .set_center(azalea_core::position::ChunkPos::new(
-                            (x as i32).div_euclid(16),
-                            (z as i32).div_euclid(16),
+                            (new_pos.x as i32).div_euclid(16),
+                            (new_pos.z as i32).div_euclid(16),
                         ));
+
+                    if let Some(renderer) = &mut self.renderer {
+                        renderer.set_camera_position(
+                            new_pos.x,
+                            new_pos.y,
+                            new_pos.z,
+                            new_look.y_rot(),
+                            new_look.x_rot(),
+                        );
+                    }
+
                     if !self.position_set {
-                        self.player.position = glam::Vec3::new(x as f32, y as f32, z as f32);
-                        self.player.yaw = yaw.to_radians();
-                        self.player.pitch = pitch.to_radians();
-                        self.prev_player_pos = self.player.position;
-                        if let Some(renderer) = &mut self.renderer {
-                            renderer.set_camera_position(x, y, z, yaw, pitch);
-                        }
                         self.position_set = true;
-                        tracing::info!("Player position set to ({x:.1}, {y:.1}, {z:.1})");
+                        tracing::info!(
+                            "Player position set to ({:.1}, {:.1}, {:.1})",
+                            new_pos.x,
+                            new_pos.y,
+                            new_pos.z
+                        );
+                    }
+
+                    if let Some(sender) = &self.packet_sender {
+                        sender.send(ServerboundGamePacket::MovePlayerPosRot(
+                            azalea_protocol::packets::game::s_move_player_pos_rot::ServerboundMovePlayerPosRot {
+                                pos: new_pos,
+                                look_direction: new_look,
+                                flags: azalea_protocol::common::movements::MoveFlags {
+                                    on_ground: false,
+                                    horizontal_collision: false,
+                                },
+                            },
+                        ));
                     }
                 }
                 NetworkEvent::PlayerHealth {


### PR DESCRIPTION
## Summary

The `PlayerPosition` handler echoed the raw `p.change.pos`. That is correct for the first login teleport (fully absolute), but wrong for any subsequent teleport that sets relative-move flags. The client would echo unadjusted deltas instead of the resulting absolute position.

- Route `PlayerPosition` through `NetworkEvent` so the main thread has access to player state.
- Apply each axis' relative flag (position, look, velocity) against current player state.
- Update player, renderer camera, and chunk center, then echo the final absolute position.