### PR TITLE
Implement VSync toggle

### DIFF
--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -111,6 +111,7 @@ impl ApplicationHandler for App {
                     &self.core.data_dirs.jar_assets_dir,
                     &self.core.asset_index,
                     &self.core.data_dirs.game_dir,
+                    self.core.menu.vsync,
                 ) {
                     Ok(r) => r,
                     Err(e) => {

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -196,6 +196,8 @@ pub fn update_game(
         .set_listener(listener_pos, game.player.look_dir.y_rot_deg());
     core.audio.set_volumes(core.menu.category_volumes());
 
+    gfx.renderer.set_vsync(core.menu.vsync);
+
     let disconnect_reason =
         core.drain_network_events(connection, None, &mut gfx.renderer, &gfx.window, game);
     if let Some(reason) = disconnect_reason {

--- a/pomme-client/src/app/phases/in_menu.rs
+++ b/pomme-client/src/app/phases/in_menu.rs
@@ -65,6 +65,8 @@ pub fn update_menu(
         core.apply_display_mode(&gfx.window);
     }
 
+    gfx.renderer.set_vsync(core.menu.vsync);
+
     if core.menu.rescan_packs {
         core.menu.rescan_packs = false;
         core.resource_packs.scan_local_packs();

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -128,6 +128,7 @@ pub struct Renderer {
     chunk_buffers: ChunkBufferStore,
     render_finished_per_image: Vec<vk::Semaphore>,
     swapchain_dirty: bool,
+    vsync: bool,
     width: u32,
     height: u32,
     last_timings: RenderTimings,
@@ -153,10 +154,12 @@ impl Renderer {
 
         let ctx = VulkanContext::new(&window)?;
 
+        let vsync = true;
         let swapchain_state = Swapchain::new(
             &ctx,
             size.width.max(1),
             size.height.max(1),
+            vsync,
             vk::SwapchainKHR::null(),
         )?;
 
@@ -401,6 +404,7 @@ impl Renderer {
             chunk_buffers,
             render_finished_per_image,
             swapchain_dirty: false,
+            vsync,
             width: size.width.max(1),
             height: size.height.max(1),
             last_timings: RenderTimings::default(),
@@ -574,6 +578,13 @@ impl Renderer {
             .set_aspect_ratio(new_size.width as f32 / new_size.height as f32);
     }
 
+    pub fn set_vsync(&mut self, vsync: bool) {
+        if self.vsync != vsync {
+            self.vsync = vsync;
+            self.swapchain_dirty = true;
+        }
+    }
+
     fn recreate_swapchain(&mut self) -> Result<(), RendererError> {
         let _ = self.ctx.device.wait_idle();
 
@@ -584,8 +595,13 @@ impl Renderer {
         self.chunk_pipeline
             .destroy(&self.ctx.device, &self.ctx.allocator);
 
-        let mut old_swapchain =
-            Swapchain::new(&self.ctx, self.width, self.height, self.swapchain.handle)?;
+        let mut old_swapchain = Swapchain::new(
+            &self.ctx,
+            self.width,
+            self.height,
+            self.vsync,
+            self.swapchain.handle,
+        )?;
         std::mem::swap(&mut self.swapchain, &mut old_swapchain);
         old_swapchain.destroy(&self.ctx.device, &self.ctx.allocator);
 

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -140,6 +140,7 @@ impl Renderer {
         jar_assets_dir: &Path,
         asset_index: &Option<AssetIndex>,
         game_dir: &Path,
+        vsync: bool,
     ) -> Result<Self, RendererError> {
         let size = window.inner_size();
 
@@ -154,7 +155,6 @@ impl Renderer {
 
         let ctx = VulkanContext::new(&window)?;
 
-        let vsync = true;
         let swapchain_state = Swapchain::new(
             &ctx,
             size.width.max(1),

--- a/pomme-client/src/renderer/swapchain.rs
+++ b/pomme-client/src/renderer/swapchain.rs
@@ -33,6 +33,7 @@ impl Swapchain {
         ctx: &VulkanContext,
         width: u32,
         height: u32,
+        vsync: bool,
         old_swapchain: vk::SwapchainKHR,
     ) -> Result<Self, ContextError> {
         let caps = ctx.physical_device.get_surface_capabilities(ctx.surface)?;
@@ -48,7 +49,9 @@ impl Swapchain {
             .copied()
             .unwrap_or(formats[0]);
 
-        let present_mode = if present_modes.contains(&vk::PresentModeKHR::Mailbox) {
+        let present_mode = if vsync {
+            vk::PresentModeKHR::Fifo
+        } else if present_modes.contains(&vk::PresentModeKHR::Mailbox) {
             vk::PresentModeKHR::Mailbox
         } else if present_modes.contains(&vk::PresentModeKHR::Immediate) {
             vk::PresentModeKHR::Immediate

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -25,6 +25,8 @@ struct Settings {
     #[serde(default = "default_true")]
     view_bobbing: bool,
     #[serde(default = "default_true")]
+    vsync: bool,
+    #[serde(default = "default_true")]
     show_online_status: bool,
     #[serde(default = "default_true")]
     show_current_server: bool,
@@ -88,6 +90,7 @@ impl Default for Settings {
             simulation_distance: 12,
             fov: 70,
             view_bobbing: true,
+            vsync: true,
             show_online_status: true,
             show_current_server: true,
             skin_cape: true,
@@ -284,6 +287,7 @@ pub struct MainMenu {
     pub simulation_distance: u32,
     pub fov: u32,
     pub view_bobbing: bool,
+    pub vsync: bool,
     pub show_online_status: bool,
     pub show_current_server: bool,
     pub master_volume: f32,
@@ -354,6 +358,7 @@ impl MainMenu {
             simulation_distance: settings.simulation_distance,
             fov: settings.fov,
             view_bobbing: settings.view_bobbing,
+            vsync: settings.vsync,
             show_online_status: settings.show_online_status,
             show_current_server: settings.show_current_server,
             master_volume: settings.master_volume,
@@ -427,6 +432,7 @@ impl MainMenu {
                 simulation_distance: self.simulation_distance,
                 fov: self.fov,
                 view_bobbing: self.view_bobbing,
+                vsync: self.vsync,
                 show_online_status: self.show_online_status,
                 show_current_server: self.show_current_server,
                 master_volume: self.master_volume,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -84,10 +84,15 @@ impl MainMenu {
         } else {
             format!("GUI Scale: {}", self.gui_scale_setting)
         };
+        let vsync_label = if self.vsync {
+            "VSync: ON"
+        } else {
+            "VSync: OFF"
+        };
         let rows: Vec<[&str; 2]> = vec![
             [&rd, &sd],
             ["Graphics: Fancy", "Smooth Lighting: ON"],
-            [&mf, "VSync: OFF"],
+            [&mf, vsync_label],
             [self.view_bobbing_label(), &gui_label],
             ["Attack Indicator: Crosshair", "Brightness: 50%"],
             ["Clouds: Fancy", fullscreen_label],
@@ -607,6 +612,10 @@ impl MainMenu {
                     }
                     if label.starts_with("View Bobbing:") {
                         self.view_bobbing = !self.view_bobbing;
+                        self.save_settings();
+                    }
+                    if label.starts_with("VSync:") {
+                        self.vsync = !self.vsync;
                         self.save_settings();
                     }
                     if label.starts_with("Show Online Status:") {


### PR DESCRIPTION
Adds an on/off VSync toggle in Video Settings that switches the swapchain between Fifo (vsync on) and Mailbox/Immediate (vsync off). Persisted in options.json, default on. Closes #38.