### PR TITLE
Ambient occlusion improvements

### DIFF
--- a/pomme-client/src/renderer/chunk/block_ao.rs
+++ b/pomme-client/src/renderer/chunk/block_ao.rs
@@ -1,0 +1,43 @@
+//! Vanilla ambient occlusion for cubic block faces, ported from
+//! `BlockModelLighter.prepareQuadAmbientOcclusion` (snapshot 26.2).
+//!
+//! Each vertex brightness is `(side1 + side2 + corner + center) * 0.25`, where
+//! every term is `0.2` (full-collision block) or `1.0`. `corner` is the
+//! in-plane diagonal, except when both sides occlude: vanilla then substitutes
+//! `shade0`, the brightness of `AdjacencyInfo.corners[0]` (the face's first
+//! edge neighbour), which gives concave corners their asymmetric brightness.
+//! With an exposed face (`center = 1.0`) the value is one of four brightnesses.
+
+/// Vertex brightness by AO level; index 0 (three occluders) is darkest.
+pub const AO_BRIGHTNESS: [f32; 4] = [0.4, 0.6, 0.8, 1.0];
+
+#[inline]
+fn occludes(shade: f32) -> bool {
+    shade < 0.5
+}
+
+/// Vanilla per-vertex AO level (`0`..=`3`, `0` darkest) for an exposed face.
+///
+/// `shade0_occ` is whether the face's `corners[0]` neighbour occludes, used as
+/// the diagonal fallback when both sides occlude.
+#[inline]
+pub fn vertex_ao_level(side1_occ: bool, side2_occ: bool, diag_occ: bool, shade0_occ: bool) -> u8 {
+    let corner_occ = if side1_occ && side2_occ {
+        shade0_occ
+    } else {
+        diag_occ
+    };
+    3 - (side1_occ as u8 + side2_occ as u8 + corner_occ as u8)
+}
+
+/// [`vertex_ao_level`] as a brightness, for callers working in shade floats.
+#[inline]
+pub fn vertex_brightness(side1: f32, side2: f32, diag: f32, shade0: f32) -> f32 {
+    let level = vertex_ao_level(
+        occludes(side1),
+        occludes(side2),
+        occludes(diag),
+        occludes(shade0),
+    );
+    AO_BRIGHTNESS[level as usize]
+}

--- a/pomme-client/src/renderer/chunk/greedy.rs
+++ b/pomme-client/src/renderer/chunk/greedy.rs
@@ -4,6 +4,8 @@
 
 use std::collections::BTreeSet;
 
+use super::block_ao;
+
 const MASK_6: u64 = 0b111111;
 
 #[derive(Copy, Clone)]
@@ -211,6 +213,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                         let ao_here = self.get_ao(face, layer, forward, bit_pos);
 
                         if (bits_next >> bit_pos & 1) != 0
+                            && ao_uniform(ao_here)
                             && v_type
                                 == voxels[get_axis_index::<CS>(
                                     axis,
@@ -227,6 +230,7 @@ impl<const CS: usize> GreedyMesher<CS> {
 
                         for right in (bit_pos + 1)..CS {
                             if (bits_here >> right & 1) == 0
+                                || !ao_uniform(ao_here)
                                 || self.forward_merged[bit_pos] != self.forward_merged[right]
                                 || v_type
                                     != voxels[get_axis_index::<CS>(
@@ -344,6 +348,7 @@ impl<const CS: usize> GreedyMesher<CS> {
 
                         if *right_merged_ref == 0
                             && (bits_forward >> bit_pos & 1) != 0
+                            && ao_uniform(ao_here)
                             && v_type
                                 == voxels
                                     [get_axis_index::<CS>(axis, right + 1, forward + 2, bit_pos)]
@@ -354,6 +359,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                         }
 
                         if (bits_right >> bit_pos & 1) != 0
+                            && ao_uniform(ao_here)
                             && self.forward_merged[forward_merge_i]
                                 == self.forward_merged[(right_cs + CS) + (bit_pos - 1)]
                             && v_type
@@ -434,19 +440,38 @@ fn compute_vertex_ao_packed(
     occ: &dyn Fn(i32, i32, i32) -> bool,
 ) -> u8 {
     let neighbors = face_ao_neighbors(face);
+    // Vanilla's `shade0` fallback (corners[0]) for the both-sides-occlude case,
+    // recovered from the neighbour table to stay in its coordinate frame.
+    let c0 = shared_side(&neighbors[0], &neighbors[1]);
+    let shade0_occ = occ(fx + c0[0], fy + c0[1], fz + c0[2]);
     let mut packed = 0u8;
     for (i, [s1, s2, c]) in neighbors.iter().enumerate() {
-        let side1 = occ(fx + s1[0], fy + s1[1], fz + s1[2]) as u8;
-        let side2 = occ(fx + s2[0], fy + s2[1], fz + s2[2]) as u8;
-        let corner = occ(fx + c[0], fy + c[1], fz + c[2]) as u8;
-        let ao = if side1 == 1 && side2 == 1 {
-            0
-        } else {
-            3 - (side1 + side2 + corner)
-        };
+        let side1 = occ(fx + s1[0], fy + s1[1], fz + s1[2]);
+        let side2 = occ(fx + s2[0], fy + s2[1], fz + s2[2]);
+        let corner = occ(fx + c[0], fy + c[1], fz + c[2]);
+        let ao = block_ao::vertex_ao_level(side1, side2, corner, shade0_occ);
         packed |= ao << (6 - i * 2);
     }
     packed
+}
+
+/// Whether all four packed AO corners are equal (a flat-lit face). Vanilla
+/// renders every block face individually, so a merged quad only reproduces its
+/// shading when the AO is uniform; gradient faces must stay 1x1.
+#[inline]
+fn ao_uniform(ao: u8) -> bool {
+    let c = (ao >> 6) & 3;
+    ((ao >> 4) & 3) == c && ((ao >> 2) & 3) == c && (ao & 3) == c
+}
+
+/// The side offset common to both vertices' neighbour triples (their first two
+/// entries are the two edge sides). This is vanilla's `corners[0]`.
+fn shared_side(v0: &[[i32; 3]; 3], v1: &[[i32; 3]; 3]) -> [i32; 3] {
+    if v0[0] == v1[0] || v0[0] == v1[1] {
+        v0[0]
+    } else {
+        v0[1]
+    }
 }
 
 fn face_ao_neighbors(face: u8) -> [[[i32; 3]; 3]; 4] {

--- a/pomme-client/src/renderer/chunk/mesher.rs
+++ b/pomme-client/src/renderer/chunk/mesher.rs
@@ -649,7 +649,7 @@ fn face_texture_name(textures: &FaceTextures, face: greedy::Face) -> &str {
     }
 }
 
-const AO_BRIGHTNESS: [f32; 4] = [0.2, 0.467, 0.733, 1.0];
+use super::block_ao::AO_BRIGHTNESS;
 
 #[allow(clippy::too_many_arguments)]
 fn greedy_mesh_section(
@@ -1315,8 +1315,23 @@ fn shade_brightness(state: azalea_block::BlockState, registry: &BlockRegistry) -
     }
 }
 
-fn vertex_ao(side1: f32, side2: f32, corner: f32) -> f32 {
-    (side1 + side2 + corner + 1.0) * 0.25
+/// Centre-relative offset of vanilla's `AdjacencyInfo.corners[0]` neighbour
+/// (`centre + dir + corners[0]`), the `shade0` occlusion fallback.
+fn corners0_offset(dir: Direction) -> [i32; 3] {
+    match dir {
+        // corners[0] = EAST(+x)
+        Direction::Up => [1, 1, 0],
+        // corners[0] = WEST(-x)
+        Direction::Down => [-1, -1, 0],
+        // corners[0] = UP(+y)
+        Direction::North => [0, 1, -1],
+        // corners[0] = WEST(-x)
+        Direction::South => [-1, 0, 1],
+        // corners[0] = UP(+y)
+        Direction::West => [-1, 1, 0],
+        // corners[0] = DOWN(-y)
+        Direction::East => [1, -1, 0],
+    }
 }
 
 fn compute_face_ao(
@@ -1339,6 +1354,12 @@ fn compute_face_ao(
         Direction::Down => 0.5,
         Direction::North | Direction::South => 0.8,
         Direction::East | Direction::West => 0.6,
+    };
+
+    let c0 = corners0_offset(dir);
+    let shade0 = s(c0[0], c0[1], c0[2]);
+    let vertex_ao = |side1: f32, side2: f32, corner: f32| -> f32 {
+        super::block_ao::vertex_brightness(side1, side2, corner, shade0)
     };
 
     let (ao, lights) = match dir {

--- a/pomme-client/src/renderer/chunk/mod.rs
+++ b/pomme-client/src/renderer/chunk/mod.rs
@@ -1,4 +1,5 @@
 pub mod atlas;
+pub mod block_ao;
 pub mod buffer;
 pub mod greedy;
 pub mod mesher;


### PR DESCRIPTION
Make block ambient occlusion match vanilla, in both the per-block and greedy meshing paths.