### PR TITLE
add distance fog to terrain and entities

### DIFF
--- a/pomme-client/build.rs
+++ b/pomme-client/build.rs
@@ -13,6 +13,21 @@ fn main() {
     );
     options.set_source_language(shaderc::SourceLanguage::GLSL);
 
+    let include_dir = shader_dir.to_path_buf();
+    options.set_include_callback(move |requested, _ty, _requesting, _depth| {
+        let path = include_dir.join(requested);
+        let content = fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read shader include {requested}: {e}"))?;
+        Ok(shaderc::ResolvedInclude {
+            resolved_name: path.to_string_lossy().into_owned(),
+            content,
+        })
+    });
+    println!(
+        "cargo:rerun-if-changed={}",
+        shader_dir.join("fog.glsl").display()
+    );
+
     let shaders = [
         ("chunk.vert", shaderc::ShaderKind::Vertex),
         ("chunk.frag", shaderc::ShaderKind::Fragment),

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -660,6 +660,11 @@ pub fn update_game(
         sky.rain(),
     );
 
+    let effective_rd = if game.server_render_distance > 0 {
+        core.menu.render_distance.min(game.server_render_distance)
+    } else {
+        core.menu.render_distance
+    };
     if let Err(e) = gfx.renderer.render_world(
         &gfx.window,
         hide_cursor,
@@ -672,6 +677,7 @@ pub fn update_game(
         &item_renders,
         &block_entity_renders,
         &weather_columns,
+        effective_rd,
     ) {
         tracing::error!("Render error: {e}");
     }

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -168,13 +168,18 @@ pub struct CameraUniform {
 }
 
 impl CameraUniform {
-    pub fn new(camera: &Camera, fog_color: [f32; 3]) -> Self {
+    pub fn new(camera: &Camera, fog_color: [f32; 3], render_distance_chunks: u32) -> Self {
         let offset = camera.third_person_offset();
         let pos = camera.position.as_vec3() + offset;
+        // Vanilla render-distance fog band: the last clamp(blocks / 10, 4, 64) blocks.
+        let blocks = (render_distance_chunks * 16) as f32;
+        let span = (blocks / 10.0).clamp(4.0, 64.0);
+        let fog_start = blocks - span;
+        let fog_end = blocks;
         Self {
             view_proj: camera.view_projection().to_cols_array_2d(),
-            camera_pos: [pos.x, pos.y, pos.z, 0.0],
-            fog_color: [fog_color[0], fog_color[1], fog_color[2], 0.0],
+            camera_pos: [pos.x, pos.y, pos.z, fog_start],
+            fog_color: [fog_color[0], fog_color[1], fog_color[2], fog_end],
         }
     }
 

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -68,6 +68,7 @@ enum RenderMode<'a> {
         item_entities: &'a [pipelines::item_entity::ItemRenderInfo],
         block_entities: &'a [BlockEntityRenderInfo],
         weather: &'a [WeatherColumn],
+        render_distance: u32,
     },
     MainMenu {
         scroll: f32,
@@ -809,12 +810,13 @@ impl Renderer {
         item_entities: &[pipelines::item_entity::ItemRenderInfo],
         block_entities: &[BlockEntityRenderInfo],
         weather: &[WeatherColumn],
+        render_distance: u32,
     ) -> Result<(), RendererError> {
-        let sky_col = sky.sky_color();
+        let fog_col = sky.fog_color();
         self.render_frame(
             window,
             hide_cursor,
-            [sky_col[0], sky_col[1], sky_col[2], 1.0],
+            [fog_col[0], fog_col[1], fog_col[2], 1.0],
             RenderMode::World {
                 overlay,
                 swing_progress,
@@ -825,6 +827,7 @@ impl Renderer {
                 item_entities,
                 block_entities,
                 weather,
+                render_distance,
             },
         )
     }
@@ -1025,9 +1028,14 @@ impl Renderer {
 
         let render_finished = self.render_finished_per_image[image_index as usize];
 
-        if let RenderMode::World { ref sky, .. } = mode {
+        if let RenderMode::World {
+            ref sky,
+            render_distance,
+            ..
+        } = mode
+        {
             let fog = sky.fog_color();
-            let uniform = CameraUniform::new(&self.camera, fog);
+            let uniform = CameraUniform::new(&self.camera, fog, render_distance);
             self.chunk_pipeline.update_camera(frame, &uniform);
             self.block_overlay_pipeline.update_camera(frame, &uniform);
             self.entity_renderer.update_camera(frame, &uniform);
@@ -1221,6 +1229,7 @@ impl Renderer {
                 item_entities,
                 block_entities,
                 weather,
+                render_distance: _,
             } => {
                 self.sky_pipeline
                     .update_and_draw(&self.ctx.device, cmd, frame, &self.camera, sky);

--- a/pomme-client/src/renderer/shaders/chunk.frag
+++ b/pomme-client/src/renderer/shaders/chunk.frag
@@ -1,5 +1,7 @@
 #version 450
 
+#include "fog.glsl"
+
 layout(set = 1, binding = 0) uniform sampler2D atlas_texture;
 
 layout(location = 0) in vec2 v_tex_coords;
@@ -7,6 +9,7 @@ layout(location = 1) in float v_light;
 layout(location = 2) in vec3 v_tint;
 layout(location = 3) flat in float v_visibility;
 layout(location = 4) in vec3 v_fog_color;
+layout(location = 5) in float v_fog;
 
 layout(location = 0) out vec4 out_color;
 
@@ -20,6 +23,8 @@ void main() {
     if (v_visibility < 1.0) {
         tinted = mix(v_fog_color, tinted, v_visibility);
     }
+
+    tinted = apply_fog(tinted, v_fog, v_fog_color);
 
     out_color = vec4(tinted, color.a);
 }

--- a/pomme-client/src/renderer/shaders/chunk.vert
+++ b/pomme-client/src/renderer/shaders/chunk.vert
@@ -1,5 +1,7 @@
 #version 450
 
+#include "fog.glsl"
+
 layout(set = 0, binding = 0) uniform CameraUniform {
     mat4 view_proj;
     vec4 camera_pos;
@@ -15,12 +17,15 @@ layout(location = 1) out float v_light;
 layout(location = 2) out vec3 v_tint;
 layout(location = 3) flat out float v_visibility;
 layout(location = 4) out vec3 v_fog_color;
+layout(location = 5) out float v_fog;
 
 void main() {
-    gl_Position = view_proj * vec4(position - camera_pos.xyz, 1.0);
+    vec3 rel = position - camera_pos.xyz;
+    gl_Position = view_proj * vec4(rel, 1.0);
     v_tex_coords = tex_coords;
     v_light = light_tint.r;
     v_tint = light_tint.gba;
     v_visibility = uintBitsToFloat(gl_InstanceIndex);
     v_fog_color = fog_color.rgb;
+    v_fog = fog_factor(rel, camera_pos.w, fog_color.w);
 }

--- a/pomme-client/src/renderer/shaders/entity.frag
+++ b/pomme-client/src/renderer/shaders/entity.frag
@@ -1,14 +1,19 @@
 #version 450
 
+#include "fog.glsl"
+
 layout(set = 1, binding = 0) uniform sampler2D entity_tex;
 
 layout(location = 0) in vec2 v_tex_coords;
 layout(location = 1) in vec4 v_tint;
+layout(location = 2) in float v_fog;
+layout(location = 3) in vec3 v_fog_color;
 
 layout(location = 0) out vec4 out_color;
 
 void main() {
     vec4 color = texture(entity_tex, v_tex_coords);
     if (color.a < 0.5) discard;
-    out_color = color * v_tint;
+    vec4 lit = color * v_tint;
+    out_color = vec4(apply_fog(lit.rgb, v_fog, v_fog_color), lit.a);
 }

--- a/pomme-client/src/renderer/shaders/entity.vert
+++ b/pomme-client/src/renderer/shaders/entity.vert
@@ -1,5 +1,7 @@
 #version 450
 
+#include "fog.glsl"
+
 layout(set = 0, binding = 0) uniform CameraUniform {
     mat4 view_proj;
     vec4 camera_pos;
@@ -17,10 +19,15 @@ layout(location = 2) in vec4 light_tint;
 
 layout(location = 0) out vec2 v_tex_coords;
 layout(location = 1) out vec4 v_tint;
+layout(location = 2) out float v_fog;
+layout(location = 3) out vec3 v_fog_color;
 
 void main() {
     vec4 world_pos = model * vec4(position, 1.0);
-    gl_Position = view_proj * vec4(world_pos.xyz - camera_pos.xyz, 1.0);
+    vec3 rel = world_pos.xyz - camera_pos.xyz;
+    gl_Position = view_proj * vec4(rel, 1.0);
     v_tex_coords = tex_coords;
     v_tint = tint;
+    v_fog = fog_factor(rel, camera_pos.w, fog_color.w);
+    v_fog_color = fog_color.rgb;
 }

--- a/pomme-client/src/renderer/shaders/fog.glsl
+++ b/pomme-client/src/renderer/shaders/fog.glsl
@@ -1,0 +1,10 @@
+// Distances live in the camera UBO's spare .w lanes; cylindrical metric like vanilla.
+float fog_factor(vec3 rel, float fog_start, float fog_end) {
+    float span = fog_end - fog_start;
+    float dist = max(length(rel.xz), abs(rel.y));
+    return span > 0.0 ? (dist - fog_start) / span : 0.0;
+}
+
+vec3 apply_fog(vec3 color, float fog, vec3 fog_color) {
+    return mix(color, fog_color, clamp(fog, 0.0, 1.0));
+}

--- a/pomme-client/src/renderer/shaders/item_entity.frag
+++ b/pomme-client/src/renderer/shaders/item_entity.frag
@@ -1,5 +1,7 @@
 #version 450
 
+#include "fog.glsl"
+
 layout(set = 1, binding = 0) uniform sampler2D atlas_texture;
 
 layout(push_constant) uniform PushConstants {
@@ -9,6 +11,8 @@ layout(push_constant) uniform PushConstants {
 layout(location = 0) in vec2 v_tex_coords;
 layout(location = 1) in float v_light;
 layout(location = 2) in vec3 v_tint;
+layout(location = 3) in float v_fog;
+layout(location = 4) in vec3 v_fog_color;
 
 layout(location = 0) out vec4 out_color;
 
@@ -16,5 +20,6 @@ void main() {
     vec4 color = texture(atlas_texture, v_tex_coords);
     if (color.a < 0.5) discard;
     vec3 tinted = color.rgb * v_tint * (world_light * v_light);
+    tinted = apply_fog(tinted, v_fog, v_fog_color);
     out_color = vec4(tinted, color.a);
 }

--- a/pomme-client/src/renderer/shaders/item_entity.vert
+++ b/pomme-client/src/renderer/shaders/item_entity.vert
@@ -1,5 +1,7 @@
 #version 450
 
+#include "fog.glsl"
+
 layout(set = 0, binding = 0) uniform CameraUniform {
     mat4 view_proj;
     vec4 camera_pos;
@@ -17,11 +19,16 @@ layout(location = 2) in vec4 light_tint;
 layout(location = 0) out vec2 v_tex_coords;
 layout(location = 1) out float v_light;
 layout(location = 2) out vec3 v_tint;
+layout(location = 3) out float v_fog;
+layout(location = 4) out vec3 v_fog_color;
 
 void main() {
     vec4 world_pos = model * vec4(position, 1.0);
-    gl_Position = view_proj * vec4(world_pos.xyz - camera_pos.xyz, 1.0);
+    vec3 rel = world_pos.xyz - camera_pos.xyz;
+    gl_Position = view_proj * vec4(rel, 1.0);
     v_tex_coords = tex_coords;
     v_light = light_tint.r;
     v_tint = light_tint.gba;
+    v_fog = fog_factor(rel, camera_pos.w, fog_color.w);
+    v_fog_color = fog_color.rgb;
 }


### PR DESCRIPTION
Fades distant terrain and entities into the fog color so the horizon is seamless and far mobs no longer float.