### PR TITLE
Implement view bobbing

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -850,6 +850,7 @@ impl AppCore {
             &mut game.player_walk_speed,
             &mut game.player_prev_walk_speed,
         );
+        game.player.tick_bob(dx, dz);
 
         renderer.set_base_fov(self.menu.fov as f32);
         renderer.update_fov_mod(compute_fov_modifier(&game.player));

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -259,6 +259,12 @@ pub fn update_game(
             .prev_eye_pos()
             .lerp(game.player.eye_pos(), partial_tick as f64),
     );
+    // Plain lerp (vanilla getInterpolatedWalkDistance); the forward-extrapolating camera
+    // variant judders across tick boundaries when per-tick speed varies.
+    let bob_walk = game.player.prev_walk_dist.lerp(game.player.walk_dist, partial_tick);
+    let bob_amount = game.player.prev_bob.lerp(game.player.bob, partial_tick);
+    gfx.renderer
+        .set_view_bob(bob_walk, bob_amount, core.menu.view_bobbing);
     gfx.renderer.update_third_person_distance(
         game.player
             .prev_eye_pos()

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -259,9 +259,12 @@ pub fn update_game(
             .prev_eye_pos()
             .lerp(game.player.eye_pos(), partial_tick as f64),
     );
-    // Plain lerp (vanilla getInterpolatedWalkDistance); the forward-extrapolating camera
-    // variant judders across tick boundaries when per-tick speed varies.
-    let bob_walk = game.player.prev_walk_dist.lerp(game.player.walk_dist, partial_tick);
+    // Plain lerp (vanilla getInterpolatedWalkDistance); the forward-extrapolating
+    // camera variant judders across tick boundaries when per-tick speed varies.
+    let bob_walk = game
+        .player
+        .prev_walk_dist
+        .lerp(game.player.walk_dist, partial_tick);
     let bob_amount = game.player.prev_bob.lerp(game.player.bob, partial_tick);
     gfx.renderer
         .set_view_bob(bob_walk, bob_amount, core.menu.view_bobbing);

--- a/pomme-client/src/physics/movement.rs
+++ b/pomme-client/src/physics/movement.rs
@@ -129,10 +129,6 @@ fn tick_land(
     };
     player.velocity.x *= h_friction;
     player.velocity.z *= h_friction;
-
-    if player.on_ground && player.velocity.y < 0.0 {
-        player.velocity.y = 0.0;
-    }
 }
 
 fn tick_water(
@@ -216,6 +212,7 @@ fn apply_collision(
     // Collisions compare against the edge-clamped delta so the clamp itself
     // never zeroes velocity, letting the player keep creeping along the edge.
     let collided_x = (resolved.x - delta.x).abs() > 1.0e-5;
+    let collided_y = (resolved.y - delta.y).abs() > 1.0e-5;
     let collided_z = (resolved.z - delta.z).abs() > 1.0e-5;
     let horizontal_collision = collided_x || collided_z;
 
@@ -228,6 +225,12 @@ fn apply_collision(
     }
     if collided_z {
         player.velocity.z = 0.0;
+    }
+    // Zero the vertical velocity on ground/ceiling contact (vanilla does this in move()).
+    // Gravity is re-applied after the move, leaving vy slightly negative so the next tick's
+    // move always probes downward and keeps `on_ground` stable instead of flickering.
+    if collided_y {
+        player.velocity.y = 0.0;
     }
 
     if player.sprinting

--- a/pomme-client/src/physics/movement.rs
+++ b/pomme-client/src/physics/movement.rs
@@ -226,9 +226,10 @@ fn apply_collision(
     if collided_z {
         player.velocity.z = 0.0;
     }
-    // Zero the vertical velocity on ground/ceiling contact (vanilla does this in move()).
-    // Gravity is re-applied after the move, leaving vy slightly negative so the next tick's
-    // move always probes downward and keeps `on_ground` stable instead of flickering.
+    // Zero the vertical velocity on ground/ceiling contact (vanilla does this in
+    // move()). Gravity is re-applied after the move, leaving vy slightly
+    // negative so the next tick's move always probes downward and keeps
+    // `on_ground` stable instead of flickering.
     if collided_y {
         player.velocity.y = 0.0;
     }

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -47,6 +47,10 @@ pub struct LocalPlayer {
     pub crouching: bool,
     pub eye_height: f64,
     pub prev_eye_height: f64,
+    pub walk_dist: f32,
+    pub prev_walk_dist: f32,
+    pub bob: f32,
+    pub prev_bob: f32,
     pub horizontal_collision: bool,
     pub sprint_toggle_timer: u32,
     pub was_forward_pressed: bool,
@@ -79,6 +83,10 @@ impl LocalPlayer {
             crouching: false,
             eye_height: STANDING_EYE_HEIGHT,
             prev_eye_height: STANDING_EYE_HEIGHT,
+            walk_dist: 0.0,
+            prev_walk_dist: 0.0,
+            bob: 0.0,
+            prev_bob: 0.0,
             horizontal_collision: false,
             sprint_toggle_timer: 0,
             was_forward_pressed: false,
@@ -113,6 +121,22 @@ impl LocalPlayer {
     pub fn tick_eye_height(&mut self) {
         self.prev_eye_height = self.eye_height;
         self.eye_height += (self.target_eye_height() - self.eye_height) * 0.5;
+    }
+
+    /// Accumulates walk distance and a smoothed bob amplitude for view bobbing,
+    /// mirroring vanilla `AbstractClientPlayer.updateBob` (caller skips this when dead).
+    pub fn tick_bob(&mut self, dx: f64, dz: f64) {
+        let horizontal = ((dx * dx + dz * dz) as f32).sqrt();
+        self.prev_walk_dist = self.walk_dist;
+        // Vanilla LocalPlayer.move: addWalkedDistance(len * 0.6) — the 0.6 sets the cadence.
+        self.walk_dist += horizontal * 0.6;
+        let target = if self.on_ground && !self.swimming {
+            horizontal.min(0.1)
+        } else {
+            0.0
+        };
+        self.prev_bob = self.bob;
+        self.bob += (target - self.bob) * 0.4;
     }
 
     pub fn prev_eye_pos(&self) -> Position {

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -2,7 +2,7 @@ pub mod interaction;
 pub mod inventory;
 pub mod tab_list;
 
-use glam::dvec3;
+use glam::{dvec2, dvec3};
 use inventory::Inventory;
 
 use crate::entity::components::{LookDirection, Position, Velocity};
@@ -127,13 +127,12 @@ impl LocalPlayer {
     /// mirroring vanilla `AbstractClientPlayer.updateBob` (caller skips this
     /// when dead).
     pub fn tick_bob(&mut self, dx: f64, dz: f64) {
-        let horizontal = ((dx * dx + dz * dz) as f32).sqrt();
         self.prev_walk_dist = self.walk_dist;
-        // Vanilla LocalPlayer.move: addWalkedDistance(len * 0.6) — the 0.6 sets the
-        // cadence.
-        self.walk_dist += horizontal * 0.6;
+        // Vanilla LocalPlayer.move: addWalkedDistance(len * 0.6).
+        self.walk_dist += dvec2(dx, dz).length() as f32 * 0.6;
+        // updateBob's target is horizontal speed, not the walk delta.
         let target = if self.on_ground && !self.swimming {
-            horizontal.min(0.1)
+            (dvec2(self.velocity.x, self.velocity.z).length() as f32).min(0.1)
         } else {
             0.0
         };

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -124,11 +124,13 @@ impl LocalPlayer {
     }
 
     /// Accumulates walk distance and a smoothed bob amplitude for view bobbing,
-    /// mirroring vanilla `AbstractClientPlayer.updateBob` (caller skips this when dead).
+    /// mirroring vanilla `AbstractClientPlayer.updateBob` (caller skips this
+    /// when dead).
     pub fn tick_bob(&mut self, dx: f64, dz: f64) {
         let horizontal = ((dx * dx + dz * dz) as f32).sqrt();
         self.prev_walk_dist = self.walk_dist;
-        // Vanilla LocalPlayer.move: addWalkedDistance(len * 0.6) — the 0.6 sets the cadence.
+        // Vanilla LocalPlayer.move: addWalkedDistance(len * 0.6) — the 0.6 sets the
+        // cadence.
         self.walk_dist += horizontal * 0.6;
         let target = if self.on_ground && !self.swimming {
             horizontal.min(0.1)

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -42,6 +42,9 @@ pub struct Camera {
     pub base_fov_degrees: f32,
     fov_modifier: f32,
     old_fov_modifier: f32,
+    bob_walk_dist: f32,
+    bob_amount: f32,
+    bob_enabled: bool,
 }
 
 impl Camera {
@@ -55,7 +58,40 @@ impl Camera {
             base_fov_degrees: DEFAULT_FOV_DEGREES,
             fov_modifier: 1.0,
             old_fov_modifier: 1.0,
+            bob_walk_dist: 0.0,
+            bob_amount: 0.0,
+            bob_enabled: false,
         }
+    }
+
+    pub fn set_view_bob(&mut self, walk_dist: f32, bob: f32, enabled: bool) {
+        self.bob_walk_dist = walk_dist;
+        self.bob_amount = bob;
+        self.bob_enabled = enabled;
+    }
+
+    /// The view-space bob transform, also applied to the first-person arm/held item.
+    pub fn view_bob_matrix(&self) -> Mat4 {
+        self.bob_matrix()
+    }
+
+    /// Replicates vanilla `GameRenderer.bobView`. Identity when disabled, not in first
+    /// person, or at rest.
+    fn bob_matrix(&self) -> Mat4 {
+        if !self.bob_enabled || self.mode != CameraMode::FirstPerson || self.bob_amount == 0.0 {
+            return Mat4::IDENTITY;
+        }
+        use std::f32::consts::PI;
+        // Vanilla's `backwardsInterpolatedWalkDistance` is the negated walk distance.
+        let f = -self.bob_walk_dist;
+        let bob = self.bob_amount;
+        let tx = (f * PI).sin() * bob * 0.5;
+        let ty = -((f * PI).cos() * bob).abs();
+        let roll_deg = (f * PI).sin() * bob * 3.0;
+        let pitch_deg = ((f * PI - 0.2).cos() * bob).abs() * 5.0;
+        Mat4::from_translation(Vec3::new(tx, ty, 0.0))
+            * Mat4::from_rotation_z(roll_deg.to_radians())
+            * Mat4::from_rotation_x(pitch_deg.to_radians())
     }
 
     pub fn update_look(&mut self, input: &mut InputState, dt: f32) {
@@ -162,7 +198,7 @@ impl Camera {
             look_dir
         };
 
-        let view = Mat4::look_to_rh(offset, forward, UP);
+        let view = self.bob_matrix() * Mat4::look_to_rh(offset, forward, UP);
         let mut proj = Mat4::perspective_rh(fov, self.aspect_ratio, NEAR, FAR);
         proj.y_axis.y *= -1.0; // Vulkan NDC has +Y down
         proj * view

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -70,13 +70,14 @@ impl Camera {
         self.bob_enabled = enabled;
     }
 
-    /// The view-space bob transform, also applied to the first-person arm/held item.
+    /// The view-space bob transform, also applied to the first-person arm/held
+    /// item.
     pub fn view_bob_matrix(&self) -> Mat4 {
         self.bob_matrix()
     }
 
-    /// Replicates vanilla `GameRenderer.bobView`. Identity when disabled, not in first
-    /// person, or at rest.
+    /// Replicates vanilla `GameRenderer.bobView`. Identity when disabled, not
+    /// in first person, or at rest.
     fn bob_matrix(&self) -> Mat4 {
         if !self.bob_enabled || self.mode != CameraMode::FirstPerson || self.bob_amount == 0.0 {
             return Mat4::IDENTITY;

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -664,6 +664,10 @@ impl Renderer {
         self.camera.sync_pos(position);
     }
 
+    pub fn set_view_bob(&mut self, walk_dist: f32, bob: f32, enabled: bool) {
+        self.camera.set_view_bob(walk_dist, bob, enabled);
+    }
+
     pub fn reset_camera(&mut self, position: Position, look_dir: LookDirection) {
         self.camera.reset(position, look_dir);
     }
@@ -1323,6 +1327,9 @@ impl Renderer {
 
                 if self.camera.mode == camera::CameraMode::FirstPerson {
                     let aspect = sw / sh.max(1.0);
+                    // Same view-bob the world uses, so the arm/item bob in lockstep
+                    // (vanilla applies bobView to the hand pose stack too).
+                    let bob = self.camera.view_bob_matrix();
                     // Vanilla renderArmWithItem draws the arm only for an empty
                     // hand; a held item renders alone.
                     match held_item {
@@ -1333,10 +1340,11 @@ impl Renderer {
                             *swing_progress,
                             item,
                             &self.item_entity_pipeline,
+                            bob,
                         ),
                         None => {
                             self.hand_pipeline
-                                .update_and_draw(cmd, frame, aspect, *swing_progress)
+                                .update_and_draw(cmd, frame, aspect, *swing_progress, bob)
                         }
                     }
                 }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1342,10 +1342,13 @@ impl Renderer {
                             &self.item_entity_pipeline,
                             bob,
                         ),
-                        None => {
-                            self.hand_pipeline
-                                .update_and_draw(cmd, frame, aspect, *swing_progress, bob)
-                        }
+                        None => self.hand_pipeline.update_and_draw(
+                            cmd,
+                            frame,
+                            aspect,
+                            *swing_progress,
+                            bob,
+                        ),
                     }
                 }
 

--- a/pomme-client/src/renderer/pipelines/hand.rs
+++ b/pomme-client/src/renderer/pipelines/hand.rs
@@ -204,6 +204,7 @@ impl HandPipeline {
         frame: usize,
         aspect: f32,
         swing_progress: f32,
+        bob: Mat4,
     ) {
         let proj = projection(aspect);
 
@@ -232,7 +233,7 @@ impl HandPipeline {
             * Mat4::from_translation(Vec3::new(5.6, 0.0, 0.0))
             * arm_local_rot;
 
-        let mvp = proj * model;
+        let mvp = proj * bob * model;
         let uniform = HandUniform {
             mvp: mvp.to_cols_array_2d(),
         };

--- a/pomme-client/src/renderer/pipelines/held_item.rs
+++ b/pomme-client/src/renderer/pipelines/held_item.rs
@@ -46,6 +46,7 @@ impl HeldItemPipeline {
         self.shared.rebind_atlas(device, atlas);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_and_draw(
         &mut self,
         cmd: vk::CommandBuffer,
@@ -54,12 +55,13 @@ impl HeldItemPipeline {
         swing_progress: f32,
         item: &HeldItemInfo,
         meshes: &ItemEntityPipeline,
+        bob: Mat4,
     ) {
         let Some((buffer, vertex_count)) = meshes.mesh_handle(&item.name) else {
             return;
         };
 
-        let uniform = CameraUniform::with_view_proj(hand::projection(aspect));
+        let uniform = CameraUniform::with_view_proj(hand::projection(aspect) * bob);
         self.shared.update_camera(frame, &uniform);
 
         let display = self

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -23,6 +23,8 @@ struct Settings {
     #[serde(default = "default_fov")]
     fov: u32,
     #[serde(default = "default_true")]
+    view_bobbing: bool,
+    #[serde(default = "default_true")]
     show_online_status: bool,
     #[serde(default = "default_true")]
     show_current_server: bool,
@@ -85,6 +87,7 @@ impl Default for Settings {
             render_distance: 12,
             simulation_distance: 12,
             fov: 70,
+            view_bobbing: true,
             show_online_status: true,
             show_current_server: true,
             skin_cape: true,
@@ -280,6 +283,7 @@ pub struct MainMenu {
     pub render_distance: u32,
     pub simulation_distance: u32,
     pub fov: u32,
+    pub view_bobbing: bool,
     pub show_online_status: bool,
     pub show_current_server: bool,
     pub master_volume: f32,
@@ -349,6 +353,7 @@ impl MainMenu {
             render_distance: settings.render_distance,
             simulation_distance: settings.simulation_distance,
             fov: settings.fov,
+            view_bobbing: settings.view_bobbing,
             show_online_status: settings.show_online_status,
             show_current_server: settings.show_current_server,
             master_volume: settings.master_volume,
@@ -421,6 +426,7 @@ impl MainMenu {
                 render_distance: self.render_distance,
                 simulation_distance: self.simulation_distance,
                 fov: self.fov,
+                view_bobbing: self.view_bobbing,
                 show_online_status: self.show_online_status,
                 show_current_server: self.show_current_server,
                 master_volume: self.master_volume,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -57,6 +57,14 @@ impl MainMenu {
         )
     }
 
+    fn view_bobbing_label(&self) -> &'static str {
+        if self.view_bobbing {
+            "View Bobbing: ON"
+        } else {
+            "View Bobbing: OFF"
+        }
+    }
+
     pub(super) fn build_options_video(
         &mut self,
         sw: f32,
@@ -80,7 +88,7 @@ impl MainMenu {
             [&rd, &sd],
             ["Graphics: Fancy", "Smooth Lighting: ON"],
             [&mf, "VSync: OFF"],
-            ["View Bobbing: ON", &gui_label],
+            [self.view_bobbing_label(), &gui_label],
             ["Attack Indicator: Crosshair", "Brightness: 50%"],
             ["Clouds: Fancy", fullscreen_label],
             ["Particles: All", "Mipmap Levels: 4"],
@@ -178,7 +186,7 @@ impl MainMenu {
             ],
             ["Chat Text Opacity: 100%", "Line Spacing: 0%"],
             ["Chat Delay: None", "Notification Time: 10.0s"],
-            ["View Bobbing: ON", "Distortion Effects: 100%"],
+            [self.view_bobbing_label(), "Distortion Effects: 100%"],
             ["FOV Effects: 100%", "Darkness Pulsing: 100%"],
             ["Damage Tilt: 100%", "Glint Speed: 100%"],
             ["Glint Strength: 100%", "Hide Lightning Flashes: OFF"],
@@ -596,6 +604,10 @@ impl MainMenu {
                     }
                     if label.starts_with("Fullscreen:") {
                         self.display_mode = self.display_mode.cycle();
+                    }
+                    if label.starts_with("View Bobbing:") {
+                        self.view_bobbing = !self.view_bobbing;
+                        self.save_settings();
                     }
                     if label.starts_with("Show Online Status:") {
                         self.show_online_status = !self.show_online_status;


### PR DESCRIPTION
Adds first-person view bobbing with a persisted toggle in Video Settings. Also fixes an on_ground flicker in the movement sim.

Closes #39