### PR TITLE
port vanilla GuiItemAtlas

### DIFF
--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1353,8 +1353,13 @@ fn build_gui_item_atlas(
     menu_tex_set: vk::DescriptorSet,
     slot_px: u32,
 ) -> pipelines::gui_item_atlas::GuiItemAtlas {
-    let atlas =
-        pipelines::gui_item_atlas::GuiItemAtlas::new(device, allocator, queue, command_pool, slot_px);
+    let atlas = pipelines::gui_item_atlas::GuiItemAtlas::new(
+        device,
+        allocator,
+        queue,
+        command_pool,
+        slot_px,
+    );
     atlas.bind_into_menu_tex_set(device, menu_tex_set);
     atlas
 }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1054,6 +1054,9 @@ impl Renderer {
                 0,
             ));
         if target_slot_px != self.gui_item_atlas.slot_px() {
+            // Mid-cmd-recording wait_idle: this cmd buffer is unsubmitted so
+            // holds no in-flight references, and `submit_one_time` inside the
+            // rebuild uses a separate primary cmd from the same pool.
             self.ctx.device.wait_idle().ok();
             self.gui_item_atlas
                 .destroy(&self.ctx.device, &self.ctx.allocator);
@@ -1077,8 +1080,13 @@ impl Renderer {
                 unique_names.insert(item_name.clone());
             }
         }
-        if !self.gui_item_atlas.has_space_for_all(&unique_names) {
-            self.gui_item_atlas.reclaim_space_for(&unique_names);
+        if !self.gui_item_atlas.has_space_for_all(&unique_names)
+            && !self.gui_item_atlas.reclaim_space_for(&unique_names)
+        {
+            tracing::warn!(
+                "gui_item_atlas: out of slots for {} unique items; some icons will not render",
+                unique_names.len()
+            );
         }
         let mut item_atlas_uvs: HashMap<String, [f32; 4]> = HashMap::new();
         struct BakeJob {
@@ -1110,13 +1118,13 @@ impl Renderer {
                     self.gui_item_atlas.clear_slot_color(cmd, &job.slot);
                 }
                 cmd.set_scissor(0, &[self.gui_item_atlas.scissor_rect(&job.slot)]);
-                let (sx, sy, sw_slot, _) = self.gui_item_atlas.slot_rect_pixels(&job.slot);
+                let (sx, sy) = self.gui_item_atlas.slot_origin_pixels(&job.slot);
                 self.gui_item_pipeline.bake_to_slot(
                     cmd,
                     &self.item_entity_pipeline,
-                    sx as u32,
-                    sy as u32,
-                    sw_slot,
+                    sx,
+                    sy,
+                    self.gui_item_atlas.slot_px(),
                     &job.name,
                     job.is_block,
                 );

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -313,14 +313,14 @@ impl Renderer {
 
         let initial_slot_px =
             pipelines::gui_item_atlas::slot_px_for_gui_scale(crate::ui::hud::gui_scale(sw, sh, 0));
-        let gui_item_atlas = pipelines::gui_item_atlas::GuiItemAtlas::new(
+        let gui_item_atlas = build_gui_item_atlas(
             &ctx.device,
             &ctx.allocator,
             ctx.graphics_queue,
             ctx.command_pool,
+            menu_pipeline.tex_descriptor_set(),
             initial_slot_px,
         );
-        gui_item_atlas.bind_into_menu_tex_set(&ctx.device, menu_pipeline.tex_descriptor_set());
 
         let gui_item_pipeline = pipelines::gui_item::GuiItemPipeline::new(
             &ctx.device,
@@ -1057,15 +1057,14 @@ impl Renderer {
             self.ctx.device.wait_idle().ok();
             self.gui_item_atlas
                 .destroy(&self.ctx.device, &self.ctx.allocator);
-            self.gui_item_atlas = pipelines::gui_item_atlas::GuiItemAtlas::new(
+            self.gui_item_atlas = build_gui_item_atlas(
                 &self.ctx.device,
                 &self.ctx.allocator,
                 self.ctx.graphics_queue,
                 self.ctx.command_pool,
+                self.menu_pipeline.tex_descriptor_set(),
                 target_slot_px,
             );
-            self.gui_item_atlas
-                .bind_into_menu_tex_set(&self.ctx.device, self.menu_pipeline.tex_descriptor_set());
             self.gui_item_pipeline
                 .set_atlas_px(self.gui_item_atlas.atlas_px());
         }
@@ -1344,6 +1343,20 @@ impl Renderer {
         self.ctx.advance_frame();
         Ok(())
     }
+}
+
+fn build_gui_item_atlas(
+    device: &vk::Device,
+    allocator: &Arc<std::sync::Mutex<pomme_gpu_allocator::vulkan::Allocator>>,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    menu_tex_set: vk::DescriptorSet,
+    slot_px: u32,
+) -> pipelines::gui_item_atlas::GuiItemAtlas {
+    let atlas =
+        pipelines::gui_item_atlas::GuiItemAtlas::new(device, allocator, queue, command_pool, slot_px);
+    atlas.bind_into_menu_tex_set(device, menu_tex_set);
+    atlas
 }
 
 fn warm_item_meshes(

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod util;
 
 pub(crate) const MAX_FRAMES_IN_FLIGHT: usize = 3;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -105,6 +105,7 @@ pub struct Renderer {
     chunk_border_pipeline: ChunkBorderPipeline,
     item_entity_pipeline: ItemEntityPipeline,
     gui_item_pipeline: pipelines::gui_item::GuiItemPipeline,
+    gui_item_atlas: pipelines::gui_item_atlas::GuiItemAtlas,
 
     atlas: TextureAtlas,
     entity_renderer: EntityRenderer,
@@ -310,14 +311,25 @@ impl Renderer {
 
         splash(&mut menu_pipeline, 0.95, "Caching item meshes...");
 
-        let mut gui_item_pipeline = pipelines::gui_item::GuiItemPipeline::new(
+        let initial_slot_px =
+            pipelines::gui_item_atlas::slot_px_for_gui_scale(crate::ui::hud::gui_scale(sw, sh, 0));
+        let gui_item_atlas = pipelines::gui_item_atlas::GuiItemAtlas::new(
             &ctx.device,
-            swapchain_state.render_pass,
+            &ctx.allocator,
+            ctx.graphics_queue,
+            ctx.command_pool,
+            initial_slot_px,
+        );
+        gui_item_atlas.bind_into_menu_tex_set(&ctx.device, menu_pipeline.tex_descriptor_set());
+
+        let gui_item_pipeline = pipelines::gui_item::GuiItemPipeline::new(
+            &ctx.device,
+            gui_item_atlas.render_pass(),
+            gui_item_atlas.atlas_px(),
             &ctx.allocator,
             &atlas,
             jar_assets_dir,
         );
-        gui_item_pipeline.update_camera(sw, sh);
 
         warm_item_meshes(
             &ctx.device,
@@ -350,6 +362,7 @@ impl Renderer {
             chunk_border_pipeline,
             item_entity_pipeline,
             gui_item_pipeline,
+            gui_item_atlas,
             chunk_buffers,
             render_finished_per_image,
             swapchain_dirty: false,
@@ -481,7 +494,8 @@ impl Renderer {
         };
         cmd.set_scissor(0, &[scissor]);
 
-        menu.draw(cmd, sw, sh, &elements, |_, _, _, _, _, _| {});
+        let empty_uvs: HashMap<String, [f32; 4]> = HashMap::new();
+        menu.draw(cmd, sw, sh, &elements, &empty_uvs);
 
         cmd.end_render_pass();
         cmd.end()?;
@@ -565,10 +579,6 @@ impl Renderer {
             .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
         self.item_entity_pipeline
             .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
-        self.gui_item_pipeline
-            .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
-        self.gui_item_pipeline
-            .update_camera(self.width as f32, self.height as f32);
         self.blur_pipeline.resize(
             &self.ctx.device,
             self.ctx.graphics_queue,
@@ -1032,6 +1042,92 @@ impl Renderer {
             },
         ];
 
+        let menu_elements: &[MenuElement] = match &mode {
+            RenderMode::World { overlay, .. } => overlay.as_slice(),
+            RenderMode::MainMenu { elements, .. } => elements.as_slice(),
+        };
+
+        let target_slot_px =
+            pipelines::gui_item_atlas::slot_px_for_gui_scale(crate::ui::hud::gui_scale(
+                self.swapchain.extent.width as f32,
+                self.swapchain.extent.height as f32,
+                0,
+            ));
+        if target_slot_px != self.gui_item_atlas.slot_px() {
+            self.ctx.device.wait_idle().ok();
+            self.gui_item_atlas
+                .destroy(&self.ctx.device, &self.ctx.allocator);
+            self.gui_item_atlas = pipelines::gui_item_atlas::GuiItemAtlas::new(
+                &self.ctx.device,
+                &self.ctx.allocator,
+                self.ctx.graphics_queue,
+                self.ctx.command_pool,
+                target_slot_px,
+            );
+            self.gui_item_atlas
+                .bind_into_menu_tex_set(&self.ctx.device, self.menu_pipeline.tex_descriptor_set());
+            self.gui_item_pipeline
+                .set_atlas_px(self.gui_item_atlas.atlas_px());
+        }
+
+        let mut unique_names: HashSet<String> = HashSet::new();
+        for elem in menu_elements {
+            if let MenuElement::ItemIcon { item_name, .. } = elem {
+                unique_names.insert(item_name.clone());
+            }
+        }
+        if !self.gui_item_atlas.has_space_for_all(&unique_names) {
+            self.gui_item_atlas.reclaim_space_for(&unique_names);
+        }
+        let mut item_atlas_uvs: HashMap<String, [f32; 4]> = HashMap::new();
+        let mut bake_list: Vec<(
+            pipelines::gui_item_atlas::Slot,
+            String,
+            bool,
+            pipelines::gui_item_atlas::SlotState,
+        )> = Vec::new();
+        for name in &unique_names {
+            let discard = pipelines::gui_item_atlas::is_animated_item(name);
+            if let Some((slot, state)) = self.gui_item_atlas.get_or_allocate(name, discard) {
+                item_atlas_uvs.insert(name.clone(), self.gui_item_atlas.slot_uv(&slot));
+                if !matches!(state, pipelines::gui_item_atlas::SlotState::Ready) {
+                    let is_block = self.registry.get_item_model(name).is_some();
+                    bake_list.push((slot, name.clone(), is_block, state));
+                }
+            }
+        }
+        if !bake_list.is_empty() {
+            self.gui_item_atlas.begin_bake_pass(cmd);
+            self.gui_item_pipeline.bind_for_bake_pass(cmd);
+            for (slot, name, is_block, state) in &bake_list {
+                if matches!(state, pipelines::gui_item_atlas::SlotState::Stale) {
+                    self.gui_item_atlas.clear_slot_color(cmd, slot);
+                }
+                let (scx, scy, scw, sch) = self.gui_item_atlas.scissor_rect_pixels(slot);
+                cmd.set_scissor(
+                    0,
+                    &[vk::Rect2D {
+                        offset: vk::Offset2D { x: scx, y: scy },
+                        extent: vk::Extent2D {
+                            width: scw,
+                            height: sch,
+                        },
+                    }],
+                );
+                let (sx, sy, sw_slot, _) = self.gui_item_atlas.slot_rect_pixels(slot);
+                self.gui_item_pipeline.bake_to_slot(
+                    cmd,
+                    &self.item_entity_pipeline,
+                    sx as u32,
+                    sy as u32,
+                    sw_slot,
+                    name,
+                    *is_block,
+                );
+            }
+            self.gui_item_atlas.end_bake_pass(cmd);
+        }
+
         let use_blur = matches!(&mode, RenderMode::MainMenu { blur, .. } if *blur > 0.01);
 
         let (rp, fb) = if use_blur {
@@ -1138,26 +1234,8 @@ impl Renderer {
                         .update_and_draw(cmd, frame, aspect, *swing_progress);
                 }
 
-                let Renderer {
-                    menu_pipeline,
-                    gui_item_pipeline,
-                    item_entity_pipeline,
-                    registry,
-                    ..
-                } = &mut *self;
-                menu_pipeline.draw(cmd, sw, sh, overlay, |cmd, x, y, w, h, name| {
-                    let is_block = registry.get_item_model(name).is_some();
-                    gui_item_pipeline.draw_one(
-                        cmd,
-                        item_entity_pipeline,
-                        x,
-                        y,
-                        w,
-                        h,
-                        name,
-                        is_block,
-                    );
-                });
+                self.menu_pipeline
+                    .draw(cmd, sw, sh, overlay, &item_atlas_uvs);
 
                 self.last_timings.cull_ms = cull_ms;
                 self.last_timings.frame_ms = frame_start.elapsed().as_secs_f32() * 1000.0;
@@ -1217,30 +1295,14 @@ impl Renderer {
                     );
                 }
 
-                let Renderer {
-                    menu_pipeline,
-                    gui_item_pipeline,
-                    item_entity_pipeline,
-                    registry,
-                    ..
-                } = &mut *self;
-                menu_pipeline.draw(cmd, sw, sh, elements, |cmd, x, y, w, h, name| {
-                    let is_block = registry.get_item_model(name).is_some();
-                    gui_item_pipeline.draw_one(
-                        cmd,
-                        item_entity_pipeline,
-                        x,
-                        y,
-                        w,
-                        h,
-                        name,
-                        is_block,
-                    );
-                });
+                self.menu_pipeline
+                    .draw(cmd, sw, sh, elements, &item_atlas_uvs);
             }
         }
 
         cmd.end_render_pass();
+
+        self.gui_item_atlas.end_frame();
 
         cmd.end()?;
 
@@ -1413,6 +1475,8 @@ impl Drop for Renderer {
         self.item_entity_pipeline
             .destroy(&self.ctx.device, &self.ctx.allocator);
         self.gui_item_pipeline
+            .destroy(&self.ctx.device, &self.ctx.allocator);
+        self.gui_item_atlas
             .destroy(&self.ctx.device, &self.ctx.allocator);
         self.atlas.destroy(&self.ctx.device, &self.ctx.allocator);
 

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1081,49 +1081,44 @@ impl Renderer {
             self.gui_item_atlas.reclaim_space_for(&unique_names);
         }
         let mut item_atlas_uvs: HashMap<String, [f32; 4]> = HashMap::new();
-        let mut bake_list: Vec<(
-            pipelines::gui_item_atlas::Slot,
-            String,
-            bool,
-            pipelines::gui_item_atlas::SlotState,
-        )> = Vec::new();
+        struct BakeJob {
+            slot: pipelines::gui_item_atlas::Slot,
+            name: String,
+            is_block: bool,
+            needs_clear: bool,
+        }
+        let mut bake_list: Vec<BakeJob> = Vec::new();
         for name in &unique_names {
             let discard = pipelines::gui_item_atlas::is_animated_item(name);
             if let Some((slot, state)) = self.gui_item_atlas.get_or_allocate(name, discard) {
                 item_atlas_uvs.insert(name.clone(), self.gui_item_atlas.slot_uv(&slot));
                 if !matches!(state, pipelines::gui_item_atlas::SlotState::Ready) {
-                    let is_block = self.registry.get_item_model(name).is_some();
-                    bake_list.push((slot, name.clone(), is_block, state));
+                    bake_list.push(BakeJob {
+                        slot,
+                        name: name.clone(),
+                        is_block: self.registry.get_item_model(name).is_some(),
+                        needs_clear: matches!(state, pipelines::gui_item_atlas::SlotState::Stale),
+                    });
                 }
             }
         }
         if !bake_list.is_empty() {
             self.gui_item_atlas.begin_bake_pass(cmd);
             self.gui_item_pipeline.bind_for_bake_pass(cmd);
-            for (slot, name, is_block, state) in &bake_list {
-                if matches!(state, pipelines::gui_item_atlas::SlotState::Stale) {
-                    self.gui_item_atlas.clear_slot_color(cmd, slot);
+            for job in &bake_list {
+                if job.needs_clear {
+                    self.gui_item_atlas.clear_slot_color(cmd, &job.slot);
                 }
-                let (scx, scy, scw, sch) = self.gui_item_atlas.scissor_rect_pixels(slot);
-                cmd.set_scissor(
-                    0,
-                    &[vk::Rect2D {
-                        offset: vk::Offset2D { x: scx, y: scy },
-                        extent: vk::Extent2D {
-                            width: scw,
-                            height: sch,
-                        },
-                    }],
-                );
-                let (sx, sy, sw_slot, _) = self.gui_item_atlas.slot_rect_pixels(slot);
+                cmd.set_scissor(0, &[self.gui_item_atlas.scissor_rect(&job.slot)]);
+                let (sx, sy, sw_slot, _) = self.gui_item_atlas.slot_rect_pixels(&job.slot);
                 self.gui_item_pipeline.bake_to_slot(
                     cmd,
                     &self.item_entity_pipeline,
                     sx as u32,
                     sy as u32,
                     sw_slot,
-                    name,
-                    *is_block,
+                    &job.name,
+                    job.is_block,
                 );
             }
             self.gui_item_atlas.end_bake_pass(cmd);

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -318,7 +318,7 @@ impl Renderer {
             &ctx.allocator,
             ctx.graphics_queue,
             ctx.command_pool,
-            menu_pipeline.tex_descriptor_set(),
+            &menu_pipeline,
             initial_slot_px,
         );
 
@@ -1062,9 +1062,11 @@ impl Renderer {
                 &self.ctx.allocator,
                 self.ctx.graphics_queue,
                 self.ctx.command_pool,
-                self.menu_pipeline.tex_descriptor_set(),
+                &self.menu_pipeline,
                 target_slot_px,
             );
+            self.gui_item_pipeline
+                .recreate_pipeline(&self.ctx.device, self.gui_item_atlas.render_pass());
             self.gui_item_pipeline
                 .set_atlas_px(self.gui_item_atlas.atlas_px());
         }
@@ -1350,7 +1352,7 @@ fn build_gui_item_atlas(
     allocator: &Arc<std::sync::Mutex<pomme_gpu_allocator::vulkan::Allocator>>,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
-    menu_tex_set: vk::DescriptorSet,
+    menu: &pipelines::menu_overlay::MenuOverlayPipeline,
     slot_px: u32,
 ) -> pipelines::gui_item_atlas::GuiItemAtlas {
     let atlas = pipelines::gui_item_atlas::GuiItemAtlas::new(
@@ -1360,7 +1362,7 @@ fn build_gui_item_atlas(
         command_pool,
         slot_px,
     );
-    atlas.bind_into_menu_tex_set(device, menu_tex_set);
+    menu.set_item_atlas(device, atlas.color_view(), atlas.sampler());
     atlas
 }
 

--- a/pomme-client/src/renderer/pipelines/gui_item.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item.rs
@@ -219,6 +219,16 @@ impl GuiItemPipeline {
         self.write_atlas_ortho(atlas_px as f32);
     }
 
+    pub fn recreate_pipeline(&mut self, device: &vk::Device, atlas_render_pass: vk::RenderPass) {
+        device.destroy_pipeline(self.pipeline, None);
+        self.pipeline = item_entity::create_pipeline_with_front_face(
+            device,
+            atlas_render_pass,
+            self.pipeline_layout,
+            vk::FrontFace::Clockwise,
+        );
+    }
+
     fn write_atlas_ortho(&mut self, atlas_px: f32) {
         // Bottom/top swapped to Y-invert the projection (matches vanilla's
         // `invertY=true`).

--- a/pomme-client/src/renderer/pipelines/gui_item.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item.rs
@@ -51,6 +51,7 @@ pub struct GuiItemPipeline {
     camera_buffer: vk::Buffer,
     camera_alloc: Option<Allocation>,
     sampler: vk::Sampler,
+    atlas_px: u32,
     display_cache: RefCell<HashMap<String, DisplayTransform>>,
     items_dir: PathBuf,
     models_dir: PathBuf,
@@ -59,7 +60,8 @@ pub struct GuiItemPipeline {
 impl GuiItemPipeline {
     pub fn new(
         device: &vk::Device,
-        render_pass: vk::RenderPass,
+        atlas_render_pass: vk::RenderPass,
+        atlas_px: u32,
         allocator: &Arc<Mutex<Allocator>>,
         atlas: &TextureAtlas,
         jar_assets_dir: &Path,
@@ -94,7 +96,7 @@ impl GuiItemPipeline {
 
         let pipeline = item_entity::create_pipeline_with_front_face(
             device,
-            render_pass,
+            atlas_render_pass,
             pipeline_layout,
             vk::FrontFace::Clockwise,
         );
@@ -192,7 +194,7 @@ impl GuiItemPipeline {
         device.update_descriptor_sets(&[cam_write, atlas_write], &[]);
 
         let mc_base = jar_assets_dir.join("minecraft");
-        Self {
+        let mut this = Self {
             pipeline,
             pipeline_layout,
             camera_layout,
@@ -203,14 +205,24 @@ impl GuiItemPipeline {
             camera_buffer,
             camera_alloc: Some(camera_alloc),
             sampler,
+            atlas_px,
             display_cache: RefCell::new(HashMap::new()),
             items_dir: mc_base.join("items"),
             models_dir: mc_base.join("models"),
-        }
+        };
+        this.write_atlas_ortho(atlas_px as f32);
+        this
     }
 
-    pub fn update_camera(&mut self, screen_w: f32, screen_h: f32) {
-        let view_proj = Mat4::orthographic_rh(0.0, screen_w, 0.0, screen_h, -10000.0, 10000.0);
+    pub fn set_atlas_px(&mut self, atlas_px: u32) {
+        self.atlas_px = atlas_px;
+        self.write_atlas_ortho(atlas_px as f32);
+    }
+
+    fn write_atlas_ortho(&mut self, atlas_px: f32) {
+        // Bottom/top swapped to Y-invert the projection (matches vanilla's
+        // `invertY=true`).
+        let view_proj = Mat4::orthographic_rh(0.0, atlas_px, atlas_px, 0.0, -10000.0, 10000.0);
         let uniform = CameraUniform::with_view_proj(view_proj);
         let bytes = bytemuck::bytes_of(&uniform);
         if let Some(alloc) = self.camera_alloc.as_mut() {
@@ -235,51 +247,7 @@ impl GuiItemPipeline {
         device.update_descriptor_sets(&[write], &[]);
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn draw_one(
-        &self,
-        cmd: vk::CommandBuffer,
-        item_entity: &ItemEntityPipeline,
-        x: f32,
-        y: f32,
-        w: f32,
-        h: f32,
-        item_name: &str,
-        is_block: bool,
-    ) {
-        let Some((buffer, vertex_count)) = item_entity.mesh_handle(item_name) else {
-            return;
-        };
-
-        let display = self.resolve_display(item_name, is_block);
-        let model = slot_model_matrix(x, y, w, h, display);
-
-        let depth_clear_rect = vk::ClearRect {
-            rect: vk::Rect2D {
-                offset: vk::Offset2D {
-                    x: x.floor() as i32,
-                    y: y.floor() as i32,
-                },
-                extent: vk::Extent2D {
-                    width: w.ceil() as u32,
-                    height: h.ceil() as u32,
-                },
-            },
-            base_array_layer: 0,
-            layer_count: 1,
-        };
-        let depth_clear = vk::ClearAttachment {
-            aspect_mask: vk::ImageAspectFlags::Depth,
-            color_attachment: 0,
-            clear_value: vk::ClearValue {
-                depth_stencil: vk::ClearDepthStencilValue {
-                    depth: 1.0,
-                    stencil: 0,
-                },
-            },
-        };
-        cmd.clear_attachments(&[depth_clear], &[depth_clear_rect]);
-
+    pub fn bind_for_bake_pass(&self, cmd: vk::CommandBuffer) {
         cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, self.pipeline);
         cmd.bind_descriptor_sets(
             vk::PipelineBindPoint::Graphics,
@@ -288,6 +256,41 @@ impl GuiItemPipeline {
             &[self.camera_set, self.atlas_set],
             &[],
         );
+        let viewport = vk::Viewport {
+            x: 0.0,
+            y: 0.0,
+            width: self.atlas_px as f32,
+            height: self.atlas_px as f32,
+            min_depth: 0.0,
+            max_depth: 1.0,
+        };
+        cmd.set_viewport(0, &[viewport]);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn bake_to_slot(
+        &self,
+        cmd: vk::CommandBuffer,
+        item_entity: &ItemEntityPipeline,
+        slot_x_px: u32,
+        slot_y_px: u32,
+        slot_size_px: u32,
+        item_name: &str,
+        is_block: bool,
+    ) {
+        let Some((buffer, vertex_count)) = item_entity.mesh_handle(item_name) else {
+            return;
+        };
+
+        let display = self.resolve_display(item_name, is_block);
+        let model = slot_model_matrix(
+            slot_x_px as f32,
+            slot_y_px as f32,
+            slot_size_px as f32,
+            slot_size_px as f32,
+            display,
+        );
+
         cmd.bind_vertex_buffers(0, &[buffer], &[0]);
 
         let mvp_data = model.to_cols_array();
@@ -324,16 +327,6 @@ impl GuiItemPipeline {
         resolved
     }
 
-    pub fn recreate_pipeline(&mut self, device: &vk::Device, render_pass: vk::RenderPass) {
-        device.destroy_pipeline(self.pipeline, None);
-        self.pipeline = item_entity::create_pipeline_with_front_face(
-            device,
-            render_pass,
-            self.pipeline_layout,
-            vk::FrontFace::Clockwise,
-        );
-    }
-
     pub fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
         device.destroy_pipeline(self.pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
@@ -350,13 +343,11 @@ impl GuiItemPipeline {
 
 fn slot_model_matrix(x: f32, y: f32, w: f32, h: f32, display: DisplayTransform) -> Mat4 {
     let depth_scale = w.max(h);
-    // The negative-Y scale flips winding; the GUI pipeline uses
-    // `FrontFace::Clockwise` to keep `CullMode::Back` correct.
-    Mat4::from_translation(Vec3::new(x, y + h, 0.0))
+    // Vertices are pre-centered to `[-0.5, +0.5]` by `build_item_mesh`, so no
+    // T(-0.5) here.
+    Mat4::from_translation(Vec3::new(x + w * 0.5, y + h * 0.5, 0.0))
         * Mat4::from_scale(Vec3::new(w, -h, depth_scale))
-        * Mat4::from_translation(Vec3::splat(0.5))
         * display.to_matrix()
-        * Mat4::from_translation(Vec3::splat(-0.5))
 }
 
 fn default_display(is_block: bool) -> DisplayTransform {

--- a/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
@@ -272,15 +272,10 @@ impl GuiItemAtlas {
         self.allocator.end_frame();
     }
 
-    /// Top-origin slot rect, consumed by `slot_model_matrix` in `gui_item.rs`
-    /// to position the baked mesh in atlas space.
-    pub fn slot_rect_pixels(&self, slot: &Slot) -> (i32, i32, u32, u32) {
-        (
-            (slot.x * self.slot_px) as i32,
-            (slot.y * self.slot_px) as i32,
-            self.slot_px,
-            self.slot_px,
-        )
+    /// Top-origin pixel coordinates of the slot's upper-left corner; pair with
+    /// `slot_px()` for the size.
+    pub fn slot_origin_pixels(&self, slot: &Slot) -> (u32, u32) {
+        (slot.x * self.slot_px, slot.y * self.slot_px)
     }
 
     /// Bottom-origin framebuffer rect for the bake-pass scissor and slot clear.

--- a/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
@@ -9,7 +9,8 @@ use crate::renderer::util;
 
 // Target capacity per atlas page in slots. The atlas is sized to fit this many
 // at the active slot size, clamped to MIN_ATLAS_PX so very small slots still
-// hit the device's framebuffer minimums.
+// hit the device's framebuffer minimums. MAX_ATLAS_PX is a conservative cap;
+// vanilla queries `RenderSystem.getDevice().limits().maxTextureSizeForFormat`.
 const TARGET_SLOT_CAPACITY: u32 = 256;
 const MIN_ATLAS_PX: u32 = 512;
 const MAX_ATLAS_PX: u32 = 4096;
@@ -45,8 +46,8 @@ pub enum SlotState {
 
 #[derive(Clone, Copy)]
 pub struct Slot {
-    pub x: u32,
-    pub y: u32,
+    x: u32,
+    y: u32,
 }
 
 struct SlotInternal {
@@ -271,7 +272,8 @@ impl GuiItemAtlas {
         self.allocator.end_frame();
     }
 
-    /// Top-origin slot rect — feed to the pose translate in `bake_to_slot`.
+    /// Top-origin slot rect, consumed by `slot_model_matrix` in `gui_item.rs`
+    /// to position the baked mesh in atlas space.
     pub fn slot_rect_pixels(&self, slot: &Slot) -> (i32, i32, u32, u32) {
         (
             (slot.x * self.slot_px) as i32,
@@ -293,7 +295,8 @@ impl GuiItemAtlas {
     }
 
     pub fn slot_uv(&self, slot: &Slot) -> [f32; 4] {
-        // V is decreasing because slot storage is bottom-origin in the atlas image.
+        // V decreases because the bake projection Y-flips the mesh into the
+        // atlas image, so the slot's top-of-mesh lands at the higher V row.
         let step = self.slot_px as f32 / self.atlas_px as f32;
         let u0 = slot.x as f32 * step;
         let v0 = 1.0 - slot.y as f32 * step;
@@ -360,21 +363,12 @@ impl GuiItemAtlas {
         cmd.clear_attachments(&[clear_attachment], &[clear_rect]);
     }
 
-    pub fn bind_into_menu_tex_set(&self, device: &vk::Device, menu_tex_set: vk::DescriptorSet) {
-        let img_info = vk::DescriptorImageInfo {
-            sampler: self.sampler,
-            image_view: self.color_view,
-            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
-        };
-        let write = vk::WriteDescriptorSet {
-            dst_set: menu_tex_set,
-            dst_binding: 2,
-            descriptor_count: 1,
-            descriptor_type: vk::DescriptorType::CombinedImageSampler,
-            image_info: &img_info,
-            ..Default::default()
-        };
-        device.update_descriptor_sets(&[write], &[]);
+    pub fn color_view(&self) -> vk::ImageView {
+        self.color_view
+    }
+
+    pub fn sampler(&self) -> vk::Sampler {
+        self.sampler
     }
 
     pub fn destroy(&mut self, device: &vk::Device, gpu_alloc: &Arc<Mutex<Allocator>>) {
@@ -619,7 +613,8 @@ fn create_render_pass(device: &vk::Device) -> vk::RenderPass {
             src_access_mask: vk::AccessFlags::ShaderRead,
             dst_stage_mask: vk::PipelineStageFlags::ColorAttachmentOutput
                 | vk::PipelineStageFlags::EarlyFragmentTests,
-            dst_access_mask: vk::AccessFlags::ColorAttachmentWrite
+            dst_access_mask: vk::AccessFlags::ColorAttachmentRead
+                | vk::AccessFlags::ColorAttachmentWrite
                 | vk::AccessFlags::DepthStencilAttachmentWrite,
             ..Default::default()
         },

--- a/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
@@ -283,15 +283,18 @@ impl GuiItemAtlas {
         )
     }
 
-    /// Bottom-origin framebuffer rect — feed to the bake-pass scissor / slot
-    /// clear.
-    pub fn scissor_rect_pixels(&self, slot: &Slot) -> (i32, i32, u32, u32) {
-        (
-            (slot.x * self.slot_px) as i32,
-            self.atlas_px as i32 - (slot.y as i32 + 1) * self.slot_px as i32,
-            self.slot_px,
-            self.slot_px,
-        )
+    /// Bottom-origin framebuffer rect for the bake-pass scissor and slot clear.
+    pub fn scissor_rect(&self, slot: &Slot) -> vk::Rect2D {
+        vk::Rect2D {
+            offset: vk::Offset2D {
+                x: (slot.x * self.slot_px) as i32,
+                y: self.atlas_px as i32 - (slot.y as i32 + 1) * self.slot_px as i32,
+            },
+            extent: vk::Extent2D {
+                width: self.slot_px,
+                height: self.slot_px,
+            },
+        }
     }
 
     pub fn slot_uv(&self, slot: &Slot) -> [f32; 4] {
@@ -339,7 +342,6 @@ impl GuiItemAtlas {
     }
 
     pub fn clear_slot_color(&self, cmd: vk::CommandBuffer, slot: &Slot) {
-        let (sx, sy, sw, sh) = self.scissor_rect_pixels(slot);
         let clear_attachment = vk::ClearAttachment {
             aspect_mask: vk::ImageAspectFlags::Color,
             color_attachment: 0,
@@ -350,13 +352,7 @@ impl GuiItemAtlas {
             },
         };
         let clear_rect = vk::ClearRect {
-            rect: vk::Rect2D {
-                offset: vk::Offset2D { x: sx, y: sy },
-                extent: vk::Extent2D {
-                    width: sw,
-                    height: sh,
-                },
-            },
+            rect: self.scissor_rect(slot),
             base_array_layer: 0,
             layer_count: 1,
         };

--- a/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item_atlas.rs
@@ -1,0 +1,672 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use pomme_gpu_allocator::MemoryLocation;
+use pomme_gpu_allocator::vulkan::{Allocation, AllocationCreateDesc, AllocationScheme, Allocator};
+use pyronyx::vk;
+
+use crate::renderer::util;
+
+// Target capacity per atlas page in slots. The atlas is sized to fit this many
+// at the active slot size, clamped to MIN_ATLAS_PX so very small slots still
+// hit the device's framebuffer minimums.
+const TARGET_SLOT_CAPACITY: u32 = 256;
+const MIN_ATLAS_PX: u32 = 512;
+const MAX_ATLAS_PX: u32 = 4096;
+
+pub fn is_animated_item(item_name: &str) -> bool {
+    matches!(item_name, "compass" | "recovery_compass" | "clock")
+}
+
+const COLOR_FORMAT: vk::Format = vk::Format::R8G8B8A8Unorm;
+const DEPTH_FORMAT: vk::Format = vk::Format::D32Sfloat;
+
+/// Returns the slot size in pixels matching `16 * gui_scale`, the vanilla
+/// formula (`GuiRenderer.prepareItemElements`). 16 is the base item size in
+/// logical GUI units; multiplying by gui_scale makes the bake 1:1 with display.
+pub fn slot_px_for_gui_scale(gui_scale: f32) -> u32 {
+    (16.0 * gui_scale.max(1.0)).round() as u32
+}
+
+/// Picks the smallest power-of-two atlas size that fits TARGET_SLOT_CAPACITY
+/// slots of the given size, clamped to [MIN_ATLAS_PX, MAX_ATLAS_PX].
+fn atlas_px_for_slot(slot_px: u32) -> u32 {
+    let slots_per_side = (TARGET_SLOT_CAPACITY as f32).sqrt().ceil() as u32;
+    let needed = slots_per_side * slot_px;
+    needed.next_power_of_two().clamp(MIN_ATLAS_PX, MAX_ATLAS_PX)
+}
+
+#[derive(Clone, Copy)]
+pub enum SlotState {
+    Empty,
+    Stale,
+    Ready,
+}
+
+#[derive(Clone, Copy)]
+pub struct Slot {
+    pub x: u32,
+    pub y: u32,
+}
+
+struct SlotInternal {
+    x: u32,
+    y: u32,
+    fresh: bool,
+    discard_after_frame: bool,
+}
+
+struct DynamicAtlasAllocator {
+    slots: Vec<SlotInternal>,
+    used_by_key: HashMap<String, usize>,
+    free: Vec<bool>,
+}
+
+impl DynamicAtlasAllocator {
+    fn new(width: u32, height: u32) -> Self {
+        let total = (width * height) as usize;
+        let mut slots = Vec::with_capacity(total);
+        for y in 0..height {
+            for x in 0..width {
+                slots.push(SlotInternal {
+                    x,
+                    y,
+                    fresh: true,
+                    discard_after_frame: false,
+                });
+            }
+        }
+        Self {
+            slots,
+            used_by_key: HashMap::new(),
+            free: vec![true; total],
+        }
+    }
+
+    fn get_or_allocate(
+        &mut self,
+        key: &str,
+        discard_after_frame: bool,
+    ) -> Option<(Slot, SlotState)> {
+        if let Some(&idx) = self.used_by_key.get(key) {
+            let s = &mut self.slots[idx];
+            s.discard_after_frame |= discard_after_frame;
+            return Some((Slot { x: s.x, y: s.y }, SlotState::Ready));
+        }
+        let idx = self.free.iter().position(|f| *f)?;
+        self.free[idx] = false;
+        let s = &mut self.slots[idx];
+        let state = if s.fresh {
+            SlotState::Empty
+        } else {
+            SlotState::Stale
+        };
+        s.fresh = false;
+        s.discard_after_frame = discard_after_frame;
+        let slot = Slot { x: s.x, y: s.y };
+        self.used_by_key.insert(key.to_string(), idx);
+        Some((slot, state))
+    }
+
+    fn has_space_for_all(&self, keys: &HashSet<String>) -> bool {
+        let mut total = self.used_by_key.len();
+        for key in keys {
+            if !self.used_by_key.contains_key(key) {
+                total += 1;
+            }
+        }
+        total <= self.slots.len()
+    }
+
+    fn reclaim_space_for(&mut self, keys: &HashSet<String>) -> bool {
+        let preexisting = keys
+            .iter()
+            .filter(|k| self.used_by_key.contains_key(*k))
+            .count();
+        if preexisting == keys.len() {
+            return true;
+        }
+        let mut needed = keys.len() - preexisting;
+        self.free_slot_if(|key, _| {
+            if needed == 0 || keys.contains(key) {
+                false
+            } else {
+                needed -= 1;
+                true
+            }
+        });
+        needed == 0
+    }
+
+    fn end_frame(&mut self) {
+        self.free_slot_if(|_, slot| slot.discard_after_frame);
+    }
+
+    fn free_slot_if(&mut self, mut predicate: impl FnMut(&str, &SlotInternal) -> bool) {
+        let to_remove: Vec<String> = self
+            .used_by_key
+            .iter()
+            .filter_map(|(k, &idx)| {
+                if predicate(k, &self.slots[idx]) {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for key in to_remove {
+            if let Some(idx) = self.used_by_key.remove(&key) {
+                self.free[idx] = true;
+                self.slots[idx].discard_after_frame = false;
+            }
+        }
+    }
+}
+
+pub struct GuiItemAtlas {
+    color_image: vk::Image,
+    color_view: vk::ImageView,
+    color_alloc: Option<Allocation>,
+    depth_image: vk::Image,
+    depth_view: vk::ImageView,
+    depth_alloc: Option<Allocation>,
+    render_pass: vk::RenderPass,
+    framebuffer: vk::Framebuffer,
+    sampler: vk::Sampler,
+    slot_px: u32,
+    atlas_px: u32,
+    allocator: DynamicAtlasAllocator,
+}
+
+impl GuiItemAtlas {
+    pub fn new(
+        device: &vk::Device,
+        gpu_alloc: &Arc<Mutex<Allocator>>,
+        queue: vk::Queue,
+        command_pool: vk::CommandPool,
+        slot_px: u32,
+    ) -> Self {
+        let atlas_px = atlas_px_for_slot(slot_px);
+        let slots_per_side = atlas_px / slot_px;
+
+        let (color_image, color_view, color_alloc) =
+            create_color_image(device, gpu_alloc, atlas_px, atlas_px);
+        let (depth_image, depth_view, depth_alloc) =
+            create_depth_image(device, gpu_alloc, atlas_px, atlas_px);
+
+        init_color_clear_and_transition(device, queue, command_pool, color_image);
+        transition_depth_to_attachment(device, queue, command_pool, depth_image);
+
+        let render_pass = create_render_pass(device);
+        let framebuffer = create_framebuffer(
+            device,
+            render_pass,
+            color_view,
+            depth_view,
+            atlas_px,
+            atlas_px,
+        );
+
+        let sampler_info = vk::SamplerCreateInfo {
+            mag_filter: vk::Filter::Nearest,
+            min_filter: vk::Filter::Nearest,
+            mipmap_mode: vk::SamplerMipmapMode::Nearest,
+            address_mode_u: vk::SamplerAddressMode::ClampToEdge,
+            address_mode_v: vk::SamplerAddressMode::ClampToEdge,
+            address_mode_w: vk::SamplerAddressMode::ClampToEdge,
+            min_lod: 0.0,
+            max_lod: 0.0,
+            ..Default::default()
+        };
+        let sampler = device
+            .create_sampler(&sampler_info, None)
+            .expect("failed to create gui_item_atlas sampler");
+
+        Self {
+            color_image,
+            color_view,
+            color_alloc: Some(color_alloc),
+            depth_image,
+            depth_view,
+            depth_alloc: Some(depth_alloc),
+            render_pass,
+            framebuffer,
+            sampler,
+            slot_px,
+            atlas_px,
+            allocator: DynamicAtlasAllocator::new(slots_per_side, slots_per_side),
+        }
+    }
+
+    pub fn slot_px(&self) -> u32 {
+        self.slot_px
+    }
+
+    pub fn atlas_px(&self) -> u32 {
+        self.atlas_px
+    }
+
+    pub fn render_pass(&self) -> vk::RenderPass {
+        self.render_pass
+    }
+
+    pub fn get_or_allocate(
+        &mut self,
+        item_name: &str,
+        discard_after_frame: bool,
+    ) -> Option<(Slot, SlotState)> {
+        self.allocator
+            .get_or_allocate(item_name, discard_after_frame)
+    }
+
+    pub fn has_space_for_all(&self, keys: &HashSet<String>) -> bool {
+        self.allocator.has_space_for_all(keys)
+    }
+
+    pub fn reclaim_space_for(&mut self, keys: &HashSet<String>) -> bool {
+        self.allocator.reclaim_space_for(keys)
+    }
+
+    pub fn end_frame(&mut self) {
+        self.allocator.end_frame();
+    }
+
+    /// Top-origin slot rect — feed to the pose translate in `bake_to_slot`.
+    pub fn slot_rect_pixels(&self, slot: &Slot) -> (i32, i32, u32, u32) {
+        (
+            (slot.x * self.slot_px) as i32,
+            (slot.y * self.slot_px) as i32,
+            self.slot_px,
+            self.slot_px,
+        )
+    }
+
+    /// Bottom-origin framebuffer rect — feed to the bake-pass scissor / slot
+    /// clear.
+    pub fn scissor_rect_pixels(&self, slot: &Slot) -> (i32, i32, u32, u32) {
+        (
+            (slot.x * self.slot_px) as i32,
+            self.atlas_px as i32 - (slot.y as i32 + 1) * self.slot_px as i32,
+            self.slot_px,
+            self.slot_px,
+        )
+    }
+
+    pub fn slot_uv(&self, slot: &Slot) -> [f32; 4] {
+        // V is decreasing because slot storage is bottom-origin in the atlas image.
+        let step = self.slot_px as f32 / self.atlas_px as f32;
+        let u0 = slot.x as f32 * step;
+        let v0 = 1.0 - slot.y as f32 * step;
+        [u0, v0, u0 + step, v0 - step]
+    }
+
+    pub fn begin_bake_pass(&self, cmd: vk::CommandBuffer) {
+        let clears = [
+            vk::ClearValue {
+                color: vk::ClearColorValue {
+                    float32: [0.0, 0.0, 0.0, 0.0],
+                },
+            },
+            vk::ClearValue {
+                depth_stencil: vk::ClearDepthStencilValue {
+                    depth: 1.0,
+                    stencil: 0,
+                },
+            },
+        ];
+        let info = vk::RenderPassBeginInfo {
+            render_pass: self.render_pass,
+            framebuffer: self.framebuffer,
+            render_area: vk::Rect2D {
+                offset: vk::Offset2D { x: 0, y: 0 },
+                extent: vk::Extent2D {
+                    width: self.atlas_px,
+                    height: self.atlas_px,
+                },
+            },
+            clear_value_count: clears.len() as u32,
+            clear_values: clears.as_ptr(),
+            ..Default::default()
+        };
+        cmd.begin_render_pass(&info, vk::SubpassContents::Inline);
+    }
+
+    pub fn end_bake_pass(&self, cmd: vk::CommandBuffer) {
+        cmd.end_render_pass();
+    }
+
+    pub fn clear_slot_color(&self, cmd: vk::CommandBuffer, slot: &Slot) {
+        let (sx, sy, sw, sh) = self.scissor_rect_pixels(slot);
+        let clear_attachment = vk::ClearAttachment {
+            aspect_mask: vk::ImageAspectFlags::Color,
+            color_attachment: 0,
+            clear_value: vk::ClearValue {
+                color: vk::ClearColorValue {
+                    float32: [0.0, 0.0, 0.0, 0.0],
+                },
+            },
+        };
+        let clear_rect = vk::ClearRect {
+            rect: vk::Rect2D {
+                offset: vk::Offset2D { x: sx, y: sy },
+                extent: vk::Extent2D {
+                    width: sw,
+                    height: sh,
+                },
+            },
+            base_array_layer: 0,
+            layer_count: 1,
+        };
+        cmd.clear_attachments(&[clear_attachment], &[clear_rect]);
+    }
+
+    pub fn bind_into_menu_tex_set(&self, device: &vk::Device, menu_tex_set: vk::DescriptorSet) {
+        let img_info = vk::DescriptorImageInfo {
+            sampler: self.sampler,
+            image_view: self.color_view,
+            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+        };
+        let write = vk::WriteDescriptorSet {
+            dst_set: menu_tex_set,
+            dst_binding: 2,
+            descriptor_count: 1,
+            descriptor_type: vk::DescriptorType::CombinedImageSampler,
+            image_info: &img_info,
+            ..Default::default()
+        };
+        device.update_descriptor_sets(&[write], &[]);
+    }
+
+    pub fn destroy(&mut self, device: &vk::Device, gpu_alloc: &Arc<Mutex<Allocator>>) {
+        device.destroy_framebuffer(self.framebuffer, None);
+        device.destroy_render_pass(self.render_pass, None);
+        device.destroy_sampler(self.sampler, None);
+        device.destroy_image_view(self.color_view, None);
+        device.destroy_image(self.color_image, None);
+        device.destroy_image_view(self.depth_view, None);
+        device.destroy_image(self.depth_image, None);
+        if let Some(a) = self.color_alloc.take() {
+            gpu_alloc.lock().unwrap().free(a).ok();
+        }
+        if let Some(a) = self.depth_alloc.take() {
+            gpu_alloc.lock().unwrap().free(a).ok();
+        }
+    }
+}
+
+fn create_color_image(
+    device: &vk::Device,
+    allocator: &Arc<Mutex<Allocator>>,
+    width: u32,
+    height: u32,
+) -> (vk::Image, vk::ImageView, Allocation) {
+    create_atlas_image(
+        device,
+        allocator,
+        width,
+        height,
+        COLOR_FORMAT,
+        vk::ImageUsageFlags::ColorAttachment
+            | vk::ImageUsageFlags::Sampled
+            | vk::ImageUsageFlags::TransferDst,
+        util::COLOR_SUBRESOURCE_RANGE,
+        "gui_item_atlas_color",
+    )
+}
+
+fn create_depth_image(
+    device: &vk::Device,
+    allocator: &Arc<Mutex<Allocator>>,
+    width: u32,
+    height: u32,
+) -> (vk::Image, vk::ImageView, Allocation) {
+    create_atlas_image(
+        device,
+        allocator,
+        width,
+        height,
+        DEPTH_FORMAT,
+        vk::ImageUsageFlags::DepthStencilAttachment,
+        util::DEPTH_SUBRESOURCE_RANGE,
+        "gui_item_atlas_depth",
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_atlas_image(
+    device: &vk::Device,
+    allocator: &Arc<Mutex<Allocator>>,
+    width: u32,
+    height: u32,
+    format: vk::Format,
+    usage: vk::ImageUsageFlags,
+    subresource_range: vk::ImageSubresourceRange,
+    name: &str,
+) -> (vk::Image, vk::ImageView, Allocation) {
+    let image_info = vk::ImageCreateInfo {
+        image_type: vk::ImageType::Type2D,
+        format,
+        extent: vk::Extent3D {
+            width,
+            height,
+            depth: 1,
+        },
+        mip_levels: 1,
+        array_layers: 1,
+        samples: vk::SampleCountFlags::Type1,
+        tiling: vk::ImageTiling::Optimal,
+        usage,
+        ..Default::default()
+    };
+    let image = device
+        .create_image(&image_info, None)
+        .expect("failed to create atlas image");
+    let mem_reqs = device.get_image_memory_requirements(image);
+    let allocation = allocator
+        .lock()
+        .unwrap()
+        .allocate(&AllocationCreateDesc {
+            name,
+            requirements: mem_reqs,
+            location: MemoryLocation::GpuOnly,
+            linear: false,
+            allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+        })
+        .expect("failed to allocate atlas image memory");
+    unsafe {
+        device
+            .bind_image_memory(image, allocation.memory(), allocation.offset())
+            .expect("failed to bind atlas image memory");
+    }
+    let view_info = vk::ImageViewCreateInfo {
+        image,
+        view_type: vk::ImageViewType::Type2D,
+        format,
+        subresource_range,
+        ..Default::default()
+    };
+    let view = device
+        .create_image_view(&view_info, None)
+        .expect("failed to create atlas image view");
+    (image, view, allocation)
+}
+
+fn init_color_clear_and_transition(
+    device: &vk::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    image: vk::Image,
+) {
+    util::submit_one_time(device, queue, command_pool, |cmd| {
+        let to_transfer = vk::ImageMemoryBarrier {
+            image,
+            old_layout: vk::ImageLayout::Undefined,
+            new_layout: vk::ImageLayout::TransferDstOptimal,
+            src_access_mask: vk::AccessFlags::empty(),
+            dst_access_mask: vk::AccessFlags::TransferWrite,
+            subresource_range: util::COLOR_SUBRESOURCE_RANGE,
+            ..Default::default()
+        };
+        cmd.pipeline_barrier(
+            vk::PipelineStageFlags::TopOfPipe,
+            vk::PipelineStageFlags::Transfer,
+            vk::DependencyFlags::empty(),
+            &[],
+            &[],
+            &[to_transfer],
+        );
+
+        let clear_color = vk::ClearColorValue {
+            float32: [0.0, 0.0, 0.0, 0.0],
+        };
+        cmd.clear_color_image(
+            image,
+            vk::ImageLayout::TransferDstOptimal,
+            &clear_color,
+            &[util::COLOR_SUBRESOURCE_RANGE],
+        );
+
+        let to_shader_read = vk::ImageMemoryBarrier {
+            image,
+            old_layout: vk::ImageLayout::TransferDstOptimal,
+            new_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+            src_access_mask: vk::AccessFlags::TransferWrite,
+            dst_access_mask: vk::AccessFlags::ShaderRead,
+            subresource_range: util::COLOR_SUBRESOURCE_RANGE,
+            ..Default::default()
+        };
+        cmd.pipeline_barrier(
+            vk::PipelineStageFlags::Transfer,
+            vk::PipelineStageFlags::FragmentShader,
+            vk::DependencyFlags::empty(),
+            &[],
+            &[],
+            &[to_shader_read],
+        );
+    });
+}
+
+fn transition_depth_to_attachment(
+    device: &vk::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    image: vk::Image,
+) {
+    util::submit_one_time(device, queue, command_pool, |cmd| {
+        let barrier = vk::ImageMemoryBarrier {
+            image,
+            old_layout: vk::ImageLayout::Undefined,
+            new_layout: vk::ImageLayout::DepthStencilAttachmentOptimal,
+            src_access_mask: vk::AccessFlags::empty(),
+            dst_access_mask: vk::AccessFlags::DepthStencilAttachmentWrite,
+            subresource_range: util::DEPTH_SUBRESOURCE_RANGE,
+            ..Default::default()
+        };
+        cmd.pipeline_barrier(
+            vk::PipelineStageFlags::TopOfPipe,
+            vk::PipelineStageFlags::EarlyFragmentTests,
+            vk::DependencyFlags::empty(),
+            &[],
+            &[],
+            &[barrier],
+        );
+    });
+}
+
+fn create_render_pass(device: &vk::Device) -> vk::RenderPass {
+    let attachments = [
+        vk::AttachmentDescription {
+            format: COLOR_FORMAT,
+            samples: vk::SampleCountFlags::Type1,
+            load_op: vk::AttachmentLoadOp::Load,
+            store_op: vk::AttachmentStoreOp::Store,
+            initial_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+            final_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+            ..Default::default()
+        },
+        vk::AttachmentDescription {
+            format: DEPTH_FORMAT,
+            samples: vk::SampleCountFlags::Type1,
+            load_op: vk::AttachmentLoadOp::Clear,
+            store_op: vk::AttachmentStoreOp::DontCare,
+            initial_layout: vk::ImageLayout::DepthStencilAttachmentOptimal,
+            final_layout: vk::ImageLayout::DepthStencilAttachmentOptimal,
+            ..Default::default()
+        },
+    ];
+
+    let color_ref = vk::AttachmentReference {
+        attachment: 0,
+        layout: vk::ImageLayout::ColorAttachmentOptimal,
+    };
+    let depth_ref = vk::AttachmentReference {
+        attachment: 1,
+        layout: vk::ImageLayout::DepthStencilAttachmentOptimal,
+    };
+    let subpass = vk::SubpassDescription {
+        pipeline_bind_point: vk::PipelineBindPoint::Graphics,
+        color_attachments: &color_ref,
+        color_attachment_count: 1,
+        depth_stencil_attachment: &depth_ref,
+        ..Default::default()
+    };
+
+    let dependencies = [
+        vk::SubpassDependency {
+            src_subpass: vk::SUBPASS_EXTERNAL,
+            dst_subpass: 0,
+            src_stage_mask: vk::PipelineStageFlags::FragmentShader,
+            src_access_mask: vk::AccessFlags::ShaderRead,
+            dst_stage_mask: vk::PipelineStageFlags::ColorAttachmentOutput
+                | vk::PipelineStageFlags::EarlyFragmentTests,
+            dst_access_mask: vk::AccessFlags::ColorAttachmentWrite
+                | vk::AccessFlags::DepthStencilAttachmentWrite,
+            ..Default::default()
+        },
+        vk::SubpassDependency {
+            src_subpass: 0,
+            dst_subpass: vk::SUBPASS_EXTERNAL,
+            src_stage_mask: vk::PipelineStageFlags::ColorAttachmentOutput,
+            src_access_mask: vk::AccessFlags::ColorAttachmentWrite,
+            dst_stage_mask: vk::PipelineStageFlags::FragmentShader,
+            dst_access_mask: vk::AccessFlags::ShaderRead,
+            ..Default::default()
+        },
+    ];
+
+    let info = vk::RenderPassCreateInfo {
+        attachment_count: attachments.len() as u32,
+        attachments: attachments.as_ptr(),
+        subpass_count: 1,
+        subpasses: &subpass,
+        dependency_count: dependencies.len() as u32,
+        dependencies: dependencies.as_ptr(),
+        ..Default::default()
+    };
+    device
+        .create_render_pass(&info, None)
+        .expect("failed to create gui_item_atlas render pass")
+}
+
+fn create_framebuffer(
+    device: &vk::Device,
+    render_pass: vk::RenderPass,
+    color_view: vk::ImageView,
+    depth_view: vk::ImageView,
+    width: u32,
+    height: u32,
+) -> vk::Framebuffer {
+    let attachments = [color_view, depth_view];
+    let info = vk::FramebufferCreateInfo {
+        render_pass,
+        attachment_count: attachments.len() as u32,
+        attachments: attachments.as_ptr(),
+        width,
+        height,
+        layers: 1,
+        ..Default::default()
+    };
+    device
+        .create_framebuffer(&info, None)
+        .expect("failed to create gui_item_atlas framebuffer")
+}

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -39,12 +39,10 @@ struct Vertex {
 const MAX_VERTICES: usize = 16384;
 const VERTEX_SIZE: usize = size_of::<Vertex>();
 
-enum DrawOp {
-    Quads {
-        start: u32,
-        count: u32,
-        scissor: Option<[f32; 4]>,
-    },
+struct DrawOp {
+    start: u32,
+    count: u32,
+    scissor: Option<[f32; 4]>,
 }
 
 struct GlyphEntry {
@@ -609,7 +607,7 @@ impl MenuOverlayPipeline {
             ) {
                 let count = vertices.len() as u32 - cmd_start;
                 if count > 0 {
-                    draw_ops.push(DrawOp::Quads {
+                    draw_ops.push(DrawOp {
                         start: cmd_start,
                         count,
                         scissor: current_scissor,
@@ -1070,7 +1068,7 @@ impl MenuOverlayPipeline {
 
         let final_count = vertices.len() as u32 - cmd_start;
         if final_count > 0 {
-            draw_ops.push(DrawOp::Quads {
+            draw_ops.push(DrawOp {
                 start: cmd_start,
                 count: final_count,
                 scissor: current_scissor,
@@ -1100,44 +1098,34 @@ impl MenuOverlayPipeline {
             },
         };
 
-        let mut needs_bind = true;
+        if !draw_ops.is_empty() {
+            cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, self.pipeline);
+            cmd.bind_descriptor_sets(
+                vk::PipelineBindPoint::Graphics,
+                self.pipeline_layout,
+                0,
+                &[self.globals_set, self.tex_set],
+                &[],
+            );
+            cmd.bind_vertex_buffers(0, &[self.vertex_buffer], &[0]);
+        }
         for op in &draw_ops {
-            match op {
-                DrawOp::Quads {
-                    start,
-                    count,
-                    scissor,
-                } => {
-                    if needs_bind {
-                        cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, self.pipeline);
-                        cmd.bind_descriptor_sets(
-                            vk::PipelineBindPoint::Graphics,
-                            self.pipeline_layout,
-                            0,
-                            &[self.globals_set, self.tex_set],
-                            &[],
-                        );
-                        cmd.bind_vertex_buffers(0, &[self.vertex_buffer], &[0]);
-                        needs_bind = false;
-                    }
-                    let rect = if let Some(s) = scissor {
-                        vk::Rect2D {
-                            offset: vk::Offset2D {
-                                x: s[0] as i32,
-                                y: s[1] as i32,
-                            },
-                            extent: vk::Extent2D {
-                                width: s[2] as u32,
-                                height: s[3] as u32,
-                            },
-                        }
-                    } else {
-                        default_scissor
-                    };
-                    cmd.set_scissor(0, &[rect]);
-                    cmd.draw(*count, 1, *start, 0);
+            let rect = if let Some(s) = op.scissor {
+                vk::Rect2D {
+                    offset: vk::Offset2D {
+                        x: s[0] as i32,
+                        y: s[1] as i32,
+                    },
+                    extent: vk::Extent2D {
+                        width: s[2] as u32,
+                        height: s[3] as u32,
+                    },
                 }
-            }
+            } else {
+                default_scissor
+            };
+            cmd.set_scissor(0, &[rect]);
+            cmd.draw(op.count, 1, op.start, 0);
         }
         cmd.set_scissor(0, &[default_scissor]);
     }

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -45,13 +45,6 @@ enum DrawOp {
         count: u32,
         scissor: Option<[f32; 4]>,
     },
-    Item {
-        x: f32,
-        y: f32,
-        w: f32,
-        h: f32,
-        item_name: String,
-    },
 }
 
 struct GlyphEntry {
@@ -586,7 +579,7 @@ impl MenuOverlayPipeline {
         screen_w: f32,
         screen_h: f32,
         elements: &[MenuElement],
-        mut draw_item: impl FnMut(vk::CommandBuffer, f32, f32, f32, f32, &str),
+        item_atlas_uvs: &HashMap<String, [f32; 4]>,
     ) {
         let globals: [f32; 2] = [screen_w, screen_h];
         self.globals_allocation
@@ -768,24 +761,25 @@ impl MenuOverlayPipeline {
                     w,
                     h,
                     item_name,
-                    tint: _,
+                    tint,
                 } => {
-                    let count = vertices.len() as u32 - cmd_start;
-                    if count > 0 {
-                        draw_ops.push(DrawOp::Quads {
-                            start: cmd_start,
-                            count,
-                            scissor: current_scissor,
-                        });
+                    if let Some(uv) = item_atlas_uvs.get(item_name) {
+                        push_quad(
+                            &mut vertices,
+                            *x,
+                            *y,
+                            *w,
+                            *h,
+                            uv[0],
+                            uv[1],
+                            uv[2],
+                            uv[3],
+                            *tint,
+                            3.0,
+                            [0.0, 0.0],
+                            0.0,
+                        );
                     }
-                    cmd_start = vertices.len() as u32;
-                    draw_ops.push(DrawOp::Item {
-                        x: *x,
-                        y: *y,
-                        w: *w,
-                        h: *h,
-                        item_name: item_name.clone(),
-                    });
                 }
                 MenuElement::McText {
                     x,
@@ -1143,19 +1137,13 @@ impl MenuOverlayPipeline {
                     cmd.set_scissor(0, &[rect]);
                     cmd.draw(*count, 1, *start, 0);
                 }
-                DrawOp::Item {
-                    x,
-                    y,
-                    w,
-                    h,
-                    item_name,
-                } => {
-                    draw_item(cmd, *x, *y, *w, *h, item_name);
-                    needs_bind = true;
-                }
             }
         }
         cmd.set_scissor(0, &[default_scissor]);
+    }
+
+    pub fn tex_descriptor_set(&self) -> vk::DescriptorSet {
+        self.tex_set
     }
 
     pub fn set_blur_texture(&self, device: &vk::Device, view: vk::ImageView, sampler: vk::Sampler) {

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1130,8 +1130,21 @@ impl MenuOverlayPipeline {
         cmd.set_scissor(0, &[default_scissor]);
     }
 
-    pub fn tex_descriptor_set(&self) -> vk::DescriptorSet {
-        self.tex_set
+    pub fn set_item_atlas(&self, device: &vk::Device, view: vk::ImageView, sampler: vk::Sampler) {
+        let info = vk::DescriptorImageInfo {
+            sampler,
+            image_view: view,
+            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+        };
+        let write = vk::WriteDescriptorSet {
+            dst_set: self.tex_set,
+            dst_binding: 2,
+            descriptor_count: 1,
+            descriptor_type: vk::DescriptorType::CombinedImageSampler,
+            image_info: &info,
+            ..Default::default()
+        };
+        device.update_descriptor_sets(&[write], &[]);
     }
 
     pub fn set_blur_texture(&self, device: &vk::Device, view: vk::ImageView, sampler: vk::Sampler) {

--- a/pomme-client/src/renderer/pipelines/mod.rs
+++ b/pomme-client/src/renderer/pipelines/mod.rs
@@ -5,6 +5,7 @@ pub mod chunk;
 pub mod chunk_borders;
 pub mod entity_renderer;
 pub mod gui_item;
+pub mod gui_item_atlas;
 pub mod hand;
 pub mod item_entity;
 pub mod menu_overlay;

--- a/pomme-client/src/renderer/shaders/menu_overlay.frag
+++ b/pomme-client/src/renderer/shaders/menu_overlay.frag
@@ -63,7 +63,7 @@ void main() {
 
     if (v_mode > 2.5) {
         vec4 tex = texture(item_tex, v_uv);
-        out_color = vec4(tex.rgb * v_color.rgb * tex.a * v_color.a, tex.a * v_color.a);
+        out_color = vec4(tex.rgb * v_color.rgb * v_color.a, tex.a * v_color.a);
         return;
     }
 

--- a/pomme-client/src/world/block/model.rs
+++ b/pomme-client/src/world/block/model.rs
@@ -466,10 +466,10 @@ pub fn bake_chest_item_model() -> BakedModel {
     add_chest_cube(
         &mut quads,
         1.0 / 16.0,
-        10.0 / 16.0,
+        9.0 / 16.0,
         1.0 / 16.0,
         15.0 / 16.0,
-        15.0 / 16.0,
+        14.0 / 16.0,
         15.0 / 16.0,
         0.0,
         0.0,
@@ -482,11 +482,11 @@ pub fn bake_chest_item_model() -> BakedModel {
     add_chest_cube(
         &mut quads,
         7.0 / 16.0,
+        7.0 / 16.0,
+        15.0 / 16.0,
         9.0 / 16.0,
+        11.0 / 16.0,
         1.0,
-        9.0 / 16.0,
-        13.0 / 16.0,
-        17.0 / 16.0,
         0.0,
         0.0,
         2.0,
@@ -600,13 +600,13 @@ fn add_chest_cube(
     let face_specs: [FaceSpec; 6] = [
         FaceSpec {
             positions: [[x0, y1, z1], [x1, y1, z1], [x1, y1, z0], [x0, y1, z0]],
-            uv_pixels: (u + d, v, u + d + w, v + d),
+            uv_pixels: (u + d + w, v, u + d + w + w, v + d),
             uv_pattern: UvPattern::Up,
             shade: shades[0],
         },
         FaceSpec {
             positions: [[x0, y0, z0], [x1, y0, z0], [x1, y0, z1], [x0, y0, z1]],
-            uv_pixels: (u + d + w, v, u + d + w + w, v + d),
+            uv_pixels: (u + d, v, u + d + w, v + d),
             uv_pattern: UvPattern::Down,
             shade: shades[1],
         },


### PR DESCRIPTION
Bakes GUI items into a shared offscreen RGBA8+D32 atlas and samples them as 2D quads. Includes chest item UV fix.