### PR TITLE
render held item in first person

### DIFF
--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -676,11 +676,24 @@ pub fn update_game(
     } else {
         core.menu.render_distance
     };
+    let held_item = match game.player.inventory.hotbar_slots()[core.input.selected_slot() as usize]
+    {
+        azalea_inventory::ItemStack::Present(ref data) => {
+            let name = crate::player::inventory::item_resource_name(data.kind);
+            (name != "air").then(|| {
+                let light =
+                    get_entity_light(&game.chunk_store, gfx.renderer.camera_pivot_position());
+                (name, light)
+            })
+        }
+        _ => None,
+    };
     if let Err(e) = gfx.renderer.render_world(
         &gfx.window,
         hide_cursor,
         elements,
         swing_progress,
+        held_item,
         destroy_info,
         game.show_chunk_borders,
         sky,

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -61,6 +61,7 @@ enum RenderMode<'a> {
     World {
         overlay: Vec<MenuElement>,
         swing_progress: f32,
+        held_item: Option<pipelines::held_item::HeldItemInfo>,
         destroy_info: Option<(BlockPos, u32, BlockState)>,
         show_chunk_borders: bool,
         sky: SkyState,
@@ -108,6 +109,7 @@ pub struct Renderer {
     skin_preview: SkinPreviewPipeline,
     chunk_border_pipeline: ChunkBorderPipeline,
     item_entity_pipeline: ItemEntityPipeline,
+    held_item_pipeline: pipelines::held_item::HeldItemPipeline,
     weather_pipeline: WeatherPipeline,
     gui_item_pipeline: pipelines::gui_item::GuiItemPipeline,
     gui_item_atlas: pipelines::gui_item_atlas::GuiItemAtlas,
@@ -324,6 +326,14 @@ impl Renderer {
             &atlas,
         );
 
+        let held_item_pipeline = pipelines::held_item::HeldItemPipeline::new(
+            &ctx.device,
+            swapchain_state.render_pass,
+            &ctx.allocator,
+            &atlas,
+            jar_assets_dir,
+        );
+
         splash(&mut menu_pipeline, 0.95, "Caching item meshes...");
 
         let initial_slot_px =
@@ -376,6 +386,7 @@ impl Renderer {
             block_entity_pipeline,
             chunk_border_pipeline,
             item_entity_pipeline,
+            held_item_pipeline,
             weather_pipeline,
             gui_item_pipeline,
             gui_item_atlas,
@@ -595,6 +606,8 @@ impl Renderer {
             .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
         self.item_entity_pipeline
             .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
+        self.held_item_pipeline
+            .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
         self.weather_pipeline
             .recreate_pipeline(&self.ctx.device, self.swapchain.render_pass);
         self.blur_pipeline.resize(
@@ -803,6 +816,7 @@ impl Renderer {
         hide_cursor: bool,
         overlay: Vec<MenuElement>,
         swing_progress: f32,
+        held_item: Option<(String, f32)>,
         destroy_info: Option<(BlockPos, u32, BlockState)>,
         show_chunk_borders: bool,
         sky: SkyState,
@@ -812,6 +826,14 @@ impl Renderer {
         weather: &[WeatherColumn],
         render_distance: u32,
     ) -> Result<(), RendererError> {
+        let held_item = held_item.map(|(name, light)| {
+            let is_block = self.ensure_item_mesh(&name);
+            pipelines::held_item::HeldItemInfo {
+                name,
+                light,
+                is_block,
+            }
+        });
         let fog_col = sky.fog_color();
         self.render_frame(
             window,
@@ -820,6 +842,7 @@ impl Renderer {
             RenderMode::World {
                 overlay,
                 swing_progress,
+                held_item,
                 destroy_info,
                 show_chunk_borders,
                 sky,
@@ -891,6 +914,8 @@ impl Renderer {
         self.chunk_pipeline
             .rebind_atlas(&self.ctx.device, &self.atlas);
         self.gui_item_pipeline
+            .rebind_atlas(&self.ctx.device, &self.atlas);
+        self.held_item_pipeline
             .rebind_atlas(&self.ctx.device, &self.atlas);
 
         tracing::info!("Assets reloaded");
@@ -1222,6 +1247,7 @@ impl Renderer {
             RenderMode::World {
                 overlay,
                 swing_progress,
+                held_item,
                 destroy_info,
                 show_chunk_borders,
                 sky,
@@ -1284,8 +1310,20 @@ impl Renderer {
 
                 if self.camera.mode == camera::CameraMode::FirstPerson {
                     let aspect = sw / sh.max(1.0);
-                    self.hand_pipeline
-                        .update_and_draw(cmd, frame, aspect, *swing_progress);
+                    match held_item {
+                        Some(item) => self.held_item_pipeline.update_and_draw(
+                            cmd,
+                            frame,
+                            aspect,
+                            *swing_progress,
+                            item,
+                            &self.item_entity_pipeline,
+                        ),
+                        None => {
+                            self.hand_pipeline
+                                .update_and_draw(cmd, frame, aspect, *swing_progress)
+                        }
+                    }
                 }
 
                 self.menu_pipeline
@@ -1546,6 +1584,8 @@ impl Drop for Renderer {
         self.chunk_border_pipeline
             .destroy(&self.ctx.device, &self.ctx.allocator);
         self.item_entity_pipeline
+            .destroy(&self.ctx.device, &self.ctx.allocator);
+        self.held_item_pipeline
             .destroy(&self.ctx.device, &self.ctx.allocator);
         self.weather_pipeline
             .destroy(&self.ctx.device, &self.ctx.allocator);

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -827,11 +827,11 @@ impl Renderer {
         render_distance: u32,
     ) -> Result<(), RendererError> {
         let held_item = held_item.map(|(name, light)| {
-            let is_block = self.ensure_item_mesh(&name);
+            let has_3d_model = self.ensure_item_mesh(&name);
             pipelines::held_item::HeldItemInfo {
                 name,
                 light,
-                is_block,
+                has_3d_model,
             }
         });
         let fog_col = sky.fog_color();
@@ -980,9 +980,11 @@ impl Renderer {
         self.menu_pipeline.text_width(text, scale)
     }
 
+    /// Builds the item mesh if needed; returns whether it has a 3D model
+    /// (vs a flat sprite), used to pick the first-person transform.
     pub fn ensure_item_mesh(&mut self, name: &str) -> bool {
-        if self.item_entity_pipeline.has_mesh(name) {
-            return self.registry.get_item_model(name).is_some();
+        if let Some(has_3d_model) = self.item_entity_pipeline.mesh_is_3d(name) {
+            return has_3d_model;
         }
         if let Some(model) = self.registry.get_item_model(name) {
             self.item_entity_pipeline.ensure_mesh(
@@ -1310,6 +1312,8 @@ impl Renderer {
 
                 if self.camera.mode == camera::CameraMode::FirstPerson {
                     let aspect = sw / sh.max(1.0);
+                    // Vanilla renderArmWithItem draws the arm only for an empty
+                    // hand; a held item renders alone.
                     match held_item {
                         Some(item) => self.held_item_pipeline.update_and_draw(
                             cmd,

--- a/pomme-client/src/renderer/pipelines/gui_item.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
@@ -10,35 +8,9 @@ use pyronyx::vk;
 
 use crate::renderer::camera::CameraUniform;
 use crate::renderer::chunk::atlas::TextureAtlas;
-use crate::renderer::pipelines::item_entity::{self, ItemEntityPipeline};
+use crate::renderer::pipelines::item_display::{DisplayResolver, DisplayTransform};
+use crate::renderer::pipelines::item_entity::{self, ItemEntityPipeline, push_model_light};
 use crate::renderer::util;
-use crate::world::block::model::{find_first_model_string, find_first_string_for_key};
-
-const MODEL_PARENT_LIMIT: u32 = 16;
-
-#[derive(Debug, Clone, Copy)]
-struct DisplayTransform {
-    rotation: Vec3,
-    translation: Vec3,
-    scale: Vec3,
-}
-
-impl DisplayTransform {
-    const IDENTITY: Self = Self {
-        rotation: Vec3::ZERO,
-        translation: Vec3::ZERO,
-        scale: Vec3::ONE,
-    };
-
-    fn to_matrix(self) -> Mat4 {
-        let t = Mat4::from_translation(self.translation);
-        let r = Mat4::from_rotation_x(self.rotation.x.to_radians())
-            * Mat4::from_rotation_y(self.rotation.y.to_radians())
-            * Mat4::from_rotation_z(self.rotation.z.to_radians());
-        let s = Mat4::from_scale(self.scale);
-        t * r * s
-    }
-}
 
 pub struct GuiItemPipeline {
     pipeline: vk::Pipeline,
@@ -52,9 +24,7 @@ pub struct GuiItemPipeline {
     camera_alloc: Option<Allocation>,
     sampler: vk::Sampler,
     atlas_px: u32,
-    display_cache: RefCell<HashMap<String, DisplayTransform>>,
-    items_dir: PathBuf,
-    models_dir: PathBuf,
+    display: DisplayResolver,
 }
 
 impl GuiItemPipeline {
@@ -193,7 +163,6 @@ impl GuiItemPipeline {
         };
         device.update_descriptor_sets(&[cam_write, atlas_write], &[]);
 
-        let mc_base = jar_assets_dir.join("minecraft");
         let mut this = Self {
             pipeline,
             pipeline_layout,
@@ -206,9 +175,7 @@ impl GuiItemPipeline {
             camera_alloc: Some(camera_alloc),
             sampler,
             atlas_px,
-            display_cache: RefCell::new(HashMap::new()),
-            items_dir: mc_base.join("items"),
-            models_dir: mc_base.join("models"),
+            display: DisplayResolver::new(jar_assets_dir, "gui"),
         };
         this.write_atlas_ortho(atlas_px as f32);
         this
@@ -292,7 +259,7 @@ impl GuiItemPipeline {
             return;
         };
 
-        let display = self.resolve_display(item_name, is_block);
+        let display = self.display.resolve(item_name, default_display(is_block));
         let model = slot_model_matrix(
             slot_x_px as f32,
             slot_y_px as f32,
@@ -302,39 +269,8 @@ impl GuiItemPipeline {
         );
 
         cmd.bind_vertex_buffers(0, &[buffer], &[0]);
-
-        let mvp_data = model.to_cols_array();
-        let mvp_bytes = bytemuck::bytes_of(&mvp_data);
-        let light: f32 = 1.0;
-        let light_bytes = bytemuck::bytes_of(&light);
-        cmd.push_constants(
-            self.pipeline_layout,
-            vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
-            0,
-            mvp_bytes,
-        );
-        cmd.push_constants(
-            self.pipeline_layout,
-            vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
-            64,
-            light_bytes,
-        );
+        push_model_light(cmd, self.pipeline_layout, &model, 1.0);
         cmd.draw(vertex_count, 1, 0, 0);
-    }
-
-    fn resolve_display(&self, item_name: &str, is_block: bool) -> DisplayTransform {
-        if let Some(t) = self.display_cache.borrow().get(item_name) {
-            return *t;
-        }
-        let model_path = resolve_item_model_path(item_name, &self.items_dir);
-        let resolved = match model_path {
-            Some(path) => resolve_display_gui(&path, &self.models_dir, is_block),
-            None => default_display(is_block),
-        };
-        self.display_cache
-            .borrow_mut()
-            .insert(item_name.to_string(), resolved);
-        resolved
     }
 
     pub fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
@@ -370,80 +306,4 @@ fn default_display(is_block: bool) -> DisplayTransform {
     } else {
         DisplayTransform::IDENTITY
     }
-}
-
-fn read_json(path: &Path) -> Option<serde_json::Value> {
-    let s = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&s).ok()
-}
-
-fn strip_mc_ns(s: &str) -> &str {
-    s.strip_prefix("minecraft:").unwrap_or(s)
-}
-
-fn resolve_item_model_path(name: &str, items_dir: &Path) -> Option<String> {
-    let item_json = read_json(&items_dir.join(format!("{name}.json")))?;
-    let model_path = find_first_model_string(&item_json)
-        .or_else(|| find_first_string_for_key(&item_json, "base"))?;
-    Some(strip_mc_ns(&model_path).to_string())
-}
-
-fn parse_vec3(value: &serde_json::Value, default: Vec3) -> Vec3 {
-    let Some(arr) = value.as_array() else {
-        return default;
-    };
-    let get = |i: usize| arr.get(i).and_then(|v| v.as_f64()).map(|v| v as f32);
-    Vec3::new(
-        get(0).unwrap_or(default.x),
-        get(1).unwrap_or(default.y),
-        get(2).unwrap_or(default.z),
-    )
-}
-
-fn parse_display_transform(json: &serde_json::Value) -> Option<DisplayTransform> {
-    let obj = json.as_object()?;
-    let rotation = obj
-        .get("rotation")
-        .map(|v| parse_vec3(v, Vec3::ZERO))
-        .unwrap_or(Vec3::ZERO);
-    let translation = obj
-        .get("translation")
-        .map(|v| parse_vec3(v, Vec3::ZERO))
-        .unwrap_or(Vec3::ZERO);
-    let scale = obj
-        .get("scale")
-        .map(|v| parse_vec3(v, Vec3::ONE))
-        .unwrap_or(Vec3::ONE);
-    Some(DisplayTransform {
-        rotation,
-        translation: translation * (1.0 / 16.0),
-        scale,
-    })
-}
-
-fn resolve_display_gui(start_path: &str, models_dir: &Path, is_block: bool) -> DisplayTransform {
-    let mut current = Some(start_path.to_string());
-    let mut depth = 0u32;
-    while let Some(path) = current.take() {
-        if depth >= MODEL_PARENT_LIMIT {
-            break;
-        }
-        depth += 1;
-
-        let file = models_dir.join(format!("{path}.json"));
-        let Some(json) = read_json(&file) else { break };
-
-        if let Some(gui) = json.get("display").and_then(|d| d.get("gui"))
-            && let Some(t) = parse_display_transform(gui)
-        {
-            return t;
-        }
-
-        current = json
-            .get("parent")
-            .and_then(|p| p.as_str())
-            .map(|p| strip_mc_ns(p).to_string());
-    }
-
-    default_display(is_block)
 }

--- a/pomme-client/src/renderer/pipelines/hand.rs
+++ b/pomme-client/src/renderer/pipelines/hand.rs
@@ -205,13 +205,7 @@ impl HandPipeline {
         aspect: f32,
         swing_progress: f32,
     ) {
-        let mut proj = Mat4::perspective_rh(
-            crate::renderer::camera::DEFAULT_FOV_DEGREES.to_radians(),
-            aspect,
-            NEAR,
-            FAR,
-        );
-        proj.y_axis.y *= -1.0;
+        let proj = projection(aspect);
 
         let sp = swing_progress;
         let sqrt_sp = sp.sqrt();
@@ -348,6 +342,17 @@ impl HandPipeline {
         device.destroy_descriptor_set_layout(self.mvp_layout, None);
         device.destroy_descriptor_set_layout(self.skin_layout, None);
     }
+}
+
+pub(super) fn projection(aspect: f32) -> Mat4 {
+    let mut proj = Mat4::perspective_rh(
+        crate::renderer::camera::DEFAULT_FOV_DEGREES.to_radians(),
+        aspect,
+        NEAR,
+        FAR,
+    );
+    proj.y_axis.y *= -1.0;
+    proj
 }
 
 fn build_arm_vertices(skin_w: u32, skin_h: u32) -> Vec<HandVertex> {

--- a/pomme-client/src/renderer/pipelines/held_item.rs
+++ b/pomme-client/src/renderer/pipelines/held_item.rs
@@ -16,7 +16,7 @@ use crate::renderer::pipelines::item_entity::{
 pub struct HeldItemInfo {
     pub name: String,
     pub light: f32,
-    pub is_block: bool,
+    pub has_3d_model: bool,
 }
 
 pub struct HeldItemPipeline {
@@ -64,7 +64,7 @@ impl HeldItemPipeline {
 
         let display = self
             .display
-            .resolve(&item.name, default_first_person(item.is_block));
+            .resolve(&item.name, default_first_person(item.has_3d_model));
         let model = first_person_item_matrix(swing_progress) * display.to_matrix();
 
         self.shared.bind(cmd, frame, self.pipeline);
@@ -104,8 +104,8 @@ fn first_person_item_matrix(swing_progress: f32) -> Mat4 {
         * Mat4::from_rotation_y((-45.0_f32).to_radians())
 }
 
-fn default_first_person(is_block: bool) -> DisplayTransform {
-    if is_block {
+fn default_first_person(has_3d_model: bool) -> DisplayTransform {
+    if has_3d_model {
         // block/block.json firstperson_righthand
         DisplayTransform {
             rotation: Vec3::new(0.0, 45.0, 0.0),

--- a/pomme-client/src/renderer/pipelines/held_item.rs
+++ b/pomme-client/src/renderer/pipelines/held_item.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use glam::{Mat4, Vec3};
+use pomme_gpu_allocator::vulkan::Allocator;
+use pyronyx::vk;
+
+use crate::renderer::camera::CameraUniform;
+use crate::renderer::chunk::atlas::TextureAtlas;
+use crate::renderer::pipelines::hand;
+use crate::renderer::pipelines::item_display::{DisplayResolver, DisplayTransform};
+use crate::renderer::pipelines::item_entity::{
+    self, ItemEntityPipeline, ItemPipelineShared, push_model_light,
+};
+
+pub struct HeldItemInfo {
+    pub name: String,
+    pub light: f32,
+    pub is_block: bool,
+}
+
+pub struct HeldItemPipeline {
+    pipeline: vk::Pipeline,
+    shared: ItemPipelineShared,
+    display: DisplayResolver,
+}
+
+impl HeldItemPipeline {
+    pub fn new(
+        device: &vk::Device,
+        render_pass: vk::RenderPass,
+        allocator: &Arc<Mutex<Allocator>>,
+        atlas: &TextureAtlas,
+        jar_assets_dir: &Path,
+    ) -> Self {
+        let shared = ItemPipelineShared::new(device, allocator, atlas, "held_item");
+        let pipeline = item_entity::create_pipeline(device, render_pass, shared.pipeline_layout);
+        Self {
+            pipeline,
+            shared,
+            display: DisplayResolver::new(jar_assets_dir, "firstperson_righthand"),
+        }
+    }
+
+    pub fn rebind_atlas(&self, device: &vk::Device, atlas: &TextureAtlas) {
+        self.shared.rebind_atlas(device, atlas);
+    }
+
+    pub fn update_and_draw(
+        &mut self,
+        cmd: vk::CommandBuffer,
+        frame: usize,
+        aspect: f32,
+        swing_progress: f32,
+        item: &HeldItemInfo,
+        meshes: &ItemEntityPipeline,
+    ) {
+        let Some((buffer, vertex_count)) = meshes.mesh_handle(&item.name) else {
+            return;
+        };
+
+        let uniform = CameraUniform::with_view_proj(hand::projection(aspect));
+        self.shared.update_camera(frame, &uniform);
+
+        let display = self
+            .display
+            .resolve(&item.name, default_first_person(item.is_block));
+        let model = first_person_item_matrix(swing_progress) * display.to_matrix();
+
+        self.shared.bind(cmd, frame, self.pipeline);
+        cmd.bind_vertex_buffers(0, &[buffer], &[0]);
+        push_model_light(cmd, self.shared.pipeline_layout, &model, item.light);
+        cmd.draw(vertex_count, 1, 0, 0);
+    }
+
+    pub fn recreate_pipeline(&mut self, device: &vk::Device, render_pass: vk::RenderPass) {
+        device.destroy_pipeline(self.pipeline, None);
+        self.pipeline =
+            item_entity::create_pipeline(device, render_pass, self.shared.pipeline_layout);
+    }
+
+    pub fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
+        device.destroy_pipeline(self.pipeline, None);
+        self.shared.destroy(device, allocator);
+    }
+}
+
+// Vanilla ItemInHandRenderer: applyItemArmTransform + swingArm (right hand,
+// inverseArmHeight = 0).
+fn first_person_item_matrix(swing_progress: f32) -> Mat4 {
+    let a = swing_progress;
+    let sq = a.sqrt();
+    let pi = std::f32::consts::PI;
+
+    Mat4::from_translation(Vec3::new(0.56, -0.52, -0.72))
+        * Mat4::from_translation(Vec3::new(
+            -0.4 * (sq * pi).sin(),
+            0.2 * (sq * pi * 2.0).sin(),
+            -0.2 * (a * pi).sin(),
+        ))
+        * Mat4::from_rotation_y((45.0 + (a * a * pi).sin() * -20.0).to_radians())
+        * Mat4::from_rotation_z(((sq * pi).sin() * -20.0).to_radians())
+        * Mat4::from_rotation_x(((sq * pi).sin() * -80.0).to_radians())
+        * Mat4::from_rotation_y((-45.0_f32).to_radians())
+}
+
+fn default_first_person(is_block: bool) -> DisplayTransform {
+    if is_block {
+        // block/block.json firstperson_righthand
+        DisplayTransform {
+            rotation: Vec3::new(0.0, 45.0, 0.0),
+            translation: Vec3::ZERO,
+            scale: Vec3::splat(0.40),
+        }
+    } else {
+        // item/generated.json firstperson_righthand
+        DisplayTransform {
+            rotation: Vec3::new(0.0, -90.0, 25.0),
+            translation: Vec3::new(1.13, 3.2, 1.13) / 16.0,
+            scale: Vec3::splat(0.68),
+        }
+    }
+}

--- a/pomme-client/src/renderer/pipelines/item_display.rs
+++ b/pomme-client/src/renderer/pipelines/item_display.rs
@@ -1,0 +1,144 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use glam::{Mat4, Vec3};
+
+use crate::world::block::model::{find_first_model_string, find_first_string_for_key};
+
+const MODEL_PARENT_LIMIT: u32 = 16;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DisplayTransform {
+    pub rotation: Vec3,
+    pub translation: Vec3,
+    pub scale: Vec3,
+}
+
+impl DisplayTransform {
+    pub const IDENTITY: Self = Self {
+        rotation: Vec3::ZERO,
+        translation: Vec3::ZERO,
+        scale: Vec3::ONE,
+    };
+
+    pub fn to_matrix(self) -> Mat4 {
+        let t = Mat4::from_translation(self.translation);
+        let r = Mat4::from_rotation_x(self.rotation.x.to_radians())
+            * Mat4::from_rotation_y(self.rotation.y.to_radians())
+            * Mat4::from_rotation_z(self.rotation.z.to_radians());
+        let s = Mat4::from_scale(self.scale);
+        t * r * s
+    }
+}
+
+/// Per-item cache of one `display.<key>` transform, resolved from the item's
+/// model JSON parent chain.
+pub struct DisplayResolver {
+    key: &'static str,
+    cache: RefCell<HashMap<String, DisplayTransform>>,
+    items_dir: PathBuf,
+    models_dir: PathBuf,
+}
+
+impl DisplayResolver {
+    pub fn new(jar_assets_dir: &Path, key: &'static str) -> Self {
+        let mc_base = jar_assets_dir.join("minecraft");
+        Self {
+            key,
+            cache: RefCell::new(HashMap::new()),
+            items_dir: mc_base.join("items"),
+            models_dir: mc_base.join("models"),
+        }
+    }
+
+    pub fn resolve(&self, item_name: &str, default: DisplayTransform) -> DisplayTransform {
+        if let Some(t) = self.cache.borrow().get(item_name) {
+            return *t;
+        }
+        let resolved = resolve_item_model_path(item_name, &self.items_dir)
+            .and_then(|path| resolve_display(&path, &self.models_dir, self.key))
+            .unwrap_or(default);
+        self.cache
+            .borrow_mut()
+            .insert(item_name.to_string(), resolved);
+        resolved
+    }
+}
+
+fn read_json(path: &Path) -> Option<serde_json::Value> {
+    let s = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+fn strip_mc_ns(s: &str) -> &str {
+    s.strip_prefix("minecraft:").unwrap_or(s)
+}
+
+fn resolve_item_model_path(name: &str, items_dir: &Path) -> Option<String> {
+    let item_json = read_json(&items_dir.join(format!("{name}.json")))?;
+    let model_path = find_first_model_string(&item_json)
+        .or_else(|| find_first_string_for_key(&item_json, "base"))?;
+    Some(strip_mc_ns(&model_path).to_string())
+}
+
+fn parse_vec3(value: &serde_json::Value, default: Vec3) -> Vec3 {
+    let Some(arr) = value.as_array() else {
+        return default;
+    };
+    let get = |i: usize| arr.get(i).and_then(|v| v.as_f64()).map(|v| v as f32);
+    Vec3::new(
+        get(0).unwrap_or(default.x),
+        get(1).unwrap_or(default.y),
+        get(2).unwrap_or(default.z),
+    )
+}
+
+fn parse_display_transform(json: &serde_json::Value) -> Option<DisplayTransform> {
+    let obj = json.as_object()?;
+    let rotation = obj
+        .get("rotation")
+        .map(|v| parse_vec3(v, Vec3::ZERO))
+        .unwrap_or(Vec3::ZERO);
+    let translation = obj
+        .get("translation")
+        .map(|v| parse_vec3(v, Vec3::ZERO))
+        .unwrap_or(Vec3::ZERO);
+    let scale = obj
+        .get("scale")
+        .map(|v| parse_vec3(v, Vec3::ONE))
+        .unwrap_or(Vec3::ONE);
+    Some(DisplayTransform {
+        rotation,
+        translation: translation * (1.0 / 16.0),
+        scale,
+    })
+}
+
+/// First `display.<key>` transform found walking up the model parent chain.
+fn resolve_display(start_path: &str, models_dir: &Path, key: &str) -> Option<DisplayTransform> {
+    let mut current = Some(start_path.to_string());
+    let mut depth = 0u32;
+    while let Some(path) = current.take() {
+        if depth >= MODEL_PARENT_LIMIT {
+            break;
+        }
+        depth += 1;
+
+        let file = models_dir.join(format!("{path}.json"));
+        let json = read_json(&file)?;
+
+        if let Some(entry) = json.get("display").and_then(|d| d.get(key))
+            && let Some(t) = parse_display_transform(entry)
+        {
+            return Some(t);
+        }
+
+        current = json
+            .get("parent")
+            .and_then(|p| p.as_str())
+            .map(|p| strip_mc_ns(p).to_string());
+    }
+
+    None
+}

--- a/pomme-client/src/renderer/pipelines/item_entity.rs
+++ b/pomme-client/src/renderer/pipelines/item_entity.rs
@@ -26,9 +26,10 @@ struct MeshEntry {
     vertex_count: u32,
 }
 
-pub struct ItemEntityPipeline {
-    pipeline: vk::Pipeline,
-    pipeline_layout: vk::PipelineLayout,
+/// Descriptor layouts, per-frame camera UBOs, and atlas set shared by the
+/// pipelines that draw item meshes with the item_entity shaders.
+pub(super) struct ItemPipelineShared {
+    pub pipeline_layout: vk::PipelineLayout,
     camera_layout: vk::DescriptorSetLayout,
     atlas_layout: vk::DescriptorSetLayout,
     descriptor_pool: vk::DescriptorPool,
@@ -36,15 +37,14 @@ pub struct ItemEntityPipeline {
     atlas_set: vk::DescriptorSet,
     camera_buffers: Vec<vk::Buffer>,
     camera_allocations: Vec<Option<Allocation>>,
-    meshes: HashMap<String, MeshEntry>,
 }
 
-impl ItemEntityPipeline {
-    pub fn new(
+impl ItemPipelineShared {
+    pub(super) fn new(
         device: &vk::Device,
-        render_pass: vk::RenderPass,
         allocator: &Arc<Mutex<Allocator>>,
         atlas: &TextureAtlas,
+        label: &str,
     ) -> Self {
         let camera_layout = util::create_descriptor_set_layout(
             device,
@@ -72,9 +72,7 @@ impl ItemEntityPipeline {
         };
         let pipeline_layout = device
             .create_pipeline_layout(&layout_info, None)
-            .expect("failed to create item entity pipeline layout");
-
-        let pipeline = create_pipeline(device, render_pass, pipeline_layout);
+            .unwrap_or_else(|_| panic!("failed to create {label} pipeline layout"));
 
         let pool_sizes = [
             vk::DescriptorPoolSize {
@@ -94,7 +92,7 @@ impl ItemEntityPipeline {
         };
         let descriptor_pool = device
             .create_descriptor_pool(&pool_info, None)
-            .expect("failed to create item entity descriptor pool");
+            .unwrap_or_else(|_| panic!("failed to create {label} descriptor pool"));
 
         let camera_layouts: Vec<_> = (0..MAX_FRAMES_IN_FLIGHT).map(|_| camera_layout).collect();
         let camera_alloc_info = vk::DescriptorSetAllocateInfo {
@@ -106,7 +104,7 @@ impl ItemEntityPipeline {
         let mut camera_sets = vec![vk::DescriptorSet::null(); camera_layouts.len()];
         device
             .allocate_descriptor_sets(&camera_alloc_info, &mut camera_sets)
-            .expect("failed to allocate item entity camera sets");
+            .unwrap_or_else(|_| panic!("failed to allocate {label} camera sets"));
 
         let atlas_alloc_info = vk::DescriptorSetAllocateInfo {
             descriptor_pool,
@@ -117,7 +115,7 @@ impl ItemEntityPipeline {
         let mut atlas_set = vk::DescriptorSet::null();
         device
             .allocate_descriptor_sets(&atlas_alloc_info, slice::from_mut(&mut atlas_set))
-            .expect("failed to allocate item entity atlas set");
+            .unwrap_or_else(|_| panic!("failed to allocate {label} atlas set"));
 
         let mut camera_buffers = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
         let mut camera_allocations: Vec<Option<Allocation>> =
@@ -128,7 +126,7 @@ impl ItemEntityPipeline {
                 device,
                 allocator,
                 size_of::<CameraUniform>() as u64,
-                "item_entity_camera",
+                &format!("{label}_camera"),
             );
             let buffer_info = vk::DescriptorBufferInfo {
                 buffer: buf,
@@ -148,23 +146,7 @@ impl ItemEntityPipeline {
             camera_allocations.push(Some(alloc));
         }
 
-        let image_info = vk::DescriptorImageInfo {
-            sampler: atlas.sampler,
-            image_view: atlas.view,
-            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
-        };
-        let atlas_write = vk::WriteDescriptorSet {
-            dst_set: atlas_set,
-            dst_binding: 0,
-            descriptor_type: vk::DescriptorType::CombinedImageSampler,
-            descriptor_count: 1,
-            image_info: &image_info,
-            ..Default::default()
-        };
-        device.update_descriptor_sets(&[atlas_write], &[]);
-
-        Self {
-            pipeline,
+        let this = Self {
             pipeline_layout,
             camera_layout,
             atlas_layout,
@@ -173,15 +155,107 @@ impl ItemEntityPipeline {
             atlas_set,
             camera_buffers,
             camera_allocations,
+        };
+        this.rebind_atlas(device, atlas);
+        this
+    }
+
+    pub(super) fn rebind_atlas(&self, device: &vk::Device, atlas: &TextureAtlas) {
+        let image_info = vk::DescriptorImageInfo {
+            sampler: atlas.sampler,
+            image_view: atlas.view,
+            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+        };
+        let write = vk::WriteDescriptorSet {
+            dst_set: self.atlas_set,
+            dst_binding: 0,
+            descriptor_type: vk::DescriptorType::CombinedImageSampler,
+            descriptor_count: 1,
+            image_info: &image_info,
+            ..Default::default()
+        };
+        device.update_descriptor_sets(&[write], &[]);
+    }
+
+    pub(super) fn update_camera(&mut self, frame: usize, uniform: &CameraUniform) {
+        let bytes = bytemuck::bytes_of(uniform);
+        if let Some(alloc) = self.camera_allocations[frame].as_mut() {
+            alloc.mapped_slice_mut().unwrap()[..bytes.len()].copy_from_slice(bytes);
+        }
+    }
+
+    pub(super) fn bind(&self, cmd: vk::CommandBuffer, frame: usize, pipeline: vk::Pipeline) {
+        cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, pipeline);
+        cmd.bind_descriptor_sets(
+            vk::PipelineBindPoint::Graphics,
+            self.pipeline_layout,
+            0,
+            &[self.camera_sets[frame], self.atlas_set],
+            &[],
+        );
+    }
+
+    pub(super) fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
+        for i in 0..MAX_FRAMES_IN_FLIGHT {
+            device.destroy_buffer(self.camera_buffers[i], None);
+            if let Some(alloc) = self.camera_allocations[i].take() {
+                allocator.lock().unwrap().free(alloc).ok();
+            }
+        }
+
+        device.destroy_pipeline_layout(self.pipeline_layout, None);
+        device.destroy_descriptor_pool(self.descriptor_pool, None);
+        device.destroy_descriptor_set_layout(self.camera_layout, None);
+        device.destroy_descriptor_set_layout(self.atlas_layout, None);
+    }
+}
+
+pub(super) fn push_model_light(
+    cmd: vk::CommandBuffer,
+    layout: vk::PipelineLayout,
+    model: &Mat4,
+    light: f32,
+) {
+    let mvp_data = model.to_cols_array();
+    cmd.push_constants(
+        layout,
+        vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
+        0,
+        bytemuck::bytes_of(&mvp_data),
+    );
+    cmd.push_constants(
+        layout,
+        vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
+        64,
+        bytemuck::bytes_of(&light),
+    );
+}
+
+pub struct ItemEntityPipeline {
+    pipeline: vk::Pipeline,
+    shared: ItemPipelineShared,
+    meshes: HashMap<String, MeshEntry>,
+}
+
+impl ItemEntityPipeline {
+    pub fn new(
+        device: &vk::Device,
+        render_pass: vk::RenderPass,
+        allocator: &Arc<Mutex<Allocator>>,
+        atlas: &TextureAtlas,
+    ) -> Self {
+        let shared = ItemPipelineShared::new(device, allocator, atlas, "item_entity");
+        let pipeline = create_pipeline(device, render_pass, shared.pipeline_layout);
+
+        Self {
+            pipeline,
+            shared,
             meshes: HashMap::new(),
         }
     }
 
     pub fn update_camera(&mut self, frame: usize, uniform: &CameraUniform) {
-        let bytes = bytemuck::bytes_of(uniform);
-        if let Some(alloc) = self.camera_allocations[frame].as_mut() {
-            alloc.mapped_slice_mut().unwrap()[..bytes.len()].copy_from_slice(bytes);
-        }
+        self.shared.update_camera(frame, uniform);
     }
 
     fn insert_mesh(
@@ -271,14 +345,7 @@ impl ItemEntityPipeline {
             return;
         }
 
-        cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, self.pipeline);
-        cmd.bind_descriptor_sets(
-            vk::PipelineBindPoint::Graphics,
-            self.pipeline_layout,
-            0,
-            &[self.camera_sets[frame], self.atlas_set],
-            &[],
-        );
+        self.shared.bind(cmd, frame, self.pipeline);
 
         for item in items {
             let mesh = match self.meshes.get(&item.item_name) {
@@ -286,22 +353,12 @@ impl ItemEntityPipeline {
                 None => continue,
             };
 
-            let mvp_data = item.model_matrix.to_cols_array();
-            let mvp_bytes = bytemuck::bytes_of(&mvp_data);
-            let light_bytes = bytemuck::bytes_of(&item.light);
-
             cmd.bind_vertex_buffers(0, &[mesh.buffer], &[0]);
-            cmd.push_constants(
-                self.pipeline_layout,
-                vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
-                0,
-                mvp_bytes,
-            );
-            cmd.push_constants(
-                self.pipeline_layout,
-                vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
-                64,
-                light_bytes,
+            push_model_light(
+                cmd,
+                self.shared.pipeline_layout,
+                &item.model_matrix,
+                item.light,
             );
             cmd.draw(mesh.vertex_count, 1, 0, 0);
         }
@@ -309,7 +366,7 @@ impl ItemEntityPipeline {
 
     pub fn recreate_pipeline(&mut self, device: &vk::Device, render_pass: vk::RenderPass) {
         device.destroy_pipeline(self.pipeline, None);
-        self.pipeline = create_pipeline(device, render_pass, self.pipeline_layout);
+        self.pipeline = create_pipeline(device, render_pass, self.shared.pipeline_layout);
     }
 
     pub fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
@@ -317,18 +374,8 @@ impl ItemEntityPipeline {
             device.destroy_buffer(entry.buffer, None);
             allocator.lock().unwrap().free(entry.allocation).ok();
         }
-        for i in 0..MAX_FRAMES_IN_FLIGHT {
-            device.destroy_buffer(self.camera_buffers[i], None);
-            if let Some(alloc) = self.camera_allocations[i].take() {
-                allocator.lock().unwrap().free(alloc).ok();
-            }
-        }
-
         device.destroy_pipeline(self.pipeline, None);
-        device.destroy_pipeline_layout(self.pipeline_layout, None);
-        device.destroy_descriptor_pool(self.descriptor_pool, None);
-        device.destroy_descriptor_set_layout(self.camera_layout, None);
-        device.destroy_descriptor_set_layout(self.atlas_layout, None);
+        self.shared.destroy(device, allocator);
     }
 }
 

--- a/pomme-client/src/renderer/pipelines/item_entity.rs
+++ b/pomme-client/src/renderer/pipelines/item_entity.rs
@@ -24,6 +24,7 @@ struct MeshEntry {
     buffer: vk::Buffer,
     allocation: Allocation,
     vertex_count: u32,
+    is_3d_model: bool,
 }
 
 /// Descriptor layouts, per-frame camera UBOs, and atlas set shared by the
@@ -264,6 +265,7 @@ impl ItemEntityPipeline {
         allocator: &Arc<Mutex<Allocator>>,
         name: &str,
         vertices: &[ChunkVertex],
+        is_3d_model: bool,
     ) {
         let bytes = bytemuck::cast_slice(vertices);
         let (buffer, allocation) = util::create_mapped_buffer(
@@ -279,12 +281,14 @@ impl ItemEntityPipeline {
                 buffer,
                 allocation,
                 vertex_count: vertices.len() as u32,
+                is_3d_model,
             },
         );
     }
 
-    pub fn has_mesh(&self, name: &str) -> bool {
-        self.meshes.contains_key(name)
+    /// `None` if no mesh is built yet, else whether it came from a 3D model.
+    pub fn mesh_is_3d(&self, name: &str) -> Option<bool> {
+        self.meshes.get(name).map(|m| m.is_3d_model)
     }
 
     pub fn mesh_handle(&self, name: &str) -> Option<(vk::Buffer, u32)> {
@@ -304,7 +308,7 @@ impl ItemEntityPipeline {
         }
         let vertices = build_item_mesh(model, uv_map);
         if !vertices.is_empty() {
-            self.insert_mesh(device, allocator, name, &vertices);
+            self.insert_mesh(device, allocator, name, &vertices, true);
         }
     }
 
@@ -336,7 +340,7 @@ impl ItemEntityPipeline {
             Err(_) => build_flat_quad(region),
         };
         if !vertices.is_empty() {
-            self.insert_mesh(device, allocator, name, &vertices);
+            self.insert_mesh(device, allocator, name, &vertices, false);
         }
     }
 

--- a/pomme-client/src/renderer/pipelines/mod.rs
+++ b/pomme-client/src/renderer/pipelines/mod.rs
@@ -7,6 +7,8 @@ pub mod entity_renderer;
 pub mod gui_item;
 pub mod gui_item_atlas;
 pub mod hand;
+pub mod held_item;
+pub mod item_display;
 pub mod item_entity;
 pub mod menu_overlay;
 pub mod panorama;


### PR DESCRIPTION
Draws the selected hotbar item in first person using the firstperson_righthand display transform from the item model JSON, with the swing animation ported from ItemInHandRenderer. Empty hand still shows the arm. Reuses the item_entity meshes and shaders; shared descriptor/UBO setup, display transform resolution, and push constant emission were deduplicated into ItemPipelineShared, DisplayResolver, and push_model_light.