### PR TITLE
fix texture atlas mip bleeding and uv quantization at sprite edges

### DIFF
--- a/pomme-client/src/renderer/chunk/atlas.rs
+++ b/pomme-client/src/renderer/chunk/atlas.rs
@@ -52,6 +52,12 @@ pub struct TextureAtlas {
 
 const MISSING_TILE: u32 = 16;
 
+/// Mip levels beyond level 0; level 4 reduces a 16x16 sprite to one texel.
+const MIP_EXTRA: u32 = 4;
+/// Sprite placement granularity, so every sprite origin stays on a texel
+/// boundary at every mip level.
+const MIP_ALIGN: u32 = 1 << MIP_EXTRA;
+
 struct Source {
     name: String,
     data: Vec<u8>,
@@ -85,7 +91,8 @@ impl TextureAtlas {
                     let frame_size = if h > w { w } else { h };
                     let row_bytes = w as usize * size_of::<u32>();
                     let frame_data = data[..frame_size as usize * row_bytes].to_vec();
-                    total_area += (w as u64) * (frame_size as u64);
+                    total_area += u64::from(w.next_multiple_of(MIP_ALIGN))
+                        * u64::from(frame_size.next_multiple_of(MIP_ALIGN));
                     sources.push(Source {
                         name: name.to_string(),
                         data: frame_data,
@@ -138,6 +145,7 @@ impl TextureAtlas {
         }
 
         let mut regions = HashMap::new();
+        let mut sprite_rects = vec![(0u32, 0u32, MISSING_TILE, MISSING_TILE)];
         for src in &sources {
             match placements.get(src.name.as_str()) {
                 Some(Some((cx, cy))) => {
@@ -149,6 +157,7 @@ impl TextureAtlas {
                             atlas_pixels[d..d + 4].copy_from_slice(&src.data[s..s + 4]);
                         }
                     }
+                    sprite_rects.push((*cx, *cy, src.w, src.h));
                     regions.insert(src.name.clone(), region);
                 }
                 _ => {
@@ -162,15 +171,18 @@ impl TextureAtlas {
             missing: missing_region,
         };
 
+        let staging_pixels = build_mip_chain(atlas_pixels, atlas_size, &sprite_rects);
+
         let (image, view, allocation, mip_levels) = util::create_gpu_image_mipmapped(
             device,
             allocator,
             atlas_size,
             atlas_size,
+            MIP_EXTRA + 1,
             "atlas_image",
         );
         let (staging_buffer, staging_allocation) =
-            util::create_staging_buffer(device, allocator, &atlas_pixels, "atlas_staging");
+            util::create_staging_buffer(device, allocator, &staging_pixels, "atlas_staging");
 
         util::upload_image_mipmapped(
             device,
@@ -219,13 +231,95 @@ impl TextureAtlas {
     }
 }
 
+/// Builds level 0 plus `MIP_EXTRA` downsampled levels, each sprite filtered
+/// within its own region so neighbouring sprites never bleed in, packed
+/// tightly level 0 first for `upload_image_mipmapped`.
+fn build_mip_chain(
+    atlas_pixels: Vec<u8>,
+    atlas_size: u32,
+    sprite_rects: &[(u32, u32, u32, u32)],
+) -> Vec<u8> {
+    let mut levels = vec![atlas_pixels];
+    for level in 1..=MIP_EXTRA {
+        let src_size = (atlas_size >> (level - 1)).max(1);
+        let dst_size = (atlas_size >> level).max(1);
+        let mut dst = vec![0u8; (dst_size * dst_size * 4) as usize];
+        for &rect in sprite_rects {
+            downsample_sprite(
+                levels.last().unwrap(),
+                src_size,
+                &mut dst,
+                dst_size,
+                rect,
+                level,
+            );
+        }
+        levels.push(dst);
+    }
+    levels.concat()
+}
+
+/// A sprite's pixel rect scaled down to the given mip level.
+fn mip_rect((x, y, w, h): (u32, u32, u32, u32), level: u32) -> (u32, u32, u32, u32) {
+    (
+        x >> level,
+        y >> level,
+        (w >> level).max(1),
+        (h >> level).max(1),
+    )
+}
+
+/// Box-filters one sprite's region from the previous mip level, clamped to the
+/// sprite's own texels. RGB is averaged over the covered texels with non-zero
+/// alpha so transparent texels don't darken cutout edges.
+fn downsample_sprite(
+    src: &[u8],
+    src_size: u32,
+    dst: &mut [u8],
+    dst_size: u32,
+    rect: (u32, u32, u32, u32),
+    level: u32,
+) {
+    let (sx, sy, sw, sh) = mip_rect(rect, level - 1);
+    let (dx, dy, dw, dh) = mip_rect(rect, level);
+    for j in 0..dh {
+        for i in 0..dw {
+            let mut rgb = [0u32; 3];
+            let mut alpha = 0u32;
+            let mut opaque = 0u32;
+            for (oi, oj) in [(0, 0), (1, 0), (0, 1), (1, 1)] {
+                let px = sx + (2 * i + oi).min(sw - 1);
+                let py = sy + (2 * j + oj).min(sh - 1);
+                let s = ((py * src_size + px) * 4) as usize;
+                let a = u32::from(src[s + 3]);
+                alpha += a;
+                if a > 0 {
+                    for (c, v) in rgb.iter_mut().enumerate() {
+                        *v += u32::from(src[s + c]);
+                    }
+                    opaque += 1;
+                }
+            }
+            let d = (((dy + j) * dst_size + dx + i) * 4) as usize;
+            for (c, v) in rgb.iter().enumerate() {
+                dst[d + c] = v.checked_div(opaque).unwrap_or(0) as u8;
+            }
+            dst[d + 3] = (alpha / 4) as u8;
+        }
+    }
+}
+
 fn pixel_region(x: u32, y: u32, w: u32, h: u32, atlas_size: u32) -> AtlasRegion {
+    // Quarter-texel inset: `pack_uv` quantises UVs to u16, whose granularity
+    // doesn't divide the atlas size, so exact-boundary UVs can round into the
+    // neighbouring sprite. The inset absorbs that at every mip level.
+    const INSET: f32 = 0.25;
     let s = atlas_size as f32;
     AtlasRegion {
-        u_min: x as f32 / s,
-        v_min: y as f32 / s,
-        u_max: (x + w) as f32 / s,
-        v_max: (y + h) as f32 / s,
+        u_min: (x as f32 + INSET) / s,
+        v_min: (y as f32 + INSET) / s,
+        u_max: ((x + w) as f32 - INSET) / s,
+        v_max: ((y + h) as f32 - INSET) / s,
     }
 }
 
@@ -244,7 +338,7 @@ fn pack(sources: &[Source], atlas_size: u32) -> (PackResult, bool) {
             continue;
         }
         if cursor_x + src.w > atlas_size {
-            cursor_y += shelf_h;
+            cursor_y = (cursor_y + shelf_h).next_multiple_of(MIP_ALIGN);
             cursor_x = 0;
             shelf_h = 0;
         }
@@ -254,8 +348,78 @@ fn pack(sources: &[Source], atlas_size: u32) -> (PackResult, bool) {
             continue;
         }
         placements.insert(src.name.clone(), Some((cursor_x, cursor_y)));
-        cursor_x += src.w;
+        cursor_x = (cursor_x + src.w).next_multiple_of(MIP_ALIGN);
         shelf_h = shelf_h.max(src.h);
     }
     ((placements, missing_region), all_fit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fill(pixels: &mut [u8], atlas_size: u32, rect: (u32, u32, u32, u32), color: [u8; 4]) {
+        let (x, y, w, h) = rect;
+        for py in y..y + h {
+            for px in x..x + w {
+                let i = ((py * atlas_size + px) * 4) as usize;
+                pixels[i..i + 4].copy_from_slice(&color);
+            }
+        }
+    }
+
+    #[test]
+    fn mips_stay_within_sprite_regions() {
+        const SIZE: u32 = 64;
+        let rects = [(16u32, 0u32, 16u32, 16u32), (32, 0, 16, 16)];
+        let colors = [[255u8, 0, 0, 255], [0, 0, 255, 255]];
+
+        let mut pixels = vec![0u8; (SIZE * SIZE * 4) as usize];
+        for (&rect, &color) in rects.iter().zip(&colors) {
+            fill(&mut pixels, SIZE, rect, color);
+        }
+
+        let chain = build_mip_chain(pixels, SIZE, &rects);
+
+        let mut offset = (SIZE * SIZE * 4) as usize;
+        for level in 1..=MIP_EXTRA {
+            let size = SIZE >> level;
+            for (&rect, &color) in rects.iter().zip(&colors) {
+                let (dx, dy, dw, dh) = mip_rect(rect, level);
+                for py in dy..dy + dh {
+                    for px in dx..dx + dw {
+                        let i = offset + ((py * size + px) * 4) as usize;
+                        assert_eq!(
+                            &chain[i..i + 4],
+                            &color,
+                            "level {level} texel ({px}, {py}) leaked outside its sprite"
+                        );
+                    }
+                }
+            }
+            offset += (size * size * 4) as usize;
+        }
+        assert_eq!(offset, chain.len());
+    }
+
+    #[test]
+    fn transparent_texels_do_not_darken_rgb() {
+        const SIZE: u32 = 16;
+        let rect = (0u32, 0u32, 16u32, 16u32);
+        let mut pixels = vec![0u8; (SIZE * SIZE * 4) as usize];
+        // Alternating opaque-green and transparent-black columns.
+        for py in 0..16 {
+            for px in (0..16).step_by(2) {
+                let i = ((py * SIZE + px) * 4) as usize;
+                pixels[i..i + 4].copy_from_slice(&[0, 255, 0, 255]);
+            }
+        }
+
+        let chain = build_mip_chain(pixels, SIZE, &[rect]);
+
+        // Level 1: each 2x2 block holds two opaque green and two transparent
+        // texels; RGB must stay full green, alpha averages to half.
+        let l1 = &chain[(SIZE * SIZE * 4) as usize..];
+        assert_eq!(&l1[0..4], &[0, 255, 0, 127]);
+    }
 }

--- a/pomme-client/src/renderer/chunk/atlas.rs
+++ b/pomme-client/src/renderer/chunk/atlas.rs
@@ -189,6 +189,7 @@ impl TextureAtlas {
             queue,
             command_pool,
             staging_buffer,
+            staging_pixels.len() as u64,
             image,
             atlas_size,
             atlas_size,

--- a/pomme-client/src/renderer/pipelines/block_entity.rs
+++ b/pomme-client/src/renderer/pipelines/block_entity.rs
@@ -562,6 +562,7 @@ fn build_texture_slot(
         util::create_staging_buffer(device, allocator, &pixels, "block_entity_texture_staging");
     pending_uploads.push(util::PendingImageUpload {
         staging_buffer: staging_buf,
+        staging_size: pixels.len() as u64,
         image,
         width,
         height,

--- a/pomme-client/src/renderer/util.rs
+++ b/pomme-client/src/renderer/util.rs
@@ -266,6 +266,7 @@ pub fn upload_image(
         queue,
         command_pool,
         staging_buffer,
+        rgba8_bytes(width, height),
         image,
         width,
         height,
@@ -474,18 +475,28 @@ pub fn upload_image_mipmapped(
     queue: vk::Queue,
     command_pool: vk::CommandPool,
     staging_buffer: vk::Buffer,
+    staging_size: u64,
     image: vk::Image,
     width: u32,
     height: u32,
     mip_levels: u32,
 ) {
     submit_one_time(device, queue, command_pool, |cmd| {
-        record_image_upload(cmd, staging_buffer, image, width, height, mip_levels);
+        record_image_upload(
+            cmd,
+            staging_buffer,
+            staging_size,
+            image,
+            width,
+            height,
+            mip_levels,
+        );
     });
 }
 
 pub struct PendingImageUpload {
     pub staging_buffer: vk::Buffer,
+    pub staging_size: u64,
     pub image: vk::Image,
     pub width: u32,
     pub height: u32,
@@ -506,6 +517,7 @@ pub fn upload_images_batched(
             record_image_upload(
                 cmd,
                 u.staging_buffer,
+                u.staging_size,
                 u.image,
                 u.width,
                 u.height,
@@ -515,9 +527,14 @@ pub fn upload_images_batched(
     });
 }
 
+fn rgba8_bytes(width: u32, height: u32) -> u64 {
+    u64::from(width) * u64::from(height) * 4
+}
+
 fn record_image_upload(
     cmd: &vk::CommandBuffer,
     staging_buffer: vk::Buffer,
+    staging_size: u64,
     image: vk::Image,
     width: u32,
     height: u32,
@@ -570,10 +587,16 @@ fn record_image_upload(
                     depth: 1,
                 },
             };
-            buffer_offset += u64::from(w) * u64::from(h) * 4;
+            buffer_offset += rgba8_bytes(w, h);
             region
         })
         .collect();
+
+    debug_assert_eq!(
+        buffer_offset, staging_size,
+        "staging buffer ({staging_size} bytes) must hold exactly all {mip_levels} mip levels \
+         ({buffer_offset} bytes); a mismatch would copy out of bounds"
+    );
 
     cmd.copy_buffer_to_image(
         staging_buffer,

--- a/pomme-client/src/renderer/util.rs
+++ b/pomme-client/src/renderer/util.rs
@@ -44,10 +44,7 @@ fn create_gpu_image_core(
     mip_levels: u32,
     name: &str,
 ) -> (vk::Image, vk::ImageView, Allocation, u32) {
-    let mut usage = vk::ImageUsageFlags::TransferDst | vk::ImageUsageFlags::Sampled;
-    if mip_levels > 1 {
-        usage |= vk::ImageUsageFlags::TransferSrc;
-    }
+    let usage = vk::ImageUsageFlags::TransferDst | vk::ImageUsageFlags::Sampled;
 
     let image_info = vk::ImageCreateInfo {
         image_type: vk::ImageType::Type2D,
@@ -450,18 +447,14 @@ pub unsafe fn create_linear_sampler(device: &vk::Device) -> vk::Sampler {
         .expect("failed to create linear sampler")
 }
 
-pub fn calculate_mip_levels(w: u32, h: u32) -> u32 {
-    (w.max(h) as f32).log2().floor() as u32 + 1
-}
-
 pub fn create_gpu_image_mipmapped(
     device: &vk::Device,
     allocator: &Arc<Mutex<Allocator>>,
     width: u32,
     height: u32,
+    mip_levels: u32,
     name: &str,
 ) -> (vk::Image, vk::ImageView, Allocation, u32) {
-    let mip_levels = calculate_mip_levels(width, height);
     create_gpu_image_core(
         device,
         allocator,
@@ -473,6 +466,8 @@ pub fn create_gpu_image_mipmapped(
     )
 }
 
+/// Uploads an image whose mip levels are all present in the staging buffer,
+/// packed tightly with level 0 first.
 #[allow(clippy::too_many_arguments)]
 pub fn upload_image_mipmapped(
     device: &vk::Device,
@@ -553,131 +548,40 @@ fn record_image_upload(
         &[barrier_all],
     );
 
-    let copy_region = vk::BufferImageCopy {
-        buffer_offset: 0,
-        buffer_row_length: 0,
-        buffer_image_height: 0,
-        image_subresource: vk::ImageSubresourceLayers {
-            aspect_mask: vk::ImageAspectFlags::Color,
-            mip_level: 0,
-            base_array_layer: 0,
-            layer_count: 1,
-        },
-        image_offset: vk::Offset3D { x: 0, y: 0, z: 0 },
-        image_extent: vk::Extent3D {
-            width,
-            height,
-            depth: 1,
-        },
-    };
+    let mut buffer_offset = 0u64;
+    let copy_regions: Vec<vk::BufferImageCopy> = (0..mip_levels)
+        .map(|level| {
+            let w = (width >> level).max(1);
+            let h = (height >> level).max(1);
+            let region = vk::BufferImageCopy {
+                buffer_offset,
+                buffer_row_length: 0,
+                buffer_image_height: 0,
+                image_subresource: vk::ImageSubresourceLayers {
+                    aspect_mask: vk::ImageAspectFlags::Color,
+                    mip_level: level,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                },
+                image_offset: vk::Offset3D { x: 0, y: 0, z: 0 },
+                image_extent: vk::Extent3D {
+                    width: w,
+                    height: h,
+                    depth: 1,
+                },
+            };
+            buffer_offset += u64::from(w) * u64::from(h) * 4;
+            region
+        })
+        .collect();
 
     cmd.copy_buffer_to_image(
         staging_buffer,
         image,
         vk::ImageLayout::TransferDstOptimal,
-        &[copy_region],
+        &copy_regions,
     );
 
-    let mut mip_w = width as i32;
-    let mut mip_h = height as i32;
-
-    for i in 1..mip_levels {
-        let barrier = vk::ImageMemoryBarrier {
-            image,
-            old_layout: vk::ImageLayout::TransferDstOptimal,
-            new_layout: vk::ImageLayout::TransferSrcOptimal,
-            src_access_mask: vk::AccessFlags::TransferWrite,
-            dst_access_mask: vk::AccessFlags::TransferRead,
-            subresource_range: vk::ImageSubresourceRange {
-                aspect_mask: vk::ImageAspectFlags::Color,
-                base_mip_level: i - 1,
-                level_count: 1,
-                base_array_layer: 0,
-                layer_count: 1,
-            },
-            ..Default::default()
-        };
-
-        cmd.pipeline_barrier(
-            vk::PipelineStageFlags::Transfer,
-            vk::PipelineStageFlags::Transfer,
-            vk::DependencyFlags::empty(),
-            &[],
-            &[],
-            &[barrier],
-        );
-
-        let next_w = (mip_w / 2).max(1);
-        let next_h = (mip_h / 2).max(1);
-
-        let blit = vk::ImageBlit {
-            src_subresource: vk::ImageSubresourceLayers {
-                aspect_mask: vk::ImageAspectFlags::Color,
-                mip_level: i - 1,
-                base_array_layer: 0,
-                layer_count: 1,
-            },
-            src_offsets: [
-                vk::Offset3D { x: 0, y: 0, z: 0 },
-                vk::Offset3D {
-                    x: mip_w,
-                    y: mip_h,
-                    z: 1,
-                },
-            ],
-            dst_subresource: vk::ImageSubresourceLayers {
-                aspect_mask: vk::ImageAspectFlags::Color,
-                mip_level: i,
-                base_array_layer: 0,
-                layer_count: 1,
-            },
-            dst_offsets: [
-                vk::Offset3D { x: 0, y: 0, z: 0 },
-                vk::Offset3D {
-                    x: next_w,
-                    y: next_h,
-                    z: 1,
-                },
-            ],
-        };
-
-        cmd.blit_image(
-            image,
-            vk::ImageLayout::TransferSrcOptimal,
-            image,
-            vk::ImageLayout::TransferDstOptimal,
-            &[blit],
-            vk::Filter::Nearest,
-        );
-
-        let barrier = vk::ImageMemoryBarrier {
-            image,
-            old_layout: vk::ImageLayout::TransferSrcOptimal,
-            new_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
-            src_access_mask: vk::AccessFlags::TransferRead,
-            dst_access_mask: vk::AccessFlags::ShaderRead,
-            subresource_range: vk::ImageSubresourceRange {
-                aspect_mask: vk::ImageAspectFlags::Color,
-                base_mip_level: i - 1,
-                level_count: 1,
-                base_array_layer: 0,
-                layer_count: 1,
-            },
-            ..Default::default()
-        };
-
-        cmd.pipeline_barrier(
-            vk::PipelineStageFlags::Transfer,
-            vk::PipelineStageFlags::FragmentShader,
-            vk::DependencyFlags::empty(),
-            &[],
-            &[],
-            &[barrier],
-        );
-
-        mip_w = next_w;
-        mip_h = next_h;
-    }
     let barrier = vk::ImageMemoryBarrier {
         image,
         old_layout: vk::ImageLayout::TransferDstOptimal,
@@ -686,8 +590,8 @@ fn record_image_upload(
         dst_access_mask: vk::AccessFlags::ShaderRead,
         subresource_range: vk::ImageSubresourceRange {
             aspect_mask: vk::ImageAspectFlags::Color,
-            base_mip_level: mip_levels - 1,
-            level_count: 1,
+            base_mip_level: 0,
+            level_count: mip_levels,
             base_array_layer: 0,
             layer_count: 1,
         },


### PR DESCRIPTION
Per-sprite mip generation with aligned packing, plus a quarter texel uv inset so quantized uvs can't sample the neighbouring sprite.