### PR TITLE
macOS rendering support

### DIFF
--- a/pomme-client/src/renderer/chunk/buffer.rs
+++ b/pomme-client/src/renderer/chunk/buffer.rs
@@ -708,6 +708,14 @@ impl ChunkBufferStore {
         self.count_allocs[frame].mapped_slice_mut().unwrap()[..4]
             .copy_from_slice(&0u32.to_ne_bytes());
 
+        // macOS draws the whole indirect buffer (no drawIndirectCount), so slots
+        // the cull shader leaves unfilled must read as no-op draws, not stale data.
+        #[cfg(target_os = "macos")]
+        self.indirect_allocs[frame]
+            .mapped_slice_mut()
+            .unwrap()
+            .fill(0);
+
         cmd.bind_pipeline(vk::PipelineBindPoint::Compute, self.compute_pipeline);
         cmd.bind_descriptor_sets(
             vk::PipelineBindPoint::Compute,

--- a/pomme-client/src/renderer/context.rs
+++ b/pomme-client/src/renderer/context.rs
@@ -192,7 +192,12 @@ impl VulkanContext {
         };
 
         let mut vk12_features = vk::PhysicalDeviceVulkan12Features {
-            draw_indirect_count: vk::TRUE,
+            // MoltenVK lacks drawIndirectCount; the chunk renderer has a macOS fallback.
+            draw_indirect_count: if cfg!(target_os = "macos") {
+                vk::FALSE
+            } else {
+                vk::TRUE
+            },
             ..Default::default()
         };
 


### PR DESCRIPTION
Gets the client rendering on macOS / MoltenVK.

- context.rs: don't request drawIndirectCount (MoltenVK lacks it); the chunk renderer already had a no-count fallback.
- buffer.rs: zero the indirect buffer each frame on macOS so the fallback's unfilled slots are no-op draws, not stale garbage (was causing ErrorDeviceLost).

Depends on macOS Metal surface support in pyronyx (unschlagbar/pyronyx#4). Until that's released and the pyronyx version is bumped here, running on macOS needs a local `[patch.crates-io]` pointing pyronyx at the fork. These two fixes are correct regardless and are no-ops on other platforms.

Verified in-game on Apple M5 Max.