### PR TITLE
Fix chunk border lighting seam

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -36,6 +36,25 @@ pub struct PendingPackDownload {
 
 pub type PackDownloadResult = Result<std::path::PathBuf, crate::resource_pack::PackError>;
 
+/// Queues `pos` plus its already-loaded 8 neighbors for meshing
+/// (de-duplicated). A chunk's border faces sample light from its neighbors, so
+/// when `pos` arrives the already-meshed neighbors must re-mesh too, else their
+/// shared border keeps the stale full-bright edge light.
+fn enqueue_with_neighbors(
+    out: &mut Vec<azalea_core::position::ChunkPos>,
+    store: &ChunkStore,
+    pos: azalea_core::position::ChunkPos,
+) {
+    for dz in -1..=1 {
+        for dx in -1..=1 {
+            let p = azalea_core::position::ChunkPos::new(pos.x + dx, pos.z + dz);
+            if ((dx == 0 && dz == 0) || store.get_chunk(&p).is_some()) && !out.contains(&p) {
+                out.push(p);
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq)]
 pub enum DisplayMode {
     Windowed,
@@ -269,7 +288,7 @@ impl AppCore {
                         &sky_y_mask,
                         &block_y_mask,
                     );
-                    chunks_to_mesh.push(pos);
+                    enqueue_with_neighbors(&mut chunks_to_mesh, &game.chunk_store, pos);
                 }
                 NetworkEvent::ChunkUnloaded { pos } => {
                     game.chunk_store.unload_chunk(&pos);
@@ -411,6 +430,9 @@ impl AppCore {
                         pos.x.div_euclid(16),
                         pos.z.div_euclid(16),
                     );
+                    // TODO(chunk-light): route edge edits through enqueue_with_neighbors so the
+                    // neighbor's border lighting refreshes too (gate on edge-proximity to avoid
+                    // churn).
                     chunks_to_mesh.push(chunk_pos);
                 }
                 NetworkEvent::SectionBlocksUpdate { updates } => {
@@ -420,6 +442,8 @@ impl AppCore {
                             pos.x.div_euclid(16),
                             pos.z.div_euclid(16),
                         );
+                        // TODO(chunk-light): same neighbor re-mesh as BlockUpdate above for edge
+                        // edits.
                         if !chunks_to_mesh.contains(&chunk_pos) {
                             chunks_to_mesh.push(chunk_pos);
                         }

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -25,7 +25,7 @@ use crate::renderer::Renderer;
 use crate::resource_pack::ResourcePackManager;
 use crate::ui::menu::{MainMenu, MenuInput};
 use crate::user::UserData;
-use crate::world::chunk::ChunkStore;
+use crate::world::chunk::{ChunkStore, mesh_neighborhood};
 
 pub struct PendingPackDownload {
     pub id: uuid::Uuid,
@@ -36,21 +36,17 @@ pub struct PendingPackDownload {
 
 pub type PackDownloadResult = Result<std::path::PathBuf, crate::resource_pack::PackError>;
 
-/// Queues `pos` plus its already-loaded 8 neighbors for meshing
-/// (de-duplicated). A chunk's border faces sample light from its neighbors, so
-/// when `pos` arrives the already-meshed neighbors must re-mesh too, else their
-/// shared border keeps the stale full-bright edge light.
+/// Queues `pos` and its already-loaded mesh neighborhood (de-duplicated): when
+/// `pos` changes, every chunk whose mesh samples it must re-mesh too, else
+/// their shared border keeps the stale full-bright edge light.
 fn enqueue_with_neighbors(
     out: &mut Vec<azalea_core::position::ChunkPos>,
     store: &ChunkStore,
     pos: azalea_core::position::ChunkPos,
 ) {
-    for dz in -1..=1 {
-        for dx in -1..=1 {
-            let p = azalea_core::position::ChunkPos::new(pos.x + dx, pos.z + dz);
-            if ((dx == 0 && dz == 0) || store.get_chunk(&p).is_some()) && !out.contains(&p) {
-                out.push(p);
-            }
+    for p in mesh_neighborhood(pos) {
+        if (p == pos || store.get_chunk(&p).is_some()) && !out.contains(&p) {
+            out.push(p);
         }
     }
 }

--- a/pomme-client/src/renderer/chunk/greedy.rs
+++ b/pomme-client/src/renderer/chunk/greedy.rs
@@ -12,13 +12,27 @@ const MASK_6: u64 = 0b111111;
 pub struct Quad {
     packed: u64,
     pub ao: u8,
+    /// Per-corner smooth light (quantised brightness 0..=255), ordered to match
+    /// `ao_levels`.
+    pub light: [u8; 4],
 }
 
 impl Quad {
-    fn pack(x: usize, y: usize, z: usize, w: usize, h: usize, v_type: usize, ao: u8) -> Self {
+    #[allow(clippy::too_many_arguments)]
+    fn pack(
+        x: usize,
+        y: usize,
+        z: usize,
+        w: usize,
+        h: usize,
+        v_type: usize,
+        ao: u8,
+        light: [u8; 4],
+    ) -> Self {
         Self {
             packed: ((v_type << 32) | (h << 24) | (w << 18) | (z << 12) | (y << 6) | x) as u64,
             ao,
+            light,
         }
     }
 
@@ -56,6 +70,7 @@ pub struct GreedyMesher<const CS: usize> {
     pub quads: [Vec<Quad>; 6],
     face_masks: Box<[u64]>,
     ao_faces: Box<[u8]>,
+    light_faces: Box<[[u8; 4]]>,
     forward_merged: Box<[u8]>,
     right_merged: Box<[u8]>,
 }
@@ -69,15 +84,22 @@ impl<const CS: usize> GreedyMesher<CS> {
         Self {
             face_masks: vec![0; Self::CS_2 * 6].into_boxed_slice(),
             ao_faces: vec![0; Self::CS_2 * 6 * CS].into_boxed_slice(),
+            light_faces: vec![[0u8; 4]; Self::CS_2 * 6 * CS].into_boxed_slice(),
             forward_merged: vec![0; Self::CS_2].into_boxed_slice(),
             right_merged: vec![0; CS].into_boxed_slice(),
             quads: core::array::from_fn(|_| Vec::new()),
         }
     }
 
-    pub fn mesh(&mut self, voxels: &[u16], occluders: &[bool], transparents: &BTreeSet<u16>) {
+    pub fn mesh(
+        &mut self,
+        voxels: &[u16],
+        occluders: &[bool],
+        light: &[f32],
+        transparents: &BTreeSet<u16>,
+    ) {
         self.face_culling(voxels, transparents);
-        self.compute_ao(occluders);
+        self.compute_ao_and_light(occluders, light);
         self.face_merging(voxels);
     }
 
@@ -111,16 +133,35 @@ impl<const CS: usize> GreedyMesher<CS> {
         }
     }
 
-    fn compute_ao(&mut self, occluders: &[bool]) {
+    /// Linear index into `ao_faces` / `light_faces` for one face cell.
+    #[inline]
+    fn cell_index(face: usize, layer: usize, forward: usize, right: usize) -> usize {
+        face * Self::CS_2 * CS + (layer * CS + forward) * CS + right
+    }
+
+    /// Index into the padded `CS_P^3` voxel/occluder/light arrays, or `None`
+    /// when out of range.
+    #[inline]
+    fn padded_index(x: i32, y: i32, z: i32) -> Option<usize> {
+        if x < 0 || y < 0 || z < 0 {
+            return None;
+        }
+        let (x, y, z) = (x as usize, y as usize, z as usize);
+        if x >= Self::CS_P || y >= Self::CS_P || z >= Self::CS_P {
+            return None;
+        }
+        Some(pad_linearize::<CS>(x, y, z))
+    }
+
+    /// Per-corner AO and smooth light for every visible face cell, written to
+    /// the same `idx` so the light merge gate stays locked to the AO gate.
+    fn compute_ao_and_light(&mut self, occluders: &[bool], light: &[f32]) {
         let occ = |x: i32, y: i32, z: i32| -> bool {
-            if x < 0 || y < 0 || z < 0 {
-                return false;
-            }
-            let (x, y, z) = (x as usize, y as usize, z as usize);
-            if x >= Self::CS_P || y >= Self::CS_P || z >= Self::CS_P {
-                return false;
-            }
-            occluders[(y * Self::CS_P + x) * Self::CS_P + z]
+            Self::padded_index(x, y, z).is_some_and(|i| occluders[i])
+        };
+        // Out of range falls back to full bright (never reached for real face cells).
+        let lit = |x: i32, y: i32, z: i32| -> f32 {
+            Self::padded_index(x, y, z).map_or(1.0, |i| light[i])
         };
 
         for face in 0..=3u8 {
@@ -144,11 +185,9 @@ impl<const CS: usize> GreedyMesher<CS> {
                         let fy = y as i32 + ny;
                         let fz = z as i32 + nz;
 
-                        let ao = compute_vertex_ao_packed(face, fx, fy, fz, &occ);
-                        let ao_idx = (face as usize * Self::CS_2 * CS)
-                            + (layer * CS + forward) * CS
-                            + bit_pos;
-                        self.ao_faces[ao_idx] = ao;
+                        let idx = Self::cell_index(face as usize, layer, forward, bit_pos);
+                        self.ao_faces[idx] = compute_vertex_ao_packed(face, fx, fy, fz, &occ);
+                        self.light_faces[idx] = compute_vertex_light_packed(face, fx, fy, fz, &lit);
                     }
                 }
             }
@@ -174,11 +213,9 @@ impl<const CS: usize> GreedyMesher<CS> {
                         let fy = y as i32 + ny;
                         let fz = z as i32 + nz;
 
-                        let ao = compute_vertex_ao_packed(face, fx, fy, fz, &occ);
-                        let ao_idx = (face as usize * Self::CS_2 * CS)
-                            + (forward * CS + right) * CS
-                            + (bit_pos - 1);
-                        self.ao_faces[ao_idx] = ao;
+                        let idx = Self::cell_index(face as usize, forward, right, bit_pos - 1);
+                        self.ao_faces[idx] = compute_vertex_ao_packed(face, fx, fy, fz, &occ);
+                        self.light_faces[idx] = compute_vertex_light_packed(face, fx, fy, fz, &lit);
                     }
                 }
             }
@@ -186,8 +223,11 @@ impl<const CS: usize> GreedyMesher<CS> {
     }
 
     fn get_ao(&self, face: usize, layer: usize, forward: usize, right: usize) -> u8 {
-        let idx = face * Self::CS_2 * CS + (layer * CS + forward) * CS + right;
-        self.ao_faces[idx]
+        self.ao_faces[Self::cell_index(face, layer, forward, right)]
+    }
+
+    fn get_light4(&self, face: usize, layer: usize, forward: usize, right: usize) -> [u8; 4] {
+        self.light_faces[Self::cell_index(face, layer, forward, right)]
     }
 
     fn face_merging(&mut self, voxels: &[u16]) {
@@ -211,9 +251,11 @@ impl<const CS: usize> GreedyMesher<CS> {
                         let v_type =
                             voxels[get_axis_index::<CS>(axis, forward + 1, bit_pos + 1, layer + 1)];
                         let ao_here = self.get_ao(face, layer, forward, bit_pos);
+                        let light_here = self.get_light4(face, layer, forward, bit_pos);
 
                         if (bits_next >> bit_pos & 1) != 0
                             && ao_uniform(ao_here)
+                            && light_uniform(light_here)
                             && v_type
                                 == voxels[get_axis_index::<CS>(
                                     axis,
@@ -222,6 +264,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                                     layer + 1,
                                 )]
                             && ao_here == self.get_ao(face, layer, forward + 1, bit_pos)
+                            && light_here == self.get_light4(face, layer, forward + 1, bit_pos)
                         {
                             self.forward_merged[bit_pos] += 1;
                             bits_here &= !(1 << bit_pos);
@@ -231,6 +274,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                         for right in (bit_pos + 1)..CS {
                             if (bits_here >> right & 1) == 0
                                 || !ao_uniform(ao_here)
+                                || !light_uniform(light_here)
                                 || self.forward_merged[bit_pos] != self.forward_merged[right]
                                 || v_type
                                     != voxels[get_axis_index::<CS>(
@@ -240,6 +284,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                                         layer + 1,
                                     )]
                                 || ao_here != self.get_ao(face, layer, forward, right)
+                                || light_here != self.get_light4(face, layer, forward, right)
                             {
                                 break;
                             }
@@ -266,6 +311,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                                 mesh_width,
                                 v_type as usize,
                                 ao_here,
+                                light_here,
                             ),
                             1 => Quad::pack(
                                 mesh_front + mesh_length,
@@ -275,6 +321,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                                 mesh_width,
                                 v_type as usize,
                                 ao_here,
+                                light_here,
                             ),
                             2 => Quad::pack(
                                 mesh_up,
@@ -284,6 +331,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                                 mesh_width,
                                 v_type as usize,
                                 ao_here,
+                                light_here,
                             ),
                             3 => Quad::pack(
                                 mesh_up,
@@ -293,6 +341,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                                 mesh_width,
                                 v_type as usize,
                                 ao_here,
+                                light_here,
                             ),
                             _ => unreachable!(),
                         };
@@ -331,6 +380,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                         let v_type =
                             voxels[get_axis_index::<CS>(axis, right + 1, forward + 1, bit_pos)];
                         let ao_here = self.get_ao(face, forward, right, bit_pos - 1);
+                        let light_here = self.get_light4(face, forward, right, bit_pos - 1);
                         let forward_merge_i = right_cs + (bit_pos - 1);
 
                         let ao_forward = if (bits_forward >> bit_pos & 1) != 0 {
@@ -343,16 +393,30 @@ impl<const CS: usize> GreedyMesher<CS> {
                         } else {
                             255
                         };
+                        // Precomputed before the `right_merged` borrow below to avoid aliasing
+                        // `self`; sentinels are guarded by the `bits_*` checks, never compared.
+                        let light_forward = if (bits_forward >> bit_pos & 1) != 0 {
+                            self.get_light4(face, forward + 1, right, bit_pos - 1)
+                        } else {
+                            [255u8; 4]
+                        };
+                        let light_right = if (bits_right >> bit_pos & 1) != 0 {
+                            self.get_light4(face, forward, right + 1, bit_pos - 1)
+                        } else {
+                            [255u8; 4]
+                        };
 
                         let right_merged_ref = &mut self.right_merged[bit_pos - 1];
 
                         if *right_merged_ref == 0
                             && (bits_forward >> bit_pos & 1) != 0
                             && ao_uniform(ao_here)
+                            && light_uniform(light_here)
                             && v_type
                                 == voxels
                                     [get_axis_index::<CS>(axis, right + 1, forward + 2, bit_pos)]
                             && ao_here == ao_forward
+                            && light_here == light_forward
                         {
                             self.forward_merged[forward_merge_i] += 1;
                             continue;
@@ -360,12 +424,14 @@ impl<const CS: usize> GreedyMesher<CS> {
 
                         if (bits_right >> bit_pos & 1) != 0
                             && ao_uniform(ao_here)
+                            && light_uniform(light_here)
                             && self.forward_merged[forward_merge_i]
                                 == self.forward_merged[(right_cs + CS) + (bit_pos - 1)]
                             && v_type
                                 == voxels
                                     [get_axis_index::<CS>(axis, right + 2, forward + 1, bit_pos)]
                             && ao_here == ao_right
+                            && light_here == light_right
                         {
                             self.forward_merged[forward_merge_i] = 0;
                             *right_merged_ref += 1;
@@ -389,6 +455,7 @@ impl<const CS: usize> GreedyMesher<CS> {
                             mesh_length as usize,
                             v_type as usize,
                             ao_here,
+                            light_here,
                         );
                         self.quads[face].push(quad);
                     }
@@ -455,6 +522,30 @@ fn compute_vertex_ao_packed(
     packed
 }
 
+/// Per-corner smooth light: each corner averages the face-adjacent block (`(fx,
+/// fy, fz)`, the face cell plus its normal) and the same three neighbours the
+/// AO pass samples, packed in `face_ao_neighbors` order to match
+/// `Quad::ao_levels`.
+fn compute_vertex_light_packed(
+    face: u8,
+    fx: i32,
+    fy: i32,
+    fz: i32,
+    lit: &dyn Fn(i32, i32, i32) -> f32,
+) -> [u8; 4] {
+    let neighbors = face_ao_neighbors(face);
+    let center = lit(fx, fy, fz);
+    let mut packed = [0u8; 4];
+    for (i, [s1, s2, c]) in neighbors.iter().enumerate() {
+        let side1 = lit(fx + s1[0], fy + s1[1], fz + s1[2]);
+        let side2 = lit(fx + s2[0], fy + s2[1], fz + s2[2]);
+        let corner = lit(fx + c[0], fy + c[1], fz + c[2]);
+        let brightness = 0.25 * (center + side1 + side2 + corner);
+        packed[i] = (brightness * 255.0).round() as u8;
+    }
+    packed
+}
+
 /// Whether all four packed AO corners are equal (a flat-lit face). Vanilla
 /// renders every block face individually, so a merged quad only reproduces its
 /// shading when the AO is uniform; gradient faces must stay 1x1.
@@ -462,6 +553,13 @@ fn compute_vertex_ao_packed(
 fn ao_uniform(ao: u8) -> bool {
     let c = (ao >> 6) & 3;
     ((ao >> 4) & 3) == c && ((ao >> 2) & 3) == c && (ao & 3) == c
+}
+
+/// Whether all four packed smooth-light corners are equal. Mirrors
+/// `ao_uniform`: a quad may only merge across cells whose light is uniform.
+#[inline]
+fn light_uniform(l: [u8; 4]) -> bool {
+    l[0] == l[1] && l[1] == l[2] && l[2] == l[3]
 }
 
 /// The side offset common to both vertices' neighbour triples (their first two
@@ -544,17 +642,6 @@ impl From<usize> for Face {
 }
 
 impl Face {
-    pub fn offset(&self) -> [i32; 3] {
-        match self {
-            Self::Up => [0, 1, 0],
-            Self::Down => [0, -1, 0],
-            Self::Right => [1, 0, 0],
-            Self::Left => [-1, 0, 0],
-            Self::Front => [0, 0, 1],
-            Self::Back => [0, 0, -1],
-        }
-    }
-
     pub fn shade_light(&self) -> f32 {
         match self {
             Self::Up => 1.0,

--- a/pomme-client/src/renderer/chunk/mesher.rs
+++ b/pomme-client/src/renderer/chunk/mesher.rs
@@ -381,6 +381,9 @@ impl MeshDispatcher {
         let biome_climate = Arc::clone(&self.biome_climate);
         let tx = self.result_tx.clone();
 
+        // TODO(chunk-light): also include the 4 diagonal neighbors (pos.x±1, pos.z±1)
+        // so smooth-light corner samples at chunk corners read real data, not
+        // the fallback.
         let chunks_needed = [
             pos,
             ChunkPos::new(pos.x - 1, pos.z),
@@ -667,6 +670,7 @@ fn greedy_mesh_section(
     let mut mesher = M::new();
     let mut voxels = vec![0u16; M::CS_P3];
     let mut occluders = vec![false; M::CS_P3];
+    let mut light = vec![0.0f32; M::CS_P3];
 
     for ly in 0..18 {
         for lx in 0..18 {
@@ -678,12 +682,13 @@ fn greedy_mesh_section(
                 let idx = greedy::pad_linearize::<SECTION_SIZE>(lx, ly, lz);
                 voxels[idx] = type_map.get_id(state);
                 occluders[idx] = registry.is_opaque_full_cube(state);
+                light[idx] = snapshot.get_light(bx, by, bz);
             }
         }
     }
 
     let transparent_set = std::collections::BTreeSet::new();
-    mesher.mesh(&voxels, &occluders, &transparent_set);
+    mesher.mesh(&voxels, &occluders, &light, &transparent_set);
 
     for face_idx in 0..6 {
         let face = greedy::Face::from(face_idx);
@@ -710,15 +715,11 @@ fn greedy_mesh_section(
             );
 
             let ao = quad.ao_levels();
-            let [qx, qy, qz] = quad.xyz();
-            let face_offset = face.offset();
-            let light_sample = snapshot.get_light(
-                world_x + qx as i32 + face_offset[0],
-                section_y + qy as i32 + face_offset[1],
-                world_z + qz as i32 + face_offset[2],
-            );
-            let lights: [f32; 4] =
-                core::array::from_fn(|i| AO_BRIGHTNESS[ao[i] as usize] * light_sample * dir_shade);
+            // Per-vertex smooth light (averaged across chunk borders in the mesher); `i`
+            // matches `ao`.
+            let lights: [f32; 4] = core::array::from_fn(|i| {
+                AO_BRIGHTNESS[ao[i] as usize] * (quad.light[i] as f32 / 255.0) * dir_shade
+            });
 
             let base = vertices.len() as u32;
             let u_span = region.u_max - region.u_min;

--- a/pomme-client/src/renderer/chunk/mesher.rs
+++ b/pomme-client/src/renderer/chunk/mesher.rs
@@ -381,16 +381,7 @@ impl MeshDispatcher {
         let biome_climate = Arc::clone(&self.biome_climate);
         let tx = self.result_tx.clone();
 
-        // TODO(chunk-light): also include the 4 diagonal neighbors (pos.x±1, pos.z±1)
-        // so smooth-light corner samples at chunk corners read real data, not
-        // the fallback.
-        let chunks_needed = [
-            pos,
-            ChunkPos::new(pos.x - 1, pos.z),
-            ChunkPos::new(pos.x + 1, pos.z),
-            ChunkPos::new(pos.x, pos.z - 1),
-            ChunkPos::new(pos.x, pos.z + 1),
-        ];
+        let chunks_needed = chunk::mesh_neighborhood(pos);
         let chunk_arcs: Vec<_> = chunks_needed
             .iter()
             .map(|p| chunk_store.get_chunk(p))

--- a/pomme-client/src/world/chunk.rs
+++ b/pomme-client/src/world/chunk.rs
@@ -15,6 +15,21 @@ use super::block_entity::StoredBlockEntity;
 const OVERWORLD_HEIGHT: u32 = 384;
 const OVERWORLD_MIN_Y: i32 = -64;
 
+/// `pos` and its four axis-neighbor chunks. This is both the neighborhood a
+/// chunk's mesh samples (see `MeshDispatcher::enqueue`) and, by symmetry, the
+/// set that must re-mesh when `pos` changes. Add the diagonals here when the
+/// corner-sample TODO(chunk-light) lands, so the mesh snapshot and the re-mesh
+/// set stay in sync.
+pub(crate) fn mesh_neighborhood(pos: ChunkPos) -> [ChunkPos; 5] {
+    [
+        pos,
+        ChunkPos::new(pos.x - 1, pos.z),
+        ChunkPos::new(pos.x + 1, pos.z),
+        ChunkPos::new(pos.x, pos.z - 1),
+        ChunkPos::new(pos.x, pos.z + 1),
+    ]
+}
+
 #[derive(Error, Debug)]
 pub enum ChunkError {
     #[error("failed to parse chunk data: {0}")]


### PR DESCRIPTION
Greedy-meshed cubes now use per-vertex smooth lighting, so grass tops no longer show a dark line at chunk borders.