### PR TITLE
keep simulation running while menus are open

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -184,13 +184,8 @@ impl AppCore {
     }
 
     pub fn apply_cursor_grab(&self, window: &Window, game: Option<&mut GameState>) {
-        let captured = game.is_some_and(|g| {
-            !g.paused
-                && !g.dead
-                && !g.gui_open()
-                && !g.chat.is_open()
-                && self.input.is_cursor_captured()
-        });
+        let captured =
+            game.is_some_and(|g| g.input_live() && !g.dead && self.input.is_cursor_captured());
         if captured {
             let _ = window
                 .set_cursor_grab(CursorGrabMode::Locked)
@@ -828,11 +823,16 @@ impl AppCore {
             return;
         }
 
+        // Open menus only release the keys; the simulation keeps ticking.
+        let input_live = game.input_live();
+        let neutral = InputState::new();
+        let input = if input_live { &self.input } else { &neutral };
+
         game.player.prev_look_dir = game.player.look_dir;
         game.player.look_dir = renderer.camera_look_dir();
 
         game.player.prev_position = game.player.position;
-        movement::tick(&mut game.player, &self.input, &game.chunk_store);
+        movement::tick(&mut game.player, input, &game.chunk_store);
         game.entity_store.tick_living();
 
         let dx = game.player.position.x - game.player.prev_position.x;
@@ -848,41 +848,43 @@ impl AppCore {
         renderer.set_base_fov(self.menu.fov as f32);
         renderer.update_fov_mod(compute_fov_modifier(&game.player));
 
-        self.send_input_packet(connection, game);
+        Self::send_input_packet(input, connection, game);
         self.send_sprint_command(connection, game);
         self.send_position_packet(connection, game);
 
-        if !game.paused && !game.gui_open() && !game.chat.is_open() {
-            let eye_pos = game.player.eye_pos();
-            game.interaction
-                .update_target(eye_pos, game.player.look_dir, &game.chunk_store);
+        let eye_pos = game.player.eye_pos();
+        game.interaction
+            .update_target(eye_pos, game.player.look_dir, &game.chunk_store);
 
-            let dirty = game.interaction.tick(
-                &self.input,
-                &game.chunk_store,
-                &connection.packet_tx,
-                &self.audio,
-                game.player.position.into(),
-                game.player.on_ground,
-                game.player.game_mode == 1,
-            );
-            for pos in dirty {
-                game.mesh_dispatcher.enqueue(&game.chunk_store, pos, 0);
-            }
+        let dirty = game.interaction.tick(
+            input,
+            &game.chunk_store,
+            &connection.packet_tx,
+            &self.audio,
+            game.player.position.into(),
+            game.player.on_ground,
+            game.player.game_mode == 1,
+        );
+        for pos in dirty {
+            game.mesh_dispatcher.enqueue(&game.chunk_store, pos, 0);
+        }
 
+        // Menus consume their own clicks later in the frame, so only clear
+        // them when the simulation saw the live input.
+        if input_live {
             self.input.clear_click_events();
         }
     }
 
-    fn send_input_packet(&mut self, connection: &ConnectionHandle, game: &mut GameState) {
+    fn send_input_packet(input: &InputState, connection: &ConnectionHandle, game: &mut GameState) {
         let sender = &connection.packet_tx;
         let current = PlayerInputState {
-            forward: self.input.key_pressed(KeyCode::KeyW),
-            backward: self.input.key_pressed(KeyCode::KeyS),
-            left: self.input.key_pressed(KeyCode::KeyA),
-            right: self.input.key_pressed(KeyCode::KeyD),
-            jump: self.input.key_pressed(KeyCode::Space),
-            shift: self.input.key_pressed(KeyCode::ShiftLeft),
+            forward: input.key_pressed(KeyCode::KeyW),
+            backward: input.key_pressed(KeyCode::KeyS),
+            left: input.key_pressed(KeyCode::KeyA),
+            right: input.key_pressed(KeyCode::KeyD),
+            jump: input.key_pressed(KeyCode::Space),
+            shift: input.key_pressed(KeyCode::ShiftLeft),
             sprint: game.player.sprinting,
         };
 
@@ -902,7 +904,7 @@ impl AppCore {
         }
     }
 
-    pub fn send_sprint_command(&mut self, connection: &ConnectionHandle, game: &mut GameState) {
+    pub fn send_sprint_command(&self, connection: &ConnectionHandle, game: &mut GameState) {
         let sprinting = game.player.sprinting;
         if sprinting != game.was_sprinting {
             let sender = &connection.packet_tx;
@@ -922,7 +924,7 @@ impl AppCore {
         }
     }
 
-    pub fn send_position_packet(&mut self, connection: &ConnectionHandle, game: &mut GameState) {
+    pub fn send_position_packet(&self, connection: &ConnectionHandle, game: &mut GameState) {
         let sender = &connection.packet_tx;
         use azalea_protocol::common::movements::MoveFlags;
         use azalea_protocol::packets::game::*;

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -825,7 +825,7 @@ impl AppCore {
 
         // Open menus only release the keys; the simulation keeps ticking.
         let input_live = game.input_live();
-        let neutral = InputState::new();
+        let neutral = InputState::released();
         let input = if input_live { &self.input } else { &neutral };
 
         game.player.prev_look_dir = game.player.look_dir;

--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -59,6 +59,15 @@ impl InputState {
         }
     }
 
+    /// Neutral input (no keys, cursor released) for ticking while a menu is
+    /// open.
+    pub fn released() -> Self {
+        Self {
+            cursor_captured: false,
+            ..Self::new()
+        }
+    }
+
     pub fn key_pressed(&self, key: KeyCode) -> bool {
         self.pressed.contains(&key)
     }

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -233,14 +233,6 @@ pub fn update_game(
 
     let partial_tick = core.tick_accumulator / TICK_RATE;
 
-    if game.input_live() {
-        game.interaction.update_target(
-            game.player.eye_pos(),
-            gfx.renderer.camera_look_dir(),
-            &game.chunk_store,
-        );
-    }
-
     let typed = core.input.drain_typed_chars();
     let backspace = core.input.backspace_pressed();
     let enter = core.input.enter_pressed();
@@ -548,6 +540,12 @@ pub fn update_game(
     game.chat.build(&mut elements, sw, sh, gs, &|t, s| {
         gfx.renderer.menu_text_width(t, s)
     });
+
+    // Chat consumes keys, not clicks; nothing else clears them while only chat
+    // is open, so drop them here to keep stray clicks out of the live sim.
+    if game.chat.is_open() {
+        core.input.clear_click_events();
+    }
 
     let swing_progress = game.interaction.get_swing_progress(partial_tick);
     let destroy_info = game.interaction.destroy_stage().map(|(pos, stage)| {

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -279,11 +279,7 @@ pub fn update_game(
     let gs = hud::gui_scale(sw, sh, core.menu.gui_scale_setting);
 
     let mut elements: Vec<MenuElement> = Vec::new();
-    let hide_cursor = !game.paused
-        && !game.dead
-        && !game.gui_open()
-        && !game.chat.is_open()
-        && core.input.is_cursor_captured();
+    let hide_cursor = game.input_live() && !game.dead && core.input.is_cursor_captured();
 
     let debug = if game.show_debug {
         Some(hud::DebugInfo {

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -137,6 +137,11 @@ impl GameState {
         self.inventory_open || self.creative_inventory_open
     }
 
+    /// No menu (pause, inventory, chat) is capturing input.
+    pub fn input_live(&self) -> bool {
+        !self.paused && !self.gui_open() && !self.chat.is_open()
+    }
+
     pub fn sync_render_distance(&mut self, connection: &ConnectionHandle, render_distance: u32) {
         self.last_render_distance = render_distance;
         tracing::info!("Render distance changed to {render_distance}");
@@ -210,24 +215,25 @@ pub fn update_game(
         core.time_tick_accumulator -= TICK_RATE;
     }
 
-    if !game.paused && !game.gui_open() && !game.chat.is_open() {
+    if game.input_live() {
         gfx.renderer.update_camera(&mut core.input);
+    }
 
-        core.tick_accumulator += dt;
-        while core.tick_accumulator >= TICK_RATE {
-            core.tick_physics(&mut gfx.renderer, connection, game);
-            game.item_entity_store.tick(
-                |bx, by, bz| !game.chunk_store.get_block_state(bx, by, bz).is_air(),
-                |bx, by, bz| block_friction(game.chunk_store.get_block_state(bx, by, bz)),
-            );
-            game.block_entity_anim.tick();
-            core.tick_accumulator -= TICK_RATE;
-        }
+    // Menus never pause the simulation; tick_physics substitutes neutral input.
+    core.tick_accumulator += dt;
+    while core.tick_accumulator >= TICK_RATE {
+        core.tick_physics(&mut gfx.renderer, connection, game);
+        game.item_entity_store.tick(
+            |bx, by, bz| !game.chunk_store.get_block_state(bx, by, bz).is_air(),
+            |bx, by, bz| block_friction(game.chunk_store.get_block_state(bx, by, bz)),
+        );
+        game.block_entity_anim.tick();
+        core.tick_accumulator -= TICK_RATE;
     }
 
     let partial_tick = core.tick_accumulator / TICK_RATE;
 
-    if !game.paused && !game.gui_open() && !game.chat.is_open() {
+    if game.input_live() {
         game.interaction.update_target(
             game.player.eye_pos(),
             gfx.renderer.camera_look_dir(),


### PR DESCRIPTION
Pause, inventory, and chat no longer freeze the world; open menus just release the keys like on a real server.