### PR TITLE
Fix compile time error and use Position instead of [f32; 3] in client's audio 

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -484,7 +484,7 @@ impl AppCore {
                     seed,
                 } => {
                     let pos = (entity_id == game.player.entity_id)
-                        .then_some(game.player.position)
+                        .then_some(game.player.position + dvec3(0.0, 1.0, 0.0))
                         .or_else(|| game.entity_store.living.get(&entity_id).map(|e| e.position));
 
                     if let Some(pos) = pos {

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -467,21 +467,13 @@ impl AppCore {
                 NetworkEvent::PlaySound {
                     sound,
                     category,
-                    x,
-                    y,
-                    z,
+                    pos,
                     volume,
                     pitch,
                     seed,
                 } => {
-                    self.audio.play_world_sound(
-                        &sound,
-                        category,
-                        [x as f32, y as f32, z as f32],
-                        volume,
-                        pitch,
-                        seed,
-                    );
+                    self.audio
+                        .play_world_sound(&sound, category, pos, volume, pitch, seed);
                 }
                 NetworkEvent::PlayEntitySound {
                     sound,
@@ -491,18 +483,10 @@ impl AppCore {
                     pitch,
                     seed,
                 } => {
-                    let pos = if entity_id == game.player.entity_id {
-                        let p = game.player.position;
-                        Some([p.x, p.y + 1.0, p.z])
-                    } else {
-                        game.entity_store.living.get(&entity_id).map(|e| {
-                            [
-                                e.position.x as f32,
-                                e.position.y as f32,
-                                e.position.z as f32,
-                            ]
-                        })
-                    };
+                    let pos = (entity_id == game.player.entity_id)
+                        .then_some(game.player.position)
+                        .or_else(|| game.entity_store.living.get(&entity_id).map(|e| e.position));
+
                     if let Some(pos) = pos {
                         self.audio
                             .play_world_sound(&sound, category, pos, volume, pitch, seed);

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -184,7 +184,7 @@ pub fn update_game(
 ) -> GameUpdateResult {
     // Position the audio listener at the player's head and push current
     // volumes before draining sound packets this frame.
-    let listener_pos = game.player.position;
+    let listener_pos = game.player.eye_pos();
     core.audio
         .set_listener(listener_pos, game.player.look_dir.y_rot_deg());
     core.audio.set_volumes(core.menu.category_volumes());

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -185,10 +185,8 @@ pub fn update_game(
     // Position the audio listener at the player's head and push current
     // volumes before draining sound packets this frame.
     let listener_pos = game.player.position;
-    core.audio.set_listener(
-        [listener_pos.x, listener_pos.y + 1.62, listener_pos.z],
-        game.player.yaw,
-    );
+    core.audio
+        .set_listener(listener_pos, game.player.look_dir.y_rot_deg());
     core.audio.set_volumes(core.menu.category_volumes());
 
     let disconnect_reason =

--- a/pomme-client/src/audio/mod.rs
+++ b/pomme-client/src/audio/mod.rs
@@ -8,6 +8,7 @@ use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink, SpatialSink};
 
 use self::sounds::{SoundsIndex, sound_asset_key};
 use crate::assets::{AssetIndex, resolve_asset_path};
+use crate::entity::components::Position;
 
 const MENU_MUSIC_EVENT: &str = "music.menu";
 const UI_CLICK_EVENT: &str = "ui.button.click";
@@ -150,12 +151,13 @@ impl AudioEngine {
     }
 
     /// Updates the listener (camera) position and facing for positional audio.
-    /// `yaw` is the Minecraft yaw in radians (0 = +Z).
-    pub fn set_listener(&mut self, pos: [f32; 3], yaw: f32) {
-        let rx = -yaw.cos() * LISTENER_EAR_OFFSET;
-        let rz = -yaw.sin() * LISTENER_EAR_OFFSET;
-        self.listener_left = [pos[0] - rx, pos[1], pos[2] - rz];
-        self.listener_right = [pos[0] + rx, pos[1], pos[2] + rz];
+    pub fn set_listener(&mut self, pos: Position, y_rot_deg: f32) {
+        let y_rot = y_rot_deg.to_radians();
+        let rx = -y_rot.cos() * LISTENER_EAR_OFFSET;
+        let rz = -y_rot.sin() * LISTENER_EAR_OFFSET;
+
+        self.listener_left = [pos.x as f32 - rx, pos.y as f32, pos.z as f32 - rz];
+        self.listener_right = [pos.x as f32 + rx, pos.y as f32, pos.z as f32 + rz];
     }
 
     /// Plays the vanilla button click: MASTER category at the fixed `forUI`
@@ -175,7 +177,7 @@ impl AudioEngine {
         &self,
         sound: &SoundRef,
         category: u8,
-        pos: [f32; 3],
+        pos: Position,
         volume: f32,
         pitch: f32,
         seed: u64,
@@ -186,9 +188,12 @@ impl AudioEngine {
         let Some((source, entry_volume)) = self.decode_sound(sound, seed) else {
             return;
         };
-        let Ok(sink) =
-            SpatialSink::try_new(&output.handle, pos, self.listener_left, self.listener_right)
-        else {
+        let Ok(sink) = SpatialSink::try_new(
+            &output.handle,
+            pos.as_vec3().into(),
+            self.listener_left,
+            self.listener_right,
+        ) else {
             return;
         };
         let gain = self.category_gain(SoundCategory::from_index(category));

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Sender;
 
 use super::NetworkEvent;
 use super::sender::PacketSender;
+use crate::entity::components::Position;
 
 pub fn handle_game_packet(
     packet: &ClientboundGamePacket,
@@ -77,9 +78,7 @@ pub fn handle_game_packet(
             let _ = event_tx.try_send(NetworkEvent::PlaySound {
                 sound: resolve_sound(&p.sound),
                 category: p.source as u8,
-                x: p.x as f64 / 8.0,
-                y: p.y as f64 / 8.0,
-                z: p.z as f64 / 8.0,
+                pos: Position::new(p.x as f64 / 8.0, p.y as f64 / 8.0, p.z as f64 / 8.0),
                 volume: p.volume,
                 pitch: p.pitch,
                 seed: p.seed,

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -92,9 +92,7 @@ pub enum NetworkEvent {
     PlaySound {
         sound: crate::audio::SoundRef,
         category: u8,
-        x: f64,
-        y: f64,
-        z: f64,
+        pos: Position,
         volume: f32,
         pitch: f32,
         seed: u64,


### PR DESCRIPTION
## Summary
- Fix compile time error introduced in [09deeba](https://github.com/PommeMC/Client/commit/09deeba4af5f180ac61c3f1065e07b0fc48092b0).
- Use the `Position` struct instead of `[f32; 3]` for positions in the audio.