### PR TITLE
Add Friends screen + menu/options fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -110,6 +110,7 @@ impl AppCore {
             &data_dirs.game_dir,
             Arc::clone(&tokio_rt),
             user.username.clone(),
+            user.access_token.clone(),
         );
 
         let asset_index =

--- a/pomme-client/src/app/phases/in_menu.rs
+++ b/pomme-client/src/app/phases/in_menu.rs
@@ -47,6 +47,13 @@ pub fn update_menu(
         }
     }
 
+    if core.menu.is_friends_screen() && core.menu.faces_changed() {
+        let faces = core.menu.collect_faces();
+        if !faces.is_empty() {
+            gfx.renderer.update_face_atlas(&faces);
+        }
+    }
+
     if let Err(e) = gfx.renderer.render_menu(
         &gfx.window,
         panorama.scroll(),

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1437,9 +1437,14 @@ impl Renderer {
                     .position(|e| matches!(e, MenuElement::BlurBackdrop));
                 let mut vbase = 0u32;
                 if let Some(i) = split {
-                    vbase = self
-                        .menu_pipeline
-                        .draw_from(cmd, sw, sh, &elements[..i], &item_atlas_uvs, 0);
+                    vbase = self.menu_pipeline.draw_from(
+                        cmd,
+                        sw,
+                        sh,
+                        &elements[..i],
+                        &item_atlas_uvs,
+                        0,
+                    );
                 }
 
                 if *blur > 0.01 {

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -162,6 +162,9 @@ impl Renderer {
             vsync,
             vk::SwapchainKHR::null(),
         )?;
+        // The swapchain may pick the surface's `current_extent` rather than the
+        // requested size; track that actual extent so layout matches rendering.
+        let swapchain_extent = swapchain_state.extent;
 
         let mut menu_pipeline = MenuOverlayPipeline::new(
             &ctx.device,
@@ -405,8 +408,8 @@ impl Renderer {
             render_finished_per_image,
             swapchain_dirty: false,
             vsync,
-            width: size.width.max(1),
-            height: size.height.max(1),
+            width: swapchain_extent.width,
+            height: swapchain_extent.height,
             last_timings: RenderTimings::default(),
         })
     }
@@ -604,6 +607,14 @@ impl Renderer {
         )?;
         std::mem::swap(&mut self.swapchain, &mut old_swapchain);
         old_swapchain.destroy(&self.ctx.device, &self.ctx.allocator);
+
+        // Adopt the swapchain's actual extent (may differ from the requested
+        // window size, e.g. macOS fullscreen) so the viewport, menu layout, blur,
+        // and camera aspect all agree — otherwise the image stretches/letterboxes.
+        self.width = self.swapchain.extent.width;
+        self.height = self.swapchain.extent.height;
+        self.camera
+            .set_aspect_ratio(self.width as f32 / self.height as f32);
 
         self.chunk_pipeline = ChunkPipeline::new(
             &self.ctx.device,
@@ -1004,6 +1015,12 @@ impl Renderer {
             &self.ctx.allocator,
             favicons,
         );
+    }
+
+    /// Friend faces reuse the favicon atlas — they're never shown on the same
+    /// screen as server favicons, so they share one string-keyed RGBA atlas.
+    pub fn update_face_atlas(&mut self, faces: &[(String, Vec<u8>, u32)]) {
+        self.update_favicon_atlas(faces);
     }
 
     pub fn menu_text_width(&self, text: &str, scale: f32) -> f32 {
@@ -1412,6 +1429,19 @@ impl Renderer {
                 self.panorama_pipeline
                     .draw(&self.ctx.device, cmd, *scroll, aspect, 0.0);
 
+                // A BlurBackdrop marker splits the elements: those before it are
+                // drawn into the scene so the blur pass captures them (the title
+                // screen behind the Friends dialog); the rest are drawn sharp.
+                let split = elements
+                    .iter()
+                    .position(|e| matches!(e, MenuElement::BlurBackdrop));
+                let mut vbase = 0u32;
+                if let Some(i) = split {
+                    vbase = self
+                        .menu_pipeline
+                        .draw_from(cmd, sw, sh, &elements[..i], &item_atlas_uvs, 0);
+                }
+
                 if *blur > 0.01 {
                     cmd.end_render_pass();
 
@@ -1456,8 +1486,12 @@ impl Renderer {
                     );
                 }
 
+                let fg = match split {
+                    Some(i) => &elements[i + 1..],
+                    None => &elements[..],
+                };
                 self.menu_pipeline
-                    .draw(cmd, sw, sh, elements, &item_atlas_uvs);
+                    .draw_from(cmd, sw, sh, fg, &item_atlas_uvs, vbase);
             }
         }
 
@@ -1565,7 +1599,7 @@ fn warm_item_meshes(
     }
 }
 
-async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32), String> {
+pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32), String> {
     #[derive(serde::Deserialize)]
     struct SessionProfile {
         properties: Vec<ProfileProperty>,

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -24,6 +24,9 @@ pub const ICON_GLOBE: char = '\u{f0ac}';
 pub const ICON_COMMENT: char = '\u{f075}';
 pub const ICON_CODE: char = '\u{f121}';
 pub const ICON_CHECK: char = '\u{f00c}';
+pub const ICON_USERS: char = '\u{f0c0}';
+pub const ICON_LANGUAGE: char = '\u{f1ab}';
+pub const ICON_UNIVERSAL_ACCESS: char = '\u{f29a}';
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
@@ -81,6 +84,9 @@ fn build_font_atlas() -> FontAtlas {
         ICON_COMMENT,
         ICON_CODE,
         ICON_CHECK,
+        ICON_USERS,
+        ICON_LANGUAGE,
+        ICON_UNIVERSAL_ACCESS,
     ]
     .iter()
     .map(|&ch| (ch, &icon_font))

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -619,9 +619,10 @@ impl MenuOverlayPipeline {
         self.draw_from(cmd, screen_w, screen_h, elements, item_atlas_uvs, 0);
     }
 
-    /// Like [`draw`], but writes vertices starting at `vertex_base` in the shared
-    /// vertex buffer and returns the next free index, so it can be called more
-    /// than once per frame (e.g. a backdrop before the blur and a dialog after).
+    /// Like [`draw`], but writes vertices starting at `vertex_base` in the
+    /// shared vertex buffer and returns the next free index, so it can be
+    /// called more than once per frame (e.g. a backdrop before the blur and
+    /// a dialog after).
     pub fn draw_from(
         &mut self,
         cmd: vk::CommandBuffer,

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -139,6 +139,37 @@ fn build_font_atlas() -> FontAtlas {
     FontAtlas { glyphs, pixels }
 }
 
+/// Extract an 8x8 RGBA player face (front face at (8,8) with the hat layer at
+/// (40,8) composited over it) from a wide player skin. `None` if the skin is
+/// too small. Shared by the Steve-head sprite and live friend faces.
+pub(crate) fn extract_face_8x8(rgba: &[u8], sw: u32, sh: u32) -> Option<Vec<u8>> {
+    // Skins are 64x64 (or 64x32 legacy); both have the face/hat in the top-left.
+    if sw < 48 || sh < 16 {
+        return None;
+    }
+    let mut out = vec![0u8; 8 * 8 * 4];
+    for y in 0..8u32 {
+        for x in 0..8u32 {
+            let face_off = (((8 + y) * sw + (8 + x)) * 4) as usize;
+            let dst = ((y * 8 + x) * 4) as usize;
+            out[dst..dst + 4].copy_from_slice(&rgba[face_off..face_off + 4]);
+            // Composite hat over face (ignore fully transparent hat pixels).
+            let hat_off = (((8 + y) * sw + (40 + x)) * 4) as usize;
+            let ha = rgba[hat_off + 3];
+            if ha > 0 {
+                let a = ha as f32 / 255.0;
+                for c in 0..3 {
+                    let fg = rgba[hat_off + c] as f32;
+                    let bg = out[dst + c] as f32;
+                    out[dst + c] = (fg * a + bg * (1.0 - a)) as u8;
+                }
+                out[dst + 3] = out[dst + 3].max(ha);
+            }
+        }
+    }
+    Some(out)
+}
+
 pub struct MenuOverlayPipeline {
     pipeline: vk::Pipeline,
     pipeline_layout: vk::PipelineLayout,
@@ -585,6 +616,21 @@ impl MenuOverlayPipeline {
         elements: &[MenuElement],
         item_atlas_uvs: &HashMap<String, [f32; 4]>,
     ) {
+        self.draw_from(cmd, screen_w, screen_h, elements, item_atlas_uvs, 0);
+    }
+
+    /// Like [`draw`], but writes vertices starting at `vertex_base` in the shared
+    /// vertex buffer and returns the next free index, so it can be called more
+    /// than once per frame (e.g. a backdrop before the blur and a dialog after).
+    pub fn draw_from(
+        &mut self,
+        cmd: vk::CommandBuffer,
+        screen_w: f32,
+        screen_h: f32,
+        elements: &[MenuElement],
+        item_atlas_uvs: &HashMap<String, [f32; 4]>,
+        vertex_base: u32,
+    ) -> u32 {
         let globals: [f32; 2] = [screen_w, screen_h];
         self.globals_allocation
             .as_mut()
@@ -841,41 +887,28 @@ impl MenuOverlayPipeline {
                     size,
                     address,
                 } => {
-                    if let Some([u0, v0, u1, v1]) = self.favicon_regions.get(address.as_str()) {
-                        push_quad(
-                            &mut vertices,
-                            *x,
-                            *y,
-                            *size,
-                            *size,
-                            *u0,
-                            *v0,
-                            *u1,
-                            *v1,
-                            [1.0, 1.0, 1.0, 1.0],
-                            6.0,
-                            [*size, *size],
-                            0.0,
-                        );
-                    } else if let Some(region) =
-                        self.sprite_atlas.regions.get(&SpriteId::UnknownServer)
-                    {
-                        push_quad(
-                            &mut vertices,
-                            *x,
-                            *y,
-                            *size,
-                            *size,
-                            region.u0,
-                            region.v0,
-                            region.u1,
-                            region.v1,
-                            [1.0, 1.0, 1.0, 1.0],
-                            2.0,
-                            [*size, *size],
-                            0.0,
-                        );
-                    }
+                    push_atlas_image(
+                        &mut vertices,
+                        &self.favicon_regions,
+                        &self.sprite_atlas,
+                        address,
+                        SpriteId::UnknownServer,
+                        *x,
+                        *y,
+                        *size,
+                    );
+                }
+                MenuElement::SkinFace { x, y, size, uuid } => {
+                    push_atlas_image(
+                        &mut vertices,
+                        &self.favicon_regions,
+                        &self.sprite_atlas,
+                        uuid,
+                        SpriteId::SteveHead,
+                        *x,
+                        *y,
+                        *size,
+                    );
                 }
                 _ => {}
             }
@@ -1054,19 +1087,24 @@ impl MenuOverlayPipeline {
         }
 
         if draw_ops.is_empty() {
-            return;
+            return vertex_base;
         }
 
-        if !vertices.is_empty() {
-            let count = vertices.len().min(MAX_VERTICES);
+        let written = if vertices.is_empty() {
+            0
+        } else {
+            let avail = MAX_VERTICES.saturating_sub(vertex_base as usize);
+            let count = vertices.len().min(avail);
             let byte_data = bytemuck::cast_slice(&vertices[..count]);
+            let byte_off = vertex_base as usize * VERTEX_SIZE;
             self.vertex_allocation
                 .as_mut()
                 .unwrap()
                 .mapped_slice_mut()
-                .unwrap()[..byte_data.len()]
+                .unwrap()[byte_off..byte_off + byte_data.len()]
                 .copy_from_slice(byte_data);
-        }
+            count
+        };
 
         let default_scissor = vk::Rect2D {
             offset: vk::Offset2D { x: 0, y: 0 },
@@ -1103,9 +1141,10 @@ impl MenuOverlayPipeline {
                 default_scissor
             };
             cmd.set_scissor(0, &[rect]);
-            cmd.draw(op.count, 1, op.start, 0);
+            cmd.draw(op.count, 1, vertex_base + op.start, 0);
         }
         cmd.set_scissor(0, &[default_scissor]);
+        vertex_base + written as u32
     }
 
     pub fn set_item_atlas(&self, device: &vk::Device, view: vk::ImageView, sampler: vk::Sampler) {
@@ -1458,6 +1497,18 @@ pub enum MenuElement {
         size: f32,
         address: String,
     },
+    /// A player's 8x8 skin face, looked up in the shared face/favicon atlas by
+    /// UUID; falls back to the default `SteveHead` sprite until it loads.
+    SkinFace {
+        x: f32,
+        y: f32,
+        size: f32,
+        uuid: String,
+    },
+    /// Split marker for the menu draw: elements before it are rendered into the
+    /// scene so the blur pass captures them; elements after are drawn sharp on
+    /// top. Used to render the title screen blurred behind the Friends dialog.
+    BlurBackdrop,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1556,6 +1607,16 @@ pub enum SpriteId {
     Incompatible,
     Unreachable,
     SteveHead,
+    FriendsBackground,
+    FriendsTab,
+    FriendsTabDisabled,
+    FriendsTabHighlighted,
+    FriendsIllustration,
+    FriendsSend,
+    FriendsRemove,
+    FriendsAccept,
+    FriendsReject,
+    FriendsCancel,
 }
 
 pub const CREATIVE_TAB_SPRITES: [[[SpriteId; 7]; 2]; 2] = [
@@ -1830,6 +1891,56 @@ fn build_sprite_atlas(
             1.0,
         ),
         (
+            SpriteId::FriendsBackground,
+            "minecraft/textures/gui/sprites/friends/background.png",
+            8.0,
+        ),
+        (
+            SpriteId::FriendsTab,
+            "minecraft/textures/gui/sprites/friends/button.png",
+            3.0,
+        ),
+        (
+            SpriteId::FriendsTabDisabled,
+            "minecraft/textures/gui/sprites/friends/button_disabled.png",
+            1.0,
+        ),
+        (
+            SpriteId::FriendsTabHighlighted,
+            "minecraft/textures/gui/sprites/friends/button_highlighted.png",
+            3.0,
+        ),
+        (
+            SpriteId::FriendsIllustration,
+            "minecraft/textures/gui/sprites/friends/illustrations_00.png",
+            0.0,
+        ),
+        (
+            SpriteId::FriendsSend,
+            "minecraft/textures/gui/sprites/friends/send_request.png",
+            0.0,
+        ),
+        (
+            SpriteId::FriendsRemove,
+            "minecraft/textures/gui/sprites/friends/remove.png",
+            0.0,
+        ),
+        (
+            SpriteId::FriendsAccept,
+            "minecraft/textures/gui/sprites/friends/accept.png",
+            0.0,
+        ),
+        (
+            SpriteId::FriendsReject,
+            "minecraft/textures/gui/sprites/friends/reject.png",
+            0.0,
+        ),
+        (
+            SpriteId::FriendsCancel,
+            "minecraft/textures/gui/sprites/friends/cancel.png",
+            0.0,
+        ),
+        (
             SpriteId::Ping1,
             "minecraft/textures/gui/sprites/icon/ping_1.png",
             0.0,
@@ -1967,35 +2078,12 @@ fn build_sprite_atlas(
     match crate::assets::load_image(&steve_path) {
         Ok(img) => {
             let rgba = img.to_rgba8();
-            let sw = rgba.width();
-            let sh = rgba.height();
-            // Skins are 64x64 (or 64x32 legacy). Face at (8,8), hat at (40,8).
-            if sw >= 48 && sh >= 16 {
-                let raw = rgba.as_raw();
-                let mut out = vec![0u8; 8 * 8 * 4];
-                for y in 0..8u32 {
-                    for x in 0..8u32 {
-                        let face_off = (((8 + y) * sw + (8 + x)) * 4) as usize;
-                        let dst = ((y * 8 + x) * 4) as usize;
-                        out[dst..dst + 4].copy_from_slice(&raw[face_off..face_off + 4]);
-                        // Composite hat over face (ignore fully transparent hat pixels).
-                        let hat_off = (((8 + y) * sw + (40 + x)) * 4) as usize;
-                        let ha = raw[hat_off + 3];
-                        if ha > 0 {
-                            let a = ha as f32 / 255.0;
-                            for c in 0..3 {
-                                let fg = raw[hat_off + c] as f32;
-                                let bg = out[dst + c] as f32;
-                                out[dst + c] = (fg * a + bg * (1.0 - a)) as u8;
-                            }
-                            out[dst + 3] = out[dst + 3].max(ha);
-                        }
-                    }
+            match extract_face_8x8(rgba.as_raw(), rgba.width(), rgba.height()) {
+                Some(out) => images.push((SpriteId::SteveHead, out, 8, 8, 0.0)),
+                None => {
+                    tracing::warn!("Steve skin too small: {}x{}", rgba.width(), rgba.height());
+                    images.push((SpriteId::SteveHead, vec![255, 0, 255, 255], 1, 1, 0.0));
                 }
-                images.push((SpriteId::SteveHead, out, 8, 8, 0.0));
-            } else {
-                tracing::warn!("Steve skin too small: {sw}x{sh}");
-                images.push((SpriteId::SteveHead, vec![255, 0, 255, 255], 1, 1, 0.0));
             }
         }
         Err(e) => {
@@ -2216,6 +2304,55 @@ fn blit_image(
                 dst[di..di + 4].copy_from_slice(&src[si..si + 4]);
             }
         }
+    }
+}
+
+/// Draw a quad from the string-keyed image atlas (favicons / friend faces),
+/// falling back to a sprite-atlas sprite when the key hasn't loaded yet.
+#[allow(clippy::too_many_arguments)]
+fn push_atlas_image(
+    verts: &mut Vec<Vertex>,
+    atlas_regions: &std::collections::HashMap<String, [f32; 4]>,
+    sprite_atlas: &SpriteAtlas,
+    key: &str,
+    fallback: SpriteId,
+    x: f32,
+    y: f32,
+    size: f32,
+) {
+    let white = [1.0, 1.0, 1.0, 1.0];
+    if let Some([u0, v0, u1, v1]) = atlas_regions.get(key) {
+        push_quad(
+            verts,
+            x,
+            y,
+            size,
+            size,
+            *u0,
+            *v0,
+            *u1,
+            *v1,
+            white,
+            6.0,
+            [size, size],
+            0.0,
+        );
+    } else if let Some(r) = sprite_atlas.regions.get(&fallback) {
+        push_quad(
+            verts,
+            x,
+            y,
+            size,
+            size,
+            r.u0,
+            r.v0,
+            r.u1,
+            r.v1,
+            white,
+            2.0,
+            [size, size],
+            0.0,
+        );
     }
 }
 

--- a/pomme-client/src/renderer/swapchain.rs
+++ b/pomme-client/src/renderer/swapchain.rs
@@ -71,6 +71,12 @@ impl Swapchain {
                 height: height.clamp(caps.min_image_extent.height, caps.max_image_extent.height),
             }
         };
+        // Guard against a degenerate (0,0) extent (e.g. a minimized window
+        // reporting current_extent = 0) so the aspect ratio stays finite.
+        let extent = vk::Extent2D {
+            width: extent.width.max(1),
+            height: extent.height.max(1),
+        };
 
         let image_count = (caps.min_image_count + 1).min(if caps.max_image_count == 0 {
             u32::MAX

--- a/pomme-client/src/renderer/swapchain.rs
+++ b/pomme-client/src/renderer/swapchain.rs
@@ -59,9 +59,17 @@ impl Swapchain {
             vk::PresentModeKHR::Fifo
         };
 
-        let extent = vk::Extent2D {
-            width: width.clamp(caps.min_image_extent.width, caps.max_image_extent.width),
-            height: height.clamp(caps.min_image_extent.height, caps.max_image_extent.height),
+        // Prefer the surface's reported drawable size: when `current_extent` is
+        // defined (not u32::MAX, as on macOS/MoltenVK), the Vulkan spec requires
+        // using it. Falling back to the window size here is what letterboxed the
+        // image in native fullscreen.
+        let extent = if caps.current_extent.width != u32::MAX {
+            caps.current_extent
+        } else {
+            vk::Extent2D {
+                width: width.clamp(caps.min_image_extent.width, caps.max_image_extent.width),
+                height: height.clamp(caps.min_image_extent.height, caps.max_image_extent.height),
+            }
         };
 
         let image_count = (caps.min_image_count + 1).min(if caps.max_image_count == 0 {

--- a/pomme-client/src/ui/death.rs
+++ b/pomme-client/src/ui/death.rs
@@ -44,8 +44,8 @@ pub fn build_death_screen(
     let title_fs = fs * 2.0;
     elements.push(MenuElement::Text {
         x: cx,
-        y: 60.0 * gs,
-        text: "You Died!".into(),
+        y: 30.0 * gs,
+        text: "You died!".into(),
         scale: title_fs,
         color: [1.0, 1.0, 1.0, 1.0],
         centered: true,

--- a/pomme-client/src/ui/friends.rs
+++ b/pomme-client/src/ui/friends.rs
@@ -1,0 +1,368 @@
+//! Client for the Minecraft friends API (read + write).
+//!
+//! Ported from the launcher's `friends.rs`. Reads the friends list + incoming/
+//! outgoing requests plus presence, and performs add/remove/accept/decline/
+//! cancel mutations. Results land in shared state via [`refresh_friends`] /
+//! [`friend_action`], mirroring the `ping_all_servers` / `PingResults` pattern.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+const FRIENDS_URL: &str = "https://api.minecraftservices.com/friends";
+const PRESENCE_URL: &str = "https://api.minecraftservices.com/presence";
+
+fn http() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+#[derive(Deserialize)]
+struct Friend {
+    #[serde(rename = "profileId")]
+    profile_id: String,
+    name: String,
+}
+
+#[derive(Deserialize, Default)]
+struct FriendsList {
+    #[serde(default)]
+    friends: Vec<Friend>,
+    #[serde(default, rename = "incomingRequests")]
+    incoming_requests: Vec<Friend>,
+    #[serde(default, rename = "outgoingRequests")]
+    outgoing_requests: Vec<Friend>,
+}
+
+#[derive(Deserialize)]
+struct PresenceEntry {
+    #[serde(rename = "profileId")]
+    profile_id: String,
+    status: String,
+}
+
+#[derive(Deserialize, Default)]
+struct PresenceResponse {
+    #[serde(default)]
+    presence: Vec<PresenceEntry>,
+}
+
+/// A friend's online status, resolved from the presence response. Mirrors the
+/// vanilla `gui.friends.presence.status.*` states.
+#[derive(Clone)]
+pub enum FriendStatus {
+    Offline,
+    Online,
+    PlayingOffline,
+    PlayingServer,
+}
+
+impl FriendStatus {
+    pub fn is_online(&self) -> bool {
+        !matches!(self, Self::Offline)
+    }
+}
+
+/// A list entry ready to display: name, UUID (for the skin face) and presence
+/// (only meaningful/rendered for confirmed friends, not requests).
+#[derive(Clone)]
+pub struct FriendView {
+    pub name: String,
+    pub uuid: String,
+    pub status: FriendStatus,
+}
+
+/// The three friends lists, ready to render.
+#[derive(Clone, Default)]
+pub struct FriendLists {
+    pub friends: Vec<FriendView>,
+    pub incoming: Vec<FriendView>,
+    pub outgoing: Vec<FriendView>,
+}
+
+/// Shared cache of fetched 8x8 faces, keyed by undashed UUID. Mirrors the
+/// `PingResults` favicon pattern; uploaded to the renderer face atlas.
+pub type FaceCache = Arc<RwLock<HashMap<String, Vec<u8>>>>;
+
+/// Last friend-mutation error, shown inline on the screen (vanilla uses
+/// toasts).
+pub type ActionError = Arc<RwLock<Option<String>>>;
+
+#[derive(Clone, Default)]
+pub enum FriendsState {
+    /// Never fetched (or no signed-in account).
+    #[default]
+    Idle,
+    Loading,
+    Loaded(FriendLists),
+    Failed(String),
+}
+
+pub type FriendsData = Arc<RwLock<FriendsState>>;
+
+#[derive(Clone, Copy)]
+pub enum UpdateType {
+    Add,
+    Remove,
+}
+
+impl UpdateType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "ADD",
+            Self::Remove => "REMOVE",
+        }
+    }
+}
+
+/// A friend mutation requested by the UI.
+pub enum FriendAction {
+    AddByName(String),
+    ById(String, UpdateType),
+}
+
+/// Set the shared state to `Loading` and spawn a fetch that resolves it to
+/// `Loaded`/`Failed`. Once loaded, spawn a skin fetch per uuid (friends and
+/// requests) that fills `faces`. Cheap to call again to refresh.
+pub fn refresh_friends(
+    rt: Arc<tokio::runtime::Runtime>,
+    access_token: String,
+    data: &FriendsData,
+    faces: &FaceCache,
+) {
+    *data.write() = FriendsState::Loading;
+    let data = Arc::clone(data);
+    let faces = Arc::clone(faces);
+    let spawn_rt = Arc::clone(&rt);
+    spawn_rt.spawn(async move {
+        match fetch(&access_token).await {
+            Ok(lists) => {
+                let uuids = lists
+                    .friends
+                    .iter()
+                    .chain(&lists.incoming)
+                    .chain(&lists.outgoing)
+                    .map(|f| f.uuid.clone());
+                for uuid in uuids {
+                    if uuid.is_empty() || faces.read().contains_key(&uuid) {
+                        continue;
+                    }
+                    let faces = Arc::clone(&faces);
+                    rt.spawn(async move {
+                        if let Ok((rgba, w, h)) = crate::renderer::fetch_skin_texture(&uuid).await
+                            && let Some(face) =
+                                crate::renderer::pipelines::menu_overlay::extract_face_8x8(
+                                    &rgba, w, h,
+                                )
+                        {
+                            faces.write().insert(uuid, face);
+                        }
+                    });
+                }
+                *data.write() = FriendsState::Loaded(lists);
+            }
+            Err(e) => *data.write() = FriendsState::Failed(e),
+        }
+    });
+}
+
+/// Perform a friend mutation, then re-fetch on success (so presence + new faces
+/// update). On failure, write the message into `err`.
+pub fn friend_action(
+    rt: Arc<tokio::runtime::Runtime>,
+    access_token: String,
+    action: FriendAction,
+    data: &FriendsData,
+    faces: &FaceCache,
+    err: &ActionError,
+) {
+    *err.write() = None;
+    let data = Arc::clone(data);
+    let faces = Arc::clone(faces);
+    let err = Arc::clone(err);
+    let spawn_rt = Arc::clone(&rt);
+    spawn_rt.spawn(async move {
+        let result = match &action {
+            FriendAction::AddByName(name) => {
+                action_by_name(&access_token, name, UpdateType::Add).await
+            }
+            FriendAction::ById(uuid, update) => action_by_id(&access_token, uuid, *update).await,
+        };
+        match result {
+            Ok(()) => refresh_friends(rt, access_token, &data, &faces),
+            Err(msg) => *err.write() = Some(msg),
+        }
+    });
+}
+
+async fn fetch(access_token: &str) -> Result<FriendLists, String> {
+    let list = get_friends(access_token).await?;
+    // Presence requires announcing our own status; the API returns friends'
+    // presence in the response. A failure here is non-fatal: show everyone
+    // offline rather than erroring out.
+    let presence = get_presence(access_token).await.unwrap_or_default();
+
+    let mut friends: Vec<FriendView> = list
+        .friends
+        .into_iter()
+        .map(|f| {
+            let status = presence
+                .get(&f.profile_id)
+                .cloned()
+                .unwrap_or(FriendStatus::Offline);
+            FriendView {
+                name: f.name,
+                uuid: f.profile_id,
+                status,
+            }
+        })
+        .collect();
+    // Online first, then alphabetical.
+    friends.sort_by(|a, b| {
+        b.status
+            .is_online()
+            .cmp(&a.status.is_online())
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+
+    Ok(FriendLists {
+        friends,
+        incoming: list
+            .incoming_requests
+            .into_iter()
+            .map(request_view)
+            .collect(),
+        outgoing: list
+            .outgoing_requests
+            .into_iter()
+            .map(request_view)
+            .collect(),
+    })
+}
+
+/// Requests carry no presence; render as offline (status isn't shown for them).
+fn request_view(f: Friend) -> FriendView {
+    FriendView {
+        name: f.name,
+        uuid: f.profile_id,
+        status: FriendStatus::Offline,
+    }
+}
+
+async fn get_friends(access_token: &str) -> Result<FriendsList, String> {
+    let resp = http()
+        .get(FRIENDS_URL)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| format!("Friends fetch failed: {e}"))?;
+    check_status(&resp, false)?;
+    resp.json()
+        .await
+        .map_err(|e| format!("Friends response parse failed: {e}"))
+}
+
+/// Posts our presence ("ONLINE", idle) and reads back friends' presence,
+/// returned keyed by undashed profile id.
+async fn get_presence(access_token: &str) -> Result<HashMap<String, FriendStatus>, String> {
+    let resp = http()
+        .post(PRESENCE_URL)
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({ "status": "ONLINE" }))
+        .send()
+        .await
+        .map_err(|e| format!("Presence post failed: {e}"))?;
+    check_status(&resp, false)?;
+    let parsed: PresenceResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Presence parse failed: {e}"))?;
+    Ok(parsed
+        .presence
+        .into_iter()
+        .map(|mut e| {
+            // /presence returns dashed UUIDs; /friends returns undashed.
+            e.profile_id.retain(|c| c != '-');
+            let status = match e.status.as_str() {
+                "ONLINE" => FriendStatus::Online,
+                "PLAYING_OFFLINE" => FriendStatus::PlayingOffline,
+                // PLAYING_SERVER / PLAYING_HOSTED_SERVER / PLAYING_REALMS
+                s if s.starts_with("PLAYING") => FriendStatus::PlayingServer,
+                _ => FriendStatus::Offline,
+            };
+            (e.profile_id, status)
+        })
+        .collect())
+}
+
+#[derive(Serialize)]
+struct FriendActionRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(rename = "profileId", skip_serializing_if = "Option::is_none")]
+    profile_id: Option<&'a str>,
+    #[serde(rename = "updateType")]
+    update_type: &'static str,
+}
+
+async fn action_by_id(
+    access_token: &str,
+    profile_id: &str,
+    action: UpdateType,
+) -> Result<(), String> {
+    put_action(
+        access_token,
+        FriendActionRequest {
+            name: None,
+            profile_id: Some(profile_id),
+            update_type: action.as_str(),
+        },
+        false,
+    )
+    .await
+}
+
+async fn action_by_name(access_token: &str, name: &str, action: UpdateType) -> Result<(), String> {
+    put_action(
+        access_token,
+        FriendActionRequest {
+            name: Some(name),
+            profile_id: None,
+            update_type: action.as_str(),
+        },
+        true,
+    )
+    .await
+}
+
+async fn put_action(
+    access_token: &str,
+    body: FriendActionRequest<'_>,
+    by_name: bool,
+) -> Result<(), String> {
+    let resp = http()
+        .put(FRIENDS_URL)
+        .bearer_auth(access_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Friend action failed: {e}"))?;
+    check_status(&resp, by_name)
+}
+
+fn check_status(resp: &reqwest::Response, by_name: bool) -> Result<(), String> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    Err(match status.as_u16() {
+        400 if by_name => "Unknown player name".to_string(),
+        401 => "Session expired — sign in again".to_string(),
+        403 => "Account has no active Java profile".to_string(),
+        429 => "Rate limited — try again shortly".to_string(),
+        s if s >= 500 => "Friends service unavailable, try again later".to_string(),
+        s => format!("Friends service returned HTTP {s}"),
+    })
+}

--- a/pomme-client/src/ui/menu/friends_screen.rs
+++ b/pomme-client/src/ui/menu/friends_screen.rs
@@ -1,0 +1,943 @@
+use super::*;
+use crate::ui::friends::{FriendAction, FriendLists, FriendStatus, FriendsState, UpdateType};
+
+// Vanilla friends-list status colors: green for any online/playing state, gray
+// for offline (gui.friends.presence.status.* uses -16711936 / -6250336).
+const STATUS_ONLINE: [f32; 4] = [0.0, 1.0, 0.0, 1.0];
+const STATUS_OFFLINE: [f32; 4] = [0.63, 0.63, 0.63, 1.0];
+const MSG_DIM: [f32; 4] = [0.667, 0.667, 0.667, 1.0]; // ChatFormatting.GRAY (0xAAAAAA)
+const TAB_DIM: [f32; 4] = [0.627, 0.627, 0.627, 1.0]; // -6250336 (0xFFA0A0A0)
+const ERR_COL: [f32; 4] = [0.88, 0.45, 0.45, 1.0];
+const BTN: f32 = 20.0; // vanilla per-row button size
+
+impl MainMenu {
+    #[allow(clippy::too_many_lines)]
+    pub(super) fn build_friends(
+        &mut self,
+        screen_w: f32,
+        screen_h: f32,
+        input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
+    ) -> MainMenuResult {
+        let gs = crate::ui::hud::gui_scale(screen_w, screen_h, self.gui_scale_setting);
+        let fs = common::FONT_SIZE * gs;
+        let cursor = input.cursor;
+        let clicked = input.clicked;
+
+        // Vanilla FriendsOverlayScreen geometry: a 220px-wide content block,
+        // height screen/gs - 80, CENTERED in the screen. An 8px background
+        // border is drawn around it; the 220x20 tab bar sits 7px above the
+        // content's top. Rows are 28px with a 24px face.
+        let content_w = 220.0 * gs; // OVERLAY_WIDTH
+        let border = 8.0 * gs; // BG_BORDER_WIDTH
+        let tab_h = 20.0 * gs; // TAB_BUTTON_HEIGHT
+        let tab_w = content_w / 2.0; // TAB_BUTTON_WIDTH = 110
+        let row_h = 28.0 * gs;
+        let face = 24.0 * gs;
+        let btn = BTN * gs;
+
+        // Cap height so the panel stays a dialog (not a tall strip) on big
+        // windows with a fixed GUI scale. 220 = content width; 280 keeps it ~1.27:1.
+        let content_h = (screen_h - 80.0 * gs).clamp(60.0 * gs, 280.0 * gs);
+        let content_x = (screen_w - content_w) / 2.0;
+        let content_y = (screen_h - content_h) / 2.0; // = 40*gs -> vertical centering
+
+        // Background frame = content plus the 8px border on every side.
+        let panel_x = content_x - border;
+        let panel_y = content_y - border;
+        let panel_w = content_w + border * 2.0;
+        let panel_h = content_h + border * 2.0 + gs; // vanilla draws bg height +1
+
+        // Tab bar: 7px above the content top.
+        let tab_y = content_y - tab_h - 7.0 * gs;
+
+        let on_friends = self.friend_tab == FriendTab::Friends;
+        if on_friends {
+            self.handle_text_input(input, 1);
+        }
+        let popup_open = self.pending_remove.is_some();
+
+        // Esc: close the popup, else blur a field, else leave the screen.
+        if input.escape {
+            if self.pending_remove.take().is_some() {
+                return empty_result(2.0);
+            }
+            if self.focused_field.take().is_none() {
+                self.set_screen(Screen::Main);
+                return empty_result(2.0);
+            }
+        }
+        // Click outside the panel closes (unless a popup is capturing input).
+        if !popup_open
+            && clicked
+            && !common::hit_test(cursor, [panel_x, tab_y, panel_w, (panel_y + panel_h) - tab_y])
+        {
+            self.set_screen(Screen::Main);
+            return empty_result(2.0);
+        }
+        if input.f5
+            && let Some(token) = self.access_token.clone()
+        {
+            self.refresh_friends_now(token);
+        }
+
+        let state = self.friends_data.read().clone();
+        let lists = match &state {
+            FriendsState::Loaded(l) => Some(l.clone()),
+            _ => None,
+        };
+        let incoming_count = lists.as_ref().map(|l| l.incoming.len()).unwrap_or(0);
+
+        // Vanilla renders Friends as a dialog over the previous screen. Re-draw
+        // the title screen as a static backdrop (neutral input → visuals only,
+        // no hover/click/actions); the renderer blurs it behind the panel.
+        let backdrop_input = MenuInput {
+            cursor: (-1.0, -1.0),
+            clicked: false,
+            mouse_held: false,
+            typed_chars: Vec::new(),
+            backspace: false,
+            enter: false,
+            escape: false,
+            tab: false,
+            f5: false,
+            select_all: false,
+            copy: false,
+            cut: false,
+            undo: false,
+            scroll_delta: 0.0,
+        };
+        let mut elements = self
+            .build_main(screen_w, screen_h, &backdrop_input, text_width_fn)
+            .elements;
+        // Everything above is the title-screen backdrop; the marker tells the
+        // renderer to draw it into the scene and blur it. A full-screen frosted
+        // quad then paints that blurred title screen, with the dialog on top.
+        elements.push(MenuElement::BlurBackdrop);
+        elements.push(MenuElement::FrostedRect {
+            x: 0.0,
+            y: 0.0,
+            w: screen_w,
+            h: screen_h,
+            corner_radius: 0.0,
+            tint: [0.6, 0.6, 0.65, 1.0],
+        });
+
+        // --- Tab bar (both clickable) ---
+        let tabs = [
+            (content_x, FriendTab::Friends, "Friends".to_string()),
+            (
+                content_x + tab_w,
+                FriendTab::Requests,
+                format!("Requests ({incoming_count})"),
+            ),
+        ];
+        for (tx, tab, label) in &tabs {
+            let active = self.friend_tab == *tab;
+            let hovered = !popup_open && common::hit_test(cursor, [*tx, tab_y, tab_w, tab_h]);
+            // Vanilla FriendsOverlayTabButton sprite + its .mcmeta nine-slice border.
+            let (sprite, tab_border) = if active {
+                (SpriteId::FriendsTab, 3.0)
+            } else if hovered {
+                (SpriteId::FriendsTabHighlighted, 3.0)
+            } else {
+                (SpriteId::FriendsTabDisabled, 1.0)
+            };
+            nine_slice(&mut elements, *tx, tab_y, tab_w, tab_h, sprite, tab_border * gs);
+            elements.push(MenuElement::Text {
+                x: tx + tab_w / 2.0,
+                y: tab_y + (tab_h - fs) / 2.0,
+                text: label.clone(),
+                scale: fs,
+                color: if active { WHITE } else { TAB_DIM },
+                centered: true,
+            });
+            if active {
+                // Vanilla renderFocusUnderline: 1px tall, label width (capped at
+                // tab_w-4), centered, 2px above the tab bottom.
+                let uw = text_width_fn(label, fs).min(tab_w - 4.0 * gs);
+                elements.push(MenuElement::Rect {
+                    x: tx + (tab_w - uw) / 2.0,
+                    y: tab_y + tab_h - 2.0 * gs,
+                    w: uw,
+                    h: gs,
+                    corner_radius: 0.0,
+                    color: WHITE,
+                });
+            }
+            if !active && clicked && hovered {
+                self.friend_tab = *tab;
+                self.scroll_offset = 0.0;
+                self.focused_field = None;
+            }
+        }
+
+        nine_slice(
+            &mut elements,
+            panel_x,
+            panel_y,
+            panel_w,
+            panel_h,
+            SpriteId::FriendsBackground,
+            border,
+        );
+
+        // --- Body ---
+        match (lists, self.friend_tab) {
+            (Some(lists), FriendTab::Friends) => self.friends_body(
+                &mut elements,
+                input,
+                text_width_fn,
+                &lists,
+                popup_open,
+                screen_w,
+                screen_h,
+                (content_x, content_y, content_w, content_h),
+                (gs, fs, row_h, face, btn),
+            ),
+            (Some(lists), FriendTab::Requests) => self.requests_body(
+                &mut elements,
+                input,
+                text_width_fn,
+                &lists,
+                popup_open,
+                screen_w,
+                screen_h,
+                (content_x, content_y, content_w, content_h),
+                (gs, fs, row_h, face, btn),
+            ),
+            (None, _) => {
+                let msg = match &state {
+                    FriendsState::Failed(e) => (e.as_str(), ERR_COL),
+                    _ => ("Loading friends…", MSG_DIM),
+                };
+                push_centered(
+                    &mut elements,
+                    panel_x + panel_w / 2.0,
+                    content_y + (content_h - fs) / 2.0,
+                    fs,
+                    msg.0,
+                    msg.1,
+                );
+            }
+        }
+
+        // --- Remove-confirm popup (drawn over everything) ---
+        if let Some((uuid, name)) = self.pending_remove.clone() {
+            let pw = 240.0 * gs;
+            let ph = 90.0 * gs;
+            let px = (screen_w - pw) / 2.0;
+            let py = (screen_h - ph) / 2.0;
+            elements.push(MenuElement::FrostedRect {
+                x: px,
+                y: py,
+                w: pw,
+                h: ph,
+                corner_radius: 6.0 * gs,
+                tint: [0.05, 0.05, 0.1, 0.95],
+            });
+            push_centered(
+                &mut elements,
+                screen_w / 2.0,
+                py + 12.0 * gs,
+                fs,
+                &format!("Remove {name}?"),
+                WHITE,
+            );
+            // Vanilla FriendsListConfirmScreen has a message body under the title.
+            push_centered(
+                &mut elements,
+                screen_w / 2.0,
+                py + 12.0 * gs + fs + 6.0 * gs,
+                fs,
+                "Are you sure you want to remove them?",
+                MSG_DIM,
+            );
+            let bw = 84.0 * gs;
+            let bh = common::BTN_H * gs;
+            let by = py + ph - bh - 10.0 * gs;
+            if common::push_button(
+                &mut elements,
+                cursor,
+                px + 12.0 * gs,
+                by,
+                bw,
+                bh,
+                gs,
+                fs,
+                "Remove",
+                true,
+            ) && clicked
+            {
+                self.pending_remove = None;
+                self.friend_mutate(FriendAction::ById(uuid, UpdateType::Remove));
+            }
+            if common::push_button(
+                &mut elements,
+                cursor,
+                px + pw - bw - 12.0 * gs,
+                by,
+                bw,
+                bh,
+                gs,
+                fs,
+                "Cancel",
+                true,
+            ) && clicked
+            {
+                self.pending_remove = None;
+            }
+        }
+
+        MainMenuResult {
+            elements,
+            action: MenuAction::None,
+            cursor_pointer: false,
+            blur: 1.0,
+            clicked_button: false,
+        }
+    }
+
+    /// Friends tab: add-friend box + send, optional error line, then the list
+    /// with per-row remove buttons.
+    #[allow(clippy::too_many_arguments)]
+    fn friends_body(
+        &mut self,
+        elements: &mut Vec<MenuElement>,
+        input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        lists: &FriendLists,
+        popup_open: bool,
+        screen_w: f32,
+        screen_h: f32,
+        (content_x, content_y, content_w, content_h): (f32, f32, f32, f32),
+        (gs, fs, row_h, face, btn): (f32, f32, f32, f32, f32),
+    ) {
+        let cursor = input.cursor;
+        let clicked = input.clicked && !popup_open;
+        let field_h = FIELD_H * gs;
+
+        let (lx, lw) = content_inset(content_x, content_w, gs);
+
+        // Add-friend row — vanilla AddFriendWidget: 3px top pad, editbox
+        // `lw - 20(button) - 3(gap)`, 20px send button flush right.
+        let field_y = content_y + 3.0 * gs;
+        let field_w = lw - 23.0 * gs;
+        push_text_field(
+            elements,
+            lx,
+            field_y,
+            field_w,
+            field_h,
+            fs,
+            gs,
+            &self.add_friend_name,
+            self.focused_field == Some(0),
+            self.focused_field == Some(0) && self.field_all_selected,
+            &self.cursor_blink,
+            text_width_fn,
+        );
+        if self.add_friend_name.is_empty() {
+            elements.push(MenuElement::Text {
+                x: lx + 4.0 * gs,
+                y: field_y + (field_h - fs) / 2.0,
+                text: "Enter Profile Name".into(),
+                scale: fs,
+                color: MSG_DIM,
+                centered: false,
+            });
+        }
+        if clicked && common::hit_test(cursor, [lx, field_y, field_w, field_h]) {
+            self.on_field_click(0);
+        }
+        let send_hit = icon_button(
+            elements,
+            cursor,
+            lx + lw - btn,
+            field_y,
+            btn,
+            gs,
+            SpriteId::FriendsSend,
+            15.0,
+            15.0,
+            screen_w,
+            screen_h,
+            "Send request",
+        );
+        let submit = (clicked && send_hit) || (self.focused_field == Some(0) && input.enter);
+        if submit {
+            let name = self.add_friend_name.trim().to_string();
+            if !name.is_empty() {
+                self.add_friend_name.clear();
+                self.friend_mutate(FriendAction::AddByName(name));
+            }
+        }
+
+        // Profile row (input 3+20 + 6px margin) then separator (+ profile 9 + 4).
+        let label = "My profile name: ";
+        let profile_y = content_y + 29.0 * gs;
+        elements.push(MenuElement::Text {
+            x: lx,
+            y: profile_y,
+            text: label.into(),
+            scale: fs,
+            color: TAB_DIM, // vanilla PROFILE_NAME_LABEL = -6250336
+            centered: false,
+        });
+        let name_x = lx + text_width_fn(label, fs);
+        elements.push(MenuElement::Text {
+            x: name_x,
+            y: profile_y,
+            text: self.username.clone(),
+            scale: fs,
+            color: WHITE,
+            centered: false,
+        });
+        // Vanilla: the profile name is a button that copies to clipboard (with tooltip).
+        let name_w = text_width_fn(&self.username, fs);
+        if common::hit_test(cursor, [name_x, profile_y, name_w, fs]) {
+            common::push_tooltip(elements, cursor, screen_w, screen_h, gs, "Copy to clipboard");
+            if clicked {
+                super::servers::write_clipboard(&self.username);
+            }
+        }
+        push_separator(
+            elements,
+            content_x,
+            content_y + 42.0 * gs,
+            content_w,
+            2.0 * gs,
+        );
+
+        // List starts just below the separator; an error line (if any) slots in
+        // first so the normal layout stays pixel-exact.
+        let mut list_top = content_y + 44.0 * gs;
+        if let Some(err) = self.action_error.read().clone() {
+            elements.push(MenuElement::Text {
+                x: lx,
+                y: list_top,
+                text: err,
+                scale: fs,
+                color: ERR_COL,
+                centered: false,
+            });
+            list_top += fs + 2.0 * gs;
+        }
+        let list_h = content_y + content_h - list_top;
+
+        if lists.friends.is_empty() {
+            // Vanilla showEmpty: 128x48 illustration above the text, 8px gap, centered.
+            let illo_w = 128.0 * gs;
+            let illo_h = 48.0 * gs;
+            let gap = 8.0 * gs;
+            let group_top = list_top + (list_h - (illo_h + gap + fs)) / 2.0;
+            elements.push(MenuElement::Image {
+                x: content_x + (content_w - illo_w) / 2.0,
+                y: group_top,
+                w: illo_w,
+                h: illo_h,
+                sprite: SpriteId::FriendsIllustration,
+                tint: WHITE,
+            });
+            push_centered(
+                elements,
+                content_x + content_w / 2.0,
+                group_top + illo_h + gap,
+                fs,
+                "No friends yet — add one above",
+                MSG_DIM,
+            );
+            return;
+        }
+
+        let n = lists.friends.len() as f32;
+        // Vanilla appends a centered "manage account" footer below the list.
+        let footer_pad = 8.0 * gs;
+        let total = n * row_h + footer_pad + fs;
+        self.scroll_region(input, [content_x, list_top, content_w, list_h], total, gs);
+
+        elements.push(MenuElement::ScissorPush {
+            x: content_x,
+            y: list_top,
+            w: content_w,
+            h: list_h,
+        });
+        for (i, friend) in lists.friends.iter().enumerate() {
+            let ey = list_top + i as f32 * row_h - self.scroll_offset;
+            if ey + row_h < list_top || ey > list_top + list_h {
+                continue;
+            }
+            push_face_name(
+                elements,
+                gs,
+                fs,
+                lx,
+                ey,
+                row_h,
+                face,
+                &friend.uuid,
+                &friend.name,
+                Some(&friend.status),
+            );
+            let bx = lx + lw - btn;
+            if icon_button(
+                elements,
+                cursor,
+                bx,
+                ey + (row_h - btn) / 2.0,
+                btn,
+                gs,
+                SpriteId::FriendsRemove,
+                13.0,
+                11.0,
+                screen_w,
+                screen_h,
+                "Unfriend",
+            ) && clicked
+            {
+                self.pending_remove = Some((friend.uuid.clone(), friend.name.clone()));
+            }
+        }
+        let footer_y = list_top + n * row_h - self.scroll_offset + footer_pad;
+        if footer_y + fs >= list_top && footer_y <= list_top + list_h {
+            push_centered(
+                elements,
+                content_x + content_w / 2.0,
+                footer_y,
+                fs,
+                "Manage your account at minecraft.net",
+                MSG_DIM,
+            );
+        }
+        elements.push(MenuElement::ScissorPop);
+        push_scrollbar(
+            elements,
+            content_x + content_w,
+            list_top,
+            list_h,
+            total,
+            self.scroll_offset,
+            gs,
+        );
+    }
+
+    /// Requests tab: "Received" (accept/decline) then "Sent" (cancel).
+    #[allow(clippy::too_many_arguments)]
+    fn requests_body(
+        &mut self,
+        elements: &mut Vec<MenuElement>,
+        input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        lists: &FriendLists,
+        popup_open: bool,
+        screen_w: f32,
+        screen_h: f32,
+        (content_x, content_y, content_w, content_h): (f32, f32, f32, f32),
+        (gs, fs, row_h, face, btn): (f32, f32, f32, f32, f32),
+    ) {
+        let cursor = input.cursor;
+        let clicked = input.clicked && !popup_open;
+        let (lx, lw) = content_inset(content_x, content_w, gs);
+
+        if lists.incoming.is_empty() && lists.outgoing.is_empty() {
+            push_centered(
+                elements,
+                content_x + content_w / 2.0,
+                content_y + (content_h - fs) / 2.0,
+                fs,
+                "No pending requests",
+                MSG_DIM,
+            );
+            return;
+        }
+
+        let header_h = fs + 6.0 * gs;
+        let section_h = |list: &[_]| {
+            if list.is_empty() {
+                0.0
+            } else {
+                header_h + list.len() as f32 * row_h
+            }
+        };
+        let total = section_h(&lists.incoming) + section_h(&lists.outgoing);
+        self.scroll_region(
+            input,
+            [content_x, content_y, content_w, content_h],
+            total,
+            gs,
+        );
+
+        elements.push(MenuElement::ScissorPush {
+            x: content_x,
+            y: content_y,
+            w: content_w,
+            h: content_h,
+        });
+        let mut y = content_y - self.scroll_offset;
+        let visible = |ey: f32| ey + row_h >= content_y && ey <= content_y + content_h;
+
+        // Incoming: accept (left) + reject (right).
+        if !lists.incoming.is_empty() {
+            push_section_header(elements, text_width_fn, content_x, content_w, y, fs, gs, "Received");
+            y += header_h;
+            for req in &lists.incoming {
+                if visible(y) {
+                    push_face_name(
+                        elements, gs, fs, lx, y, row_h, face, &req.uuid, &req.name, None,
+                    );
+                    let reject_x = lx + lw - btn;
+                    let accept_x = reject_x - btn - 4.0 * gs;
+                    let by = y + (row_h - btn) / 2.0;
+                    if icon_button(
+                        elements,
+                        cursor,
+                        accept_x,
+                        by,
+                        btn,
+                        gs,
+                        SpriteId::FriendsAccept,
+                        18.0,
+                        18.0,
+                        screen_w,
+                        screen_h,
+                        "Accept",
+                    ) && clicked
+                    {
+                        self.friend_mutate(FriendAction::ById(req.uuid.clone(), UpdateType::Add));
+                    }
+                    if icon_button(
+                        elements,
+                        cursor,
+                        reject_x,
+                        by,
+                        btn,
+                        gs,
+                        SpriteId::FriendsReject,
+                        18.0,
+                        18.0,
+                        screen_w,
+                        screen_h,
+                        "Decline",
+                    ) && clicked
+                    {
+                        self.friend_mutate(FriendAction::ById(
+                            req.uuid.clone(),
+                            UpdateType::Remove,
+                        ));
+                    }
+                }
+                y += row_h;
+            }
+        }
+        // Outgoing: cancel (right).
+        if !lists.outgoing.is_empty() {
+            push_section_header(elements, text_width_fn, content_x, content_w, y, fs, gs, "Sent");
+            y += header_h;
+            for req in &lists.outgoing {
+                if visible(y) {
+                    push_face_name(
+                        elements, gs, fs, lx, y, row_h, face, &req.uuid, &req.name, None,
+                    );
+                    let by = y + (row_h - btn) / 2.0;
+                    if icon_button(
+                        elements,
+                        cursor,
+                        lx + lw - btn,
+                        by,
+                        btn,
+                        gs,
+                        SpriteId::FriendsCancel,
+                        12.0,
+                        12.0,
+                        screen_w,
+                        screen_h,
+                        "Cancel request",
+                    ) && clicked
+                    {
+                        self.friend_mutate(FriendAction::ById(
+                            req.uuid.clone(),
+                            UpdateType::Remove,
+                        ));
+                    }
+                }
+                y += row_h;
+            }
+        }
+        elements.push(MenuElement::ScissorPop);
+        push_scrollbar(
+            elements,
+            content_x + content_w,
+            content_y,
+            content_h,
+            total,
+            self.scroll_offset,
+            gs,
+        );
+    }
+
+    /// Apply mouse-wheel scrolling within `area`, clamp the offset, and return
+    /// the right-edge gutter to reserve for the scrollbar (0 when it all fits).
+    fn scroll_region(&mut self, input: &MenuInput, area: [f32; 4], total: f32, gs: f32) -> f32 {
+        let max_scroll = (total - area[3]).max(0.0);
+        if common::hit_test(input.cursor, area) {
+            self.scroll_offset -= input.scroll_delta * 20.0 * gs;
+        }
+        self.scroll_offset = self.scroll_offset.clamp(0.0, max_scroll);
+        if max_scroll > 0.0 { 8.0 * gs } else { 0.0 }
+    }
+
+    fn friend_mutate(&mut self, action: FriendAction) {
+        if let Some(token) = self.access_token.clone() {
+            friends::friend_action(
+                std::sync::Arc::clone(&self.rt),
+                token,
+                action,
+                &self.friends_data,
+                &self.face_cache,
+                &self.action_error,
+            );
+        }
+    }
+
+    fn refresh_friends_now(&mut self, token: String) {
+        friends::refresh_friends(
+            std::sync::Arc::clone(&self.rt),
+            token,
+            &self.friends_data,
+            &self.face_cache,
+        );
+    }
+}
+
+fn nine_slice(
+    elements: &mut Vec<MenuElement>,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    sprite: SpriteId,
+    border: f32,
+) {
+    elements.push(MenuElement::NineSlice {
+        x,
+        y,
+        w,
+        h,
+        sprite,
+        border,
+        tint: WHITE,
+    });
+}
+
+/// A 20×20 sprite button with a faint hover highlight; returns whether hovered.
+/// Vanilla `SpriteIconButton`: a widget-button background with the icon
+/// centered at its native size (`iw`×`ih` source pixels), not stretched to the
+/// button.
+#[allow(clippy::too_many_arguments)]
+fn icon_button(
+    elements: &mut Vec<MenuElement>,
+    cursor: (f32, f32),
+    x: f32,
+    y: f32,
+    size: f32,
+    gs: f32,
+    sprite: SpriteId,
+    iw: f32,
+    ih: f32,
+    screen_w: f32,
+    screen_h: f32,
+    tooltip: &str,
+) -> bool {
+    let hovered = common::hit_test(cursor, [x, y, size, size]);
+    nine_slice(
+        elements,
+        x,
+        y,
+        size,
+        size,
+        if hovered {
+            SpriteId::ButtonHover
+        } else {
+            SpriteId::ButtonNormal
+        },
+        3.0 * gs,
+    );
+    let (icon_w, icon_h) = (iw * gs, ih * gs);
+    elements.push(MenuElement::Image {
+        x: x + (size - icon_w) / 2.0,
+        y: y + (size - icon_h) / 2.0,
+        w: icon_w,
+        h: icon_h,
+        sprite,
+        tint: WHITE,
+    });
+    if hovered && !tooltip.is_empty() {
+        common::push_tooltip(elements, cursor, screen_w, screen_h, gs, tooltip);
+    }
+    hovered
+}
+
+/// Face + name; with `status` it's a two-line row, without it the name is
+/// vertically centered (used for requests, which carry no presence).
+#[allow(clippy::too_many_arguments)]
+fn push_face_name(
+    elements: &mut Vec<MenuElement>,
+    gs: f32,
+    fs: f32,
+    content_x: f32,
+    ey: f32,
+    row_h: f32,
+    face: f32,
+    uuid: &str,
+    name: &str,
+    status: Option<&FriendStatus>,
+) {
+    elements.push(MenuElement::SkinFace {
+        x: content_x,
+        y: ey + (row_h - face) / 2.0,
+        size: face,
+        uuid: uuid.into(),
+    });
+    let text_x = content_x + face + 4.0 * gs;
+    match status {
+        Some(s) => {
+            // Vanilla: name at row_h/3 (centered on the glyph), status below it.
+            let name_y = ey + row_h / 3.0 - fs / 2.0;
+            elements.push(MenuElement::Text {
+                x: text_x,
+                y: name_y,
+                text: name.into(),
+                scale: fs,
+                color: WHITE,
+                centered: false,
+            });
+            let (label, color) = status_label(s);
+            elements.push(MenuElement::Text {
+                x: text_x,
+                y: name_y + fs + 2.0 * gs,
+                text: label.into(),
+                scale: fs,
+                color,
+                centered: false,
+            });
+        }
+        None => elements.push(MenuElement::Text {
+            x: text_x,
+            y: ey + (row_h - fs) / 2.0,
+            text: name.into(),
+            scale: fs,
+            color: WHITE,
+            centered: false,
+        }),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_section_header(
+    elements: &mut Vec<MenuElement>,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
+    content_x: f32,
+    content_w: f32,
+    y: f32,
+    fs: f32,
+    gs: f32,
+    text: &str,
+) {
+    // Vanilla RECEIVED/SENT headers: white, BOLD + UNDERLINE, centered.
+    let cx = content_x + content_w / 2.0;
+    let ty = y + 3.0 * gs;
+    // Faux-bold: draw twice, second offset 1px in x (MC's bold overdraw).
+    for dx in [0.0, gs] {
+        elements.push(MenuElement::Text {
+            x: cx + dx,
+            y: ty,
+            text: text.into(),
+            scale: fs,
+            color: WHITE,
+            centered: true,
+        });
+    }
+    let tw = text_width_fn(text, fs) + gs; // +1px for the bold overdraw
+    elements.push(MenuElement::Rect {
+        x: cx - tw / 2.0,
+        y: ty + fs + gs,
+        w: tw,
+        h: gs,
+        corner_radius: 0.0,
+        color: WHITE,
+    });
+}
+
+fn push_scrollbar(
+    elements: &mut Vec<MenuElement>,
+    right_x: f32,
+    top: f32,
+    h: f32,
+    total: f32,
+    scroll: f32,
+    gs: f32,
+) {
+    let max_scroll = (total - h).max(0.0);
+    if max_scroll <= 0.0 {
+        return;
+    }
+    // 6px track, inset 2px from the content's right edge (vanilla spacing).
+    let track_w = 6.0 * gs;
+    let track_x = right_x - track_w - 2.0 * gs;
+    let thumb_h = (h * h / total).max(16.0 * gs); // vanilla min thumb is larger
+    let thumb_y = top + (scroll / max_scroll) * (h - thumb_h);
+    nine_slice(
+        elements,
+        track_x,
+        top,
+        track_w,
+        h,
+        SpriteId::ScrollerBackground,
+        gs,
+    );
+    nine_slice(
+        elements,
+        track_x,
+        thumb_y,
+        track_w,
+        thumb_h,
+        SpriteId::Scroller,
+        gs,
+    );
+}
+
+/// Vanilla `gui.friends.presence.status.*` label + color for a friend.
+fn status_label(status: &FriendStatus) -> (&'static str, [f32; 4]) {
+    match status {
+        FriendStatus::Online => ("Online", STATUS_ONLINE),
+        FriendStatus::PlayingOffline => ("Playing offline", STATUS_ONLINE),
+        FriendStatus::PlayingServer => ("Playing on a server", STATUS_ONLINE),
+        FriendStatus::Offline => ("Offline", STATUS_OFFLINE),
+    }
+}
+
+/// Vanilla insets the input/profile rows and list entries 8px from the content's
+/// left edge (paddingLeft 8; getListContentWidth = w - 16), leaving the right
+/// margin for the scrollbar. Returns `(left x, usable width)`.
+fn content_inset(content_x: f32, content_w: f32, gs: f32) -> (f32, f32) {
+    let inset = 8.0 * gs;
+    (content_x + inset, content_w - inset * 2.0)
+}
+
+fn push_centered(
+    elements: &mut Vec<MenuElement>,
+    cx: f32,
+    y: f32,
+    fs: f32,
+    text: &str,
+    color: [f32; 4],
+) {
+    elements.push(MenuElement::Text {
+        x: cx,
+        y,
+        text: text.into(),
+        scale: fs,
+        color,
+        centered: true,
+    });
+}

--- a/pomme-client/src/ui/menu/friends_screen.rs
+++ b/pomme-client/src/ui/menu/friends_screen.rs
@@ -4,7 +4,7 @@ use crate::ui::friends::{FriendAction, FriendLists, FriendStatus, FriendsState, 
 // Vanilla friends-list status colors: green for any online/playing state, gray
 // for offline (gui.friends.presence.status.* uses -16711936 / -6250336).
 const STATUS_ONLINE: [f32; 4] = [0.0, 1.0, 0.0, 1.0];
-const STATUS_OFFLINE: [f32; 4] = [0.63, 0.63, 0.63, 1.0];
+const STATUS_OFFLINE: [f32; 4] = [0.627, 0.627, 0.627, 1.0]; // -6250336 (0xFFA0A0A0)
 const MSG_DIM: [f32; 4] = [0.667, 0.667, 0.667, 1.0]; // ChatFormatting.GRAY (0xAAAAAA)
 const TAB_DIM: [f32; 4] = [0.627, 0.627, 0.627, 1.0]; // -6250336 (0xFFA0A0A0)
 const ERR_COL: [f32; 4] = [0.88, 0.45, 0.45, 1.0];
@@ -70,15 +70,16 @@ impl MainMenu {
         // Click outside the panel closes (unless a popup is capturing input).
         if !popup_open
             && clicked
-            && !common::hit_test(cursor, [panel_x, tab_y, panel_w, (panel_y + panel_h) - tab_y])
+            && !common::hit_test(
+                cursor,
+                [panel_x, tab_y, panel_w, (panel_y + panel_h) - tab_y],
+            )
         {
             self.set_screen(Screen::Main);
             return empty_result(2.0);
         }
-        if input.f5
-            && let Some(token) = self.access_token.clone()
-        {
-            self.refresh_friends_now(token);
+        if input.f5 {
+            self.refresh_friends_now();
         }
 
         let state = self.friends_data.read().clone();
@@ -143,7 +144,15 @@ impl MainMenu {
             } else {
                 (SpriteId::FriendsTabDisabled, 1.0)
             };
-            nine_slice(&mut elements, *tx, tab_y, tab_w, tab_h, sprite, tab_border * gs);
+            nine_slice(
+                &mut elements,
+                *tx,
+                tab_y,
+                tab_w,
+                tab_h,
+                sprite,
+                tab_border * gs,
+            );
             elements.push(MenuElement::Text {
                 x: tx + tab_w / 2.0,
                 y: tab_y + (tab_h - fs) / 2.0,
@@ -393,10 +402,18 @@ impl MainMenu {
             color: WHITE,
             centered: false,
         });
-        // Vanilla: the profile name is a button that copies to clipboard (with tooltip).
+        // Vanilla: the profile name is a button that copies to clipboard (with
+        // tooltip).
         let name_w = text_width_fn(&self.username, fs);
         if common::hit_test(cursor, [name_x, profile_y, name_w, fs]) {
-            common::push_tooltip(elements, cursor, screen_w, screen_h, gs, "Copy to clipboard");
+            common::push_tooltip(
+                elements,
+                cursor,
+                screen_w,
+                screen_h,
+                gs,
+                "Copy to clipboard",
+            );
             if clicked {
                 super::servers::write_clipboard(&self.username);
             }
@@ -578,7 +595,16 @@ impl MainMenu {
 
         // Incoming: accept (left) + reject (right).
         if !lists.incoming.is_empty() {
-            push_section_header(elements, text_width_fn, content_x, content_w, y, fs, gs, "Received");
+            push_section_header(
+                elements,
+                text_width_fn,
+                content_x,
+                content_w,
+                y,
+                fs,
+                gs,
+                "Received",
+            );
             y += header_h;
             for req in &lists.incoming {
                 if visible(y) {
@@ -631,7 +657,16 @@ impl MainMenu {
         }
         // Outgoing: cancel (right).
         if !lists.outgoing.is_empty() {
-            push_section_header(elements, text_width_fn, content_x, content_w, y, fs, gs, "Sent");
+            push_section_header(
+                elements,
+                text_width_fn,
+                content_x,
+                content_w,
+                y,
+                fs,
+                gs,
+                "Sent",
+            );
             y += header_h;
             for req in &lists.outgoing {
                 if visible(y) {
@@ -699,13 +734,16 @@ impl MainMenu {
         }
     }
 
-    fn refresh_friends_now(&mut self, token: String) {
-        friends::refresh_friends(
-            std::sync::Arc::clone(&self.rt),
-            token,
-            &self.friends_data,
-            &self.face_cache,
-        );
+    /// Re-fetch the friends list + faces (no-op without a signed-in account).
+    pub(super) fn refresh_friends_now(&mut self) {
+        if let Some(token) = self.access_token.clone() {
+            friends::refresh_friends(
+                std::sync::Arc::clone(&self.rt),
+                token,
+                &self.friends_data,
+                &self.face_cache,
+            );
+        }
     }
 }
 
@@ -916,9 +954,9 @@ fn status_label(status: &FriendStatus) -> (&'static str, [f32; 4]) {
     }
 }
 
-/// Vanilla insets the input/profile rows and list entries 8px from the content's
-/// left edge (paddingLeft 8; getListContentWidth = w - 16), leaving the right
-/// margin for the scrollbar. Returns `(left x, usable width)`.
+/// Vanilla insets the input/profile rows and list entries 8px from the
+/// content's left edge (paddingLeft 8; getListContentWidth = w - 16), leaving
+/// the right margin for the scrollbar. Returns `(left x, usable width)`.
 fn content_inset(content_x: f32, content_w: f32, gs: f32) -> (f32, f32) {
     let inset = 8.0 * gs;
     (content_x + inset, content_w - inset * 2.0)

--- a/pomme-client/src/ui/menu/main_screen.rs
+++ b/pomme-client/src/ui/menu/main_screen.rs
@@ -317,12 +317,18 @@ impl MainMenu {
             }
         }
 
-        // Second row mirrors vanilla 26.2: friends (disabled — pomme has no
-        // social system), language and accessibility, centered.
+        // Second row mirrors vanilla 26.2: friends, language and accessibility,
+        // centered. Friends needs a signed-in account, so it's disabled offline.
+        let friends_enabled = self.access_token.is_some();
+        let friends_tip = if friends_enabled {
+            "Friends"
+        } else {
+            "Sign in to use friends"
+        };
         let new_row_w = icon_size * 3.0 + icon_gap * 2.0;
         let new_x0 = btn_x + (content_w - new_row_w) / 2.0;
         let new_icons: [(f32, char, bool, &str); 3] = [
-            (new_x0, ICON_USERS, false, "Friends (unavailable)"),
+            (new_x0, ICON_USERS, friends_enabled, friends_tip),
             (
                 new_x0 + icon_size + icon_gap,
                 ICON_LANGUAGE,
@@ -347,10 +353,16 @@ impl MainMenu {
 
             if enabled && clicked && hovered {
                 any_clicked = true;
-                self.settings_back = Screen::Main;
                 match icon {
-                    ICON_LANGUAGE => self.set_screen(Screen::OptionsLanguage),
-                    ICON_UNIVERSAL_ACCESS => self.set_screen(Screen::OptionsAccessibility),
+                    ICON_USERS => self.open_friends(),
+                    ICON_LANGUAGE => {
+                        self.settings_back = Screen::Main;
+                        self.set_screen(Screen::OptionsLanguage);
+                    }
+                    ICON_UNIVERSAL_ACCESS => {
+                        self.settings_back = Screen::Main;
+                        self.set_screen(Screen::OptionsAccessibility);
+                    }
                     _ => {}
                 }
             }

--- a/pomme-client/src/ui/menu/main_screen.rs
+++ b/pomme-client/src/ui/menu/main_screen.rs
@@ -67,12 +67,20 @@ impl MainMenu {
         let accent_w = 3.0 * s;
         let icon_size = 28.0 * s;
         let icon_gap = 6.0 * s;
+        let icon_row_gap = icon_gap;
 
         let header_h = accent_bar_h + 14.0 * s + title_size + 4.0 * s + sub_size + 18.0 * s;
         let btns_total = buttons.len() as f32 * (btn_h + btn_gap) - btn_gap;
-        let panel_h =
-            (panel_pad + header_h + 1.0 + 16.0 * s + btns_total + 16.0 * s + icon_size + panel_pad)
-                .min(screen_h * 0.9);
+        let icons_total = icon_size * 2.0 + icon_row_gap;
+        let panel_h = (panel_pad
+            + header_h
+            + 1.0
+            + 16.0 * s
+            + btns_total
+            + 16.0 * s
+            + icons_total
+            + panel_pad)
+            .min(screen_h * 0.9);
         let panel_margin = (screen_w * 0.06).max(12.0);
         let panel_start_x = -panel_w;
         let panel_final_x = panel_margin;
@@ -237,10 +245,40 @@ impl MainMenu {
             }
         }
 
-        let icon_area_y = panel_y + panel_h - panel_pad - icon_size;
+        let new_row_y = panel_y + panel_h - panel_pad - icon_size;
+        let icon_area_y = new_row_y - icon_size - icon_row_gap;
         let icon_r = 7.0 * s;
         let icon_scale = 13.0 * s;
         let drop_style = DropdownStyle::new(gs);
+
+        let icon_btn =
+            |elements: &mut Vec<MenuElement>, bx: f32, by: f32, icon: char, enabled: bool| {
+                let hovered = common::hit_test(cursor, [bx, by, icon_size, icon_size]);
+                if hovered && enabled {
+                    elements.push(MenuElement::Rect {
+                        x: bx,
+                        y: by,
+                        w: icon_size,
+                        h: icon_size,
+                        corner_radius: icon_r,
+                        color: glass_hover,
+                    });
+                }
+                elements.push(MenuElement::Icon {
+                    x: bx + icon_size / 2.0,
+                    y: by + icon_size / 2.0,
+                    icon,
+                    scale: icon_scale,
+                    color: if !enabled {
+                        [0.45, 0.47, 0.58, 0.35]
+                    } else if hovered {
+                        text_bright
+                    } else {
+                        text_dim
+                    },
+                });
+                hovered
+            };
 
         let bottom_icons: [(f32, char); 4] = [
             (btn_x, ICON_USER),
@@ -253,29 +291,8 @@ impl MainMenu {
         ];
 
         for &(bx, icon) in &bottom_icons {
-            let rect = [bx, icon_area_y, icon_size, icon_size];
-            let hovered = common::hit_test(cursor, rect);
+            let hovered = icon_btn(&mut elements, bx, icon_area_y, icon, true);
             any_hovered |= hovered;
-
-            elements.push(MenuElement::Rect {
-                x: bx,
-                y: icon_area_y,
-                w: icon_size,
-                h: icon_size,
-                corner_radius: icon_r,
-                color: if hovered {
-                    glass_hover
-                } else {
-                    [0.0, 0.0, 0.0, 0.0]
-                },
-            });
-            elements.push(MenuElement::Icon {
-                x: bx + icon_size / 2.0,
-                y: icon_area_y + icon_size / 2.0,
-                icon,
-                scale: icon_scale,
-                color: if hovered { text_bright } else { text_dim },
-            });
 
             if clicked && hovered {
                 any_clicked = true;
@@ -295,6 +312,45 @@ impl MainMenu {
                             self.links_open = false;
                         }
                     }
+                    _ => {}
+                }
+            }
+        }
+
+        // Second row mirrors vanilla 26.2: friends (disabled — pomme has no
+        // social system), language and accessibility, centered.
+        let new_row_w = icon_size * 3.0 + icon_gap * 2.0;
+        let new_x0 = btn_x + (content_w - new_row_w) / 2.0;
+        let new_icons: [(f32, char, bool, &str); 3] = [
+            (new_x0, ICON_USERS, false, "Friends (unavailable)"),
+            (
+                new_x0 + icon_size + icon_gap,
+                ICON_LANGUAGE,
+                true,
+                "Language",
+            ),
+            (
+                new_x0 + (icon_size + icon_gap) * 2.0,
+                ICON_UNIVERSAL_ACCESS,
+                true,
+                "Accessibility Settings",
+            ),
+        ];
+
+        for &(bx, icon, enabled, tip) in &new_icons {
+            let hovered = icon_btn(&mut elements, bx, new_row_y, icon, enabled);
+            any_hovered |= enabled && hovered;
+
+            if hovered {
+                common::push_tooltip(&mut elements, cursor, screen_w, screen_h, gs, tip);
+            }
+
+            if enabled && clicked && hovered {
+                any_clicked = true;
+                self.settings_back = Screen::Main;
+                match icon {
+                    ICON_LANGUAGE => self.set_screen(Screen::OptionsLanguage),
+                    ICON_UNIVERSAL_ACCESS => self.set_screen(Screen::OptionsAccessibility),
                     _ => {}
                 }
             }

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::core::DisplayMode;
 use crate::renderer::pipelines::menu_overlay::{
-    ICON_CHECK, ICON_CODE, ICON_COMMENT, ICON_GEAR, ICON_GLOBE, ICON_LINK, ICON_PAINTBRUSH,
-    ICON_USER, MenuElement, SpriteId,
+    ICON_CHECK, ICON_CODE, ICON_COMMENT, ICON_GEAR, ICON_GLOBE, ICON_LANGUAGE, ICON_LINK,
+    ICON_PAINTBRUSH, ICON_UNIVERSAL_ACCESS, ICON_USER, ICON_USERS, MenuElement, SpriteId,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -271,6 +271,9 @@ pub struct MainMenu {
     rt: Arc<tokio::runtime::Runtime>,
     links_open: bool,
     theme_open: bool,
+    /// Return target for Language/Accessibility, which open from both the
+    /// title-screen icon row and the Options grid.
+    settings_back: Screen,
     theme: PanoramaTheme,
     transition: Option<ThemeTransition>,
     scroll_offset: f32,
@@ -342,6 +345,7 @@ impl MainMenu {
             rt,
             links_open: false,
             theme_open: false,
+            settings_back: Screen::Options,
             theme: PanoramaTheme::Pomme,
             transition: None,
             scroll_offset: 0.0,
@@ -585,7 +589,8 @@ impl MainMenu {
                 Screen::OptionsControls,
             ),
             Screen::OptionsLanguage => {
-                self.build_options_stub(screen_w, screen_h, input, "Language", Screen::Options)
+                let back = self.settings_back.clone_screen();
+                self.build_options_stub(screen_w, screen_h, input, "Language", back)
             }
             Screen::OptionsChatSettings => self.build_options_chat(screen_w, screen_h, input),
             Screen::OptionsResourcePacks => {

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -532,14 +532,7 @@ impl MainMenu {
         self.add_friend_name.clear();
         self.pending_remove = None;
         *self.action_error.write() = None;
-        if let Some(token) = self.access_token.clone() {
-            friends::refresh_friends(
-                Arc::clone(&self.rt),
-                token,
-                &self.friends_data,
-                &self.face_cache,
-            );
-        }
+        self.refresh_friends_now();
     }
 
     pub fn is_options_screen(&self) -> bool {

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -1,3 +1,4 @@
+mod friends_screen;
 mod helpers;
 mod main_screen;
 mod options;
@@ -135,6 +136,7 @@ use helpers::*;
 
 use super::common;
 use super::common::WHITE;
+use super::friends::{self, ActionError, FaceCache, FriendsData};
 use super::server_list::{
     PingResults, PingState, ServerEntry, ServerList, is_valid_address, ping_all_servers,
 };
@@ -143,6 +145,12 @@ use super::server_list::{
 pub enum PanoramaTheme {
     Pomme,
     Default,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FriendTab {
+    Friends,
+    Requests,
 }
 
 struct ThemeTransition {
@@ -212,6 +220,7 @@ const DOUBLE_CLICK_MS: u128 = 400;
 enum Screen {
     Main,
     ServerList,
+    Friends,
     ConfirmDelete(usize),
     DirectConnect,
     AddServer,
@@ -236,6 +245,7 @@ impl Screen {
     fn clone_screen(&self) -> Self {
         match self {
             Self::Main => Self::Main,
+            Self::Friends => Self::Friends,
             Self::Options => Self::Options,
             Self::OptionsOnline => Self::OptionsOnline,
             Self::OptionsVideo => Self::OptionsVideo,
@@ -259,6 +269,25 @@ impl Screen {
     }
 }
 
+/// Returns true once `count` has held steady for 500ms since it last changed —
+/// debounces favicon / friend-face atlas rebuilds.
+fn atlas_dirty(count: usize, last: &mut usize, since: &mut Option<Instant>) -> bool {
+    if count != *last {
+        *last = count;
+        *since = Some(Instant::now());
+        false
+    } else if let Some(t) = *since {
+        if t.elapsed().as_millis() >= 500 {
+            *since = None;
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
 pub struct MainMenu {
     username: String,
     screen: Screen,
@@ -268,6 +297,15 @@ pub struct MainMenu {
     edit_address: String,
     last_mp_ip: String,
     ping_results: PingResults,
+    access_token: Option<String>,
+    friends_data: FriendsData,
+    face_cache: FaceCache,
+    last_face_count: usize,
+    face_dirty_since: Option<Instant>,
+    friend_tab: FriendTab,
+    add_friend_name: String,
+    action_error: ActionError,
+    pending_remove: Option<(String, String)>,
     rt: Arc<tokio::runtime::Runtime>,
     links_open: bool,
     theme_open: bool,
@@ -328,7 +366,12 @@ pub struct MainMenu {
 }
 
 impl MainMenu {
-    pub fn new(game_dir: &Path, rt: Arc<tokio::runtime::Runtime>, username: String) -> Self {
+    pub fn new(
+        game_dir: &Path,
+        rt: Arc<tokio::runtime::Runtime>,
+        username: String,
+        access_token: Option<String>,
+    ) -> Self {
         let server_list = ServerList::load(game_dir);
         let ping_results: PingResults = Default::default();
         ping_all_servers(&rt, &server_list.servers, &ping_results);
@@ -342,6 +385,15 @@ impl MainMenu {
             edit_address: String::new(),
             last_mp_ip: String::new(),
             ping_results,
+            access_token,
+            friends_data: Default::default(),
+            face_cache: Default::default(),
+            last_face_count: 0,
+            face_dirty_since: None,
+            friend_tab: FriendTab::Friends,
+            add_friend_name: String::new(),
+            action_error: Default::default(),
+            pending_remove: None,
             rt,
             links_open: false,
             theme_open: false,
@@ -407,6 +459,12 @@ impl MainMenu {
         self.last_field_click = None;
         self.field_undo_stack.clear();
         self.cursor_blink = Instant::now();
+        // Favicons and friend faces share one GPU atlas; force a rebuild on
+        // screen change so the correct set loads for the screen we're entering.
+        self.last_favicon_count = usize::MAX;
+        self.favicon_dirty_since = None;
+        self.last_face_count = usize::MAX;
+        self.face_dirty_since = None;
     }
 
     /// Per-category volumes in `SoundCategory` order
@@ -466,6 +524,24 @@ impl MainMenu {
         self.set_screen(Screen::Options);
     }
 
+    /// Open the friends screen and kick off a fetch (no-op without a token).
+    fn open_friends(&mut self) {
+        self.set_screen(Screen::Friends);
+        self.scroll_offset = 0.0;
+        self.friend_tab = FriendTab::Friends;
+        self.add_friend_name.clear();
+        self.pending_remove = None;
+        *self.action_error.write() = None;
+        if let Some(token) = self.access_token.clone() {
+            friends::refresh_friends(
+                Arc::clone(&self.rt),
+                token,
+                &self.friends_data,
+                &self.face_cache,
+            );
+        }
+    }
+
     pub fn is_options_screen(&self) -> bool {
         matches!(
             self.screen,
@@ -499,9 +575,14 @@ impl MainMenu {
         matches!(self.screen, Screen::ServerList)
     }
 
+    pub fn is_friends_screen(&self) -> bool {
+        matches!(self.screen, Screen::Friends)
+    }
+
     pub fn favicons_changed(&mut self) -> bool {
-        let results = self.ping_results.read();
-        let count = results
+        let count = self
+            .ping_results
+            .read()
             .values()
             .filter(|s| {
                 matches!(
@@ -513,20 +594,11 @@ impl MainMenu {
                 )
             })
             .count();
-        if count != self.last_favicon_count {
-            self.last_favicon_count = count;
-            self.favicon_dirty_since = Some(Instant::now());
-            false
-        } else if let Some(since) = self.favicon_dirty_since {
-            if since.elapsed().as_millis() >= 500 {
-                self.favicon_dirty_since = None;
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        atlas_dirty(
+            count,
+            &mut self.last_favicon_count,
+            &mut self.favicon_dirty_since,
+        )
     }
 
     pub fn collect_favicons(&self) -> Vec<(String, Vec<u8>, u32)> {
@@ -548,6 +620,19 @@ impl MainMenu {
             .collect()
     }
 
+    pub fn faces_changed(&mut self) -> bool {
+        let count = self.face_cache.read().len();
+        atlas_dirty(count, &mut self.last_face_count, &mut self.face_dirty_since)
+    }
+
+    pub fn collect_faces(&self) -> Vec<(String, Vec<u8>, u32)> {
+        self.face_cache
+            .read()
+            .iter()
+            .map(|(uuid, rgba)| (uuid.clone(), rgba.clone(), 8))
+            .collect()
+    }
+
     pub fn show_disconnect(&mut self, reason: String) {
         self.set_screen(Screen::Disconnected(reason));
     }
@@ -563,6 +648,7 @@ impl MainMenu {
             Screen::Main => self.build_main(screen_w, screen_h, input, text_width_fn),
 
             Screen::ServerList => self.build_server_list(screen_w, screen_h, input, &text_width_fn),
+            Screen::Friends => self.build_friends(screen_w, screen_h, input, &text_width_fn),
             Screen::ConfirmDelete(_) => {
                 self.build_confirm_delete(screen_w, screen_h, input, &text_width_fn)
             }

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -20,6 +20,8 @@ fn compat_label(compat: PackCompat) -> (&'static str, [f32; 4]) {
 
 impl MainMenu {
     pub(super) fn build_options(&mut self, sw: f32, sh: f32, input: &MenuInput) -> MainMenuResult {
+        // Sub-screens reached from here (Language/Accessibility) return to Options.
+        self.settings_back = Screen::Options;
         let fov_label = if self.fov == 70 {
             "FOV: Normal".to_string()
         } else if self.fov >= 110 {
@@ -219,12 +221,13 @@ impl MainMenu {
             OptRow::Pair("Hide Splash Texts: OFF", "Narrator Hotkey: ON"),
             OptRow::Pair("Rotate with Minecart: OFF", "High Contrast Outlines: OFF"),
         ];
+        let back = self.settings_back.clone_screen();
         self.build_options_grid(
             sw,
             sh,
             input,
             "Accessibility Settings",
-            Screen::Options,
+            back,
             &rows,
             &[],
             &[],

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::resource_pack::PackCompat;
 
-/// A row in a vanilla-style options list: 25px pitch, a 310px `Big` widget, or two
-/// 150px widgets per `Pair` (`PairLeft` for an odd trailing widget).
+/// A row in a vanilla-style options list: 25px pitch, a 310px `Big` widget, or
+/// two 150px widgets per `Pair` (`PairLeft` for an odd trailing widget).
 pub(super) enum OptRow<'a> {
     Header(&'a str),
     Big(&'a str),
@@ -29,7 +29,8 @@ impl MainMenu {
         } else {
             format!("FOV: {}", self.fov)
         };
-        // FOV slider + Online lead the grid, above the categories (vanilla header sub-row).
+        // FOV slider + Online lead the grid, above the categories (vanilla header
+        // sub-row).
         let rows: Vec<OptRow> = vec![
             OptRow::Pair(&fov_label, "Online..."),
             OptRow::Pair("Skin Customization...", "Music & Sounds..."),
@@ -107,7 +108,7 @@ impl MainMenu {
             OptRow::Pair(&mf, vsync_label),
             OptRow::Pair("Inactivity FPS Limit: 1 minute", &gui_label),
             OptRow::Pair(fullscreen_label, "Exclusive Fullscreen: OFF"),
-            OptRow::PairLeft("Brightness: 50%"),
+            OptRow::Pair("Brightness: 50%", "Graphics Backend: Default"),
             OptRow::Header("Quality"),
             OptRow::Big("Graphics: Fancy"),
             OptRow::Pair("Biome Blend: 5x5", &rd),
@@ -210,7 +211,10 @@ impl MainMenu {
         let rows: Vec<OptRow> = vec![
             OptRow::Pair("Narrator: OFF", "Show Subtitles: OFF"),
             OptRow::Pair("High Contrast: OFF", "Menu Background Blur: 50%"),
-            OptRow::Pair("Text Background Opacity: 50%", "Background for Chat Only: OFF"),
+            OptRow::Pair(
+                "Text Background Opacity: 50%",
+                "Background for Chat Only: OFF",
+            ),
             OptRow::Pair("Chat Text Opacity: 100%", "Line Spacing: 0%"),
             OptRow::Pair("Chat Delay: None", "Notification Time: 10.0s"),
             OptRow::Pair(self.view_bobbing_label(), "Distortion Effects: 100%"),
@@ -522,7 +526,8 @@ impl MainMenu {
         }
 
         let content_pad = if header_footer { 4.0 * gs } else { 0.0 };
-        // Vertical advance per row (vanilla OptionsList: 25px pitch; headers pad above).
+        // Vertical advance per row (vanilla OptionsList: 25px pitch; headers pad
+        // above).
         let header_pad_top = |i: usize| if i == 0 { 0.0 } else { 2.0 * lh };
         let row_advance = |i: usize, row: &OptRow| -> f32 {
             match row {

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -1,6 +1,15 @@
 use super::*;
 use crate::resource_pack::PackCompat;
 
+/// A row in a vanilla-style options list: 25px pitch, a 310px `Big` widget, or two
+/// 150px widgets per `Pair` (`PairLeft` for an odd trailing widget).
+pub(super) enum OptRow<'a> {
+    Header(&'a str),
+    Big(&'a str),
+    Pair(&'a str, &'a str),
+    PairLeft(&'a str),
+}
+
 fn compat_label(compat: PackCompat) -> (&'static str, [f32; 4]) {
     match compat {
         PackCompat::Compatible => ("Compatible", [0.33, 0.87, 0.33, 1.0]),
@@ -18,13 +27,14 @@ impl MainMenu {
         } else {
             format!("FOV: {}", self.fov)
         };
-        let rows: Vec<[&str; 2]> = vec![
-            [&fov_label, "Online..."],
-            ["Skin Customization...", "Music & Sounds..."],
-            ["Video Settings...", "Controls..."],
-            ["Language...", "Chat Settings..."],
-            ["Resource Packs...", "Accessibility Settings..."],
-            ["Telemetry Data...", "Credits & Attribution..."],
+        // FOV slider + Online lead the grid, above the categories (vanilla header sub-row).
+        let rows: Vec<OptRow> = vec![
+            OptRow::Pair(&fov_label, "Online..."),
+            OptRow::Pair("Skin Customization...", "Music & Sounds..."),
+            OptRow::Pair("Video Settings...", "Controls..."),
+            OptRow::Pair("Language...", "Chat Settings..."),
+            OptRow::Pair("Resource Packs...", "Accessibility Settings..."),
+            OptRow::Pair("Telemetry Data...", "Credits & Attribution..."),
         ];
 
         let nav: &[(&str, Screen)] = &[
@@ -77,7 +87,7 @@ impl MainMenu {
             DisplayMode::Fullscreen => "Fullscreen: Exclusive",
         };
         let rd = format!("Render Distance: {} chunks", self.render_distance);
-        let sd = format!("Simulation Distance: {} chunks", self.render_distance);
+        let sd = format!("Simulation Distance: {} chunks", self.simulation_distance);
         let mf = format!("Max Framerate: {} fps", 120);
         let gui_label = if self.gui_scale_setting == 0 {
             "GUI Scale: Auto".to_string()
@@ -89,14 +99,27 @@ impl MainMenu {
         } else {
             "VSync: OFF"
         };
-        let rows: Vec<[&str; 2]> = vec![
-            [&rd, &sd],
-            ["Graphics: Fancy", "Smooth Lighting: ON"],
-            [&mf, vsync_label],
-            [self.view_bobbing_label(), &gui_label],
-            ["Attack Indicator: Crosshair", "Brightness: 50%"],
-            ["Clouds: Fancy", fullscreen_label],
-            ["Particles: All", "Mipmap Levels: 4"],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Header("Display"),
+            OptRow::Big("Fullscreen Resolution: Current"),
+            OptRow::Pair(&mf, vsync_label),
+            OptRow::Pair("Inactivity FPS Limit: 1 minute", &gui_label),
+            OptRow::Pair(fullscreen_label, "Exclusive Fullscreen: OFF"),
+            OptRow::PairLeft("Brightness: 50%"),
+            OptRow::Header("Quality"),
+            OptRow::Big("Graphics: Fancy"),
+            OptRow::Pair("Biome Blend: 5x5", &rd),
+            OptRow::Pair("Prioritize Chunk Updates: None", &sd),
+            OptRow::Pair("Smooth Lighting: ON", "Clouds: Fancy"),
+            OptRow::Pair("Particles: All", "Mipmap Levels: 4"),
+            OptRow::Pair("Entity Shadows: ON", "Entity Distance: 100%"),
+            OptRow::Pair("Menu Background Blur: 50%", "Cloud Range: 128"),
+            OptRow::Pair("Cutout Leaves: Fancy", "Improved Transparency: OFF"),
+            OptRow::Pair("Texture Filtering: None", "Max Anisotropy: 1"),
+            OptRow::PairLeft("Weather Radius: 10"),
+            OptRow::Header("Preferences"),
+            OptRow::Pair("Show Autosave Indicator: ON", "Vignette: ON"),
+            OptRow::Pair("Attack Indicator: Crosshair", "Chunk Fade-in: 1.0s"),
         ];
         let rd_frac = (self.render_distance as f32 - 2.0) / 30.0;
         let sd_frac = (self.simulation_distance as f32 - 5.0) / 27.0;
@@ -124,11 +147,11 @@ impl MainMenu {
         sh: f32,
         input: &MenuInput,
     ) -> MainMenuResult {
-        let rows: Vec<[&str; 2]> = vec![
-            ["Sensitivity: 100%", "Invert Mouse: OFF"],
-            ["Auto-Jump: ON", "Operator Items Tab: OFF"],
-            ["Key Binds...", "Mouse Settings..."],
-            ["Sneak: Toggle", "Sprint: Hold"],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Pair("Sensitivity: 100%", "Invert Mouse: OFF"),
+            OptRow::Pair("Auto-Jump: ON", "Operator Items Tab: OFF"),
+            OptRow::Pair("Key Binds...", "Mouse Settings..."),
+            OptRow::Pair("Sneak: Toggle", "Sprint: Hold"),
         ];
         let nav: &[(&str, Screen)] = &[("Key Binds...", Screen::OptionsKeybinds)];
         self.build_options_grid(
@@ -151,16 +174,16 @@ impl MainMenu {
         sh: f32,
         input: &MenuInput,
     ) -> MainMenuResult {
-        let rows: Vec<[&str; 2]> = vec![
-            ["Chat: Shown", "Chat Colors: ON"],
-            ["Web Links: ON", "Prompt on Links: ON"],
-            ["Chat Text Opacity: 100%", "Text Background Opacity: 50%"],
-            ["Chat Text Size: 100%", "Line Spacing: 0%"],
-            ["Chat Delay: None", "Chat Width: 100%"],
-            ["Focused Height: 100%", "Unfocused Height: 100%"],
-            ["Narrator: OFF", "Command Suggestions: ON"],
-            ["Hide Matched Names: ON", "Reduced Debug Info: OFF"],
-            ["Only Show Secure Chat: OFF", "Save Chat Drafts: OFF"],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Pair("Chat: Shown", "Chat Colors: ON"),
+            OptRow::Pair("Web Links: ON", "Prompt on Links: ON"),
+            OptRow::Pair("Chat Text Opacity: 100%", "Text Background Opacity: 50%"),
+            OptRow::Pair("Chat Text Size: 100%", "Line Spacing: 0%"),
+            OptRow::Pair("Chat Delay: None", "Chat Width: 100%"),
+            OptRow::Pair("Focused Height: 100%", "Unfocused Height: 100%"),
+            OptRow::Pair("Narrator: OFF", "Command Suggestions: ON"),
+            OptRow::Pair("Hide Matched Names: ON", "Reduced Debug Info: OFF"),
+            OptRow::Pair("Only Show Secure Chat: OFF", "Save Chat Drafts: OFF"),
         ];
         self.build_options_grid(
             sw,
@@ -182,22 +205,19 @@ impl MainMenu {
         sh: f32,
         input: &MenuInput,
     ) -> MainMenuResult {
-        let rows: Vec<[&str; 2]> = vec![
-            ["Narrator: OFF", "Show Subtitles: OFF"],
-            ["High Contrast: OFF", "Menu Background Blur: 50%"],
-            [
-                "Text Background Opacity: 50%",
-                "Background for Chat Only: OFF",
-            ],
-            ["Chat Text Opacity: 100%", "Line Spacing: 0%"],
-            ["Chat Delay: None", "Notification Time: 10.0s"],
-            [self.view_bobbing_label(), "Distortion Effects: 100%"],
-            ["FOV Effects: 100%", "Darkness Pulsing: 100%"],
-            ["Damage Tilt: 100%", "Glint Speed: 100%"],
-            ["Glint Strength: 100%", "Hide Lightning Flashes: OFF"],
-            ["Dark Loading Screen: OFF", "Panorama Scroll Speed: 100%"],
-            ["Hide Splash Texts: OFF", "Narrator Hotkey: ON"],
-            ["Rotate with Minecart: OFF", "High Contrast Outlines: OFF"],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Pair("Narrator: OFF", "Show Subtitles: OFF"),
+            OptRow::Pair("High Contrast: OFF", "Menu Background Blur: 50%"),
+            OptRow::Pair("Text Background Opacity: 50%", "Background for Chat Only: OFF"),
+            OptRow::Pair("Chat Text Opacity: 100%", "Line Spacing: 0%"),
+            OptRow::Pair("Chat Delay: None", "Notification Time: 10.0s"),
+            OptRow::Pair(self.view_bobbing_label(), "Distortion Effects: 100%"),
+            OptRow::Pair("FOV Effects: 100%", "Darkness Pulsing: 100%"),
+            OptRow::Pair("Damage Tilt: 100%", "Glint Speed: 100%"),
+            OptRow::Pair("Glint Strength: 100%", "Hide Lightning Flashes: OFF"),
+            OptRow::Pair("Dark Loading Screen: OFF", "Panorama Scroll Speed: 100%"),
+            OptRow::Pair("Hide Splash Texts: OFF", "Narrator Hotkey: ON"),
+            OptRow::Pair("Rotate with Minecart: OFF", "High Contrast Outlines: OFF"),
         ];
         self.build_options_grid(
             sw,
@@ -238,16 +258,16 @@ impl MainMenu {
         let ambient = format!("Ambient/Environment: {}", pct(self.ambient_volume));
         let voice = format!("Voice/Speech: {}", pct(self.voice_volume));
         let ui = format!("UI: {}", pct(self.ui_volume));
-        let rows: Vec<[&str; 2]> = vec![
-            [&master, ""],
-            [&music, &jukebox],
-            [&weather, &blocks],
-            [&hostile, &friendly],
-            [&players, &ambient],
-            [&voice, &ui],
-            ["Device: Default", ""],
-            ["Show Subtitles: OFF", "Directional Audio: OFF"],
-            ["Music Frequency: Normal", "Music Toast: ON"],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Big(&master),
+            OptRow::Pair(&music, &jukebox),
+            OptRow::Pair(&weather, &blocks),
+            OptRow::Pair(&hostile, &friendly),
+            OptRow::Pair(&players, &ambient),
+            OptRow::Pair(&voice, &ui),
+            OptRow::Big("Device: Default"),
+            OptRow::Pair("Show Subtitles: OFF", "Directional Audio: OFF"),
+            OptRow::Pair("Music Frequency: Normal", "Music Toast: ON"),
         ];
         let sliders: &[(&str, f32)] = &[
             ("Master Volume:", self.master_volume),
@@ -318,11 +338,11 @@ impl MainMenu {
         } else {
             "Main Hand: Left"
         };
-        let rows: Vec<[&str; 2]> = vec![
-            [cape, jacket],
-            [left_sleeve, right_sleeve],
-            [left_pants, right_pants],
-            [hat, main_hand],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Pair(cape, jacket),
+            OptRow::Pair(left_sleeve, right_sleeve),
+            OptRow::Pair(left_pants, right_pants),
+            OptRow::Pair(hat, main_hand),
         ];
         self.build_options_grid(
             sw,
@@ -354,9 +374,9 @@ impl MainMenu {
         } else {
             "Show Current Server: OFF"
         };
-        let rows: Vec<[&str; 2]> = vec![
-            ["Realms Notifications: ON", "Allow Server Listings: ON"],
-            [online_status_label, current_server_label],
+        let rows: Vec<OptRow> = vec![
+            OptRow::Pair("Realms Notifications: ON", "Allow Server Listings: ON"),
+            OptRow::Pair(online_status_label, current_server_label),
         ];
         let tooltips: &[(&str, &str)] = &[
             (
@@ -398,7 +418,7 @@ impl MainMenu {
         input: &MenuInput,
         title: &str,
         back: Screen,
-        rows: &[[&str; 2]],
+        rows: &[OptRow],
         nav: &[(&str, Screen)],
         sliders: &[(&'static str, f32)],
         header_footer: bool,
@@ -412,10 +432,14 @@ impl MainMenu {
         let gs = crate::ui::hud::gui_scale(sw, sh, self.gui_scale_setting);
         let fs = common::FONT_SIZE * gs;
         let btn_h = common::BTN_H * gs;
-        let gap = BTN_GAP * gs;
-        let btn_w = 150.0 * gs;
-        let half_w = (btn_w * 2.0 + gap) / 2.0;
+        let big_w = 310.0 * gs;
+        let small_w = 150.0 * gs;
+        let row_h = 25.0 * gs;
+        let lh = 9.0 * gs;
+        let btn_dy = (row_h - btn_h) / 2.0;
         let cx = sw / 2.0;
+        let left_x = cx - 155.0 * gs;
+        let right_x = left_x + 160.0 * gs;
         let cursor = input.cursor;
         let clicked = input.clicked;
 
@@ -495,9 +519,19 @@ impl MainMenu {
         }
 
         let content_pad = if header_footer { 4.0 * gs } else { 0.0 };
-        let first_row_gap = if header_footer { 0.0 } else { 24.0 * gs };
-        let grid_h =
-            rows.len() as f32 * btn_h + (rows.len() as f32 - 1.0).max(0.0) * gap + first_row_gap;
+        // Vertical advance per row (vanilla OptionsList: 25px pitch; headers pad above).
+        let header_pad_top = |i: usize| if i == 0 { 0.0 } else { 2.0 * lh };
+        let row_advance = |i: usize, row: &OptRow| -> f32 {
+            match row {
+                OptRow::Header(_) => header_pad_top(i) + lh + 4.0 * gs,
+                _ => row_h,
+            }
+        };
+        let grid_h: f32 = rows
+            .iter()
+            .enumerate()
+            .map(|(i, row)| row_advance(i, row))
+            .sum();
         let content_h = content_bottom - content_top;
         let scrollable = header_footer && grid_h + content_pad > content_h;
         if scrollable {
@@ -515,10 +549,6 @@ impl MainMenu {
         } else {
             content_top + (content_h - grid_h) / 2.0
         };
-        let lx = cx - half_w;
-        let rx = lx + btn_w + gap;
-        let full_w = btn_w * 2.0 + gap;
-
         let mut slider_results: Vec<(&str, f32)> = Vec::new();
 
         if header_footer {
@@ -530,22 +560,30 @@ impl MainMenu {
             });
         }
 
-        for (row, pair) in rows.iter().enumerate() {
-            let extra = if row > 0 { first_row_gap } else { 0.0 };
-            let by = top_y + row as f32 * (btn_h + gap) + extra;
-            let is_full_width = pair[1].is_empty();
-            for (col, label) in pair.iter().enumerate() {
-                if label.is_empty() {
-                    continue;
+        let mut y_cursor = top_y;
+        for (i, row) in rows.iter().enumerate() {
+            let by = y_cursor + btn_dy;
+            let mut widgets: Vec<(&str, f32, f32)> = Vec::new();
+            match row {
+                OptRow::Header(title) => {
+                    let pad_top = header_pad_top(i);
+                    elements.push(MenuElement::Text {
+                        x: left_x,
+                        y: y_cursor + pad_top + (lh - fs) / 2.0,
+                        text: (*title).into(),
+                        scale: fs,
+                        color: WHITE,
+                        centered: false,
+                    });
                 }
-                let (bx, bw) = if is_full_width {
-                    (lx, full_w)
-                } else if col == 0 {
-                    (lx, btn_w)
-                } else {
-                    (rx, btn_w)
-                };
-
+                OptRow::Big(label) => widgets.push((*label, left_x, big_w)),
+                OptRow::Pair(a, b) => {
+                    widgets.push((*a, left_x, small_w));
+                    widgets.push((*b, right_x, small_w));
+                }
+                OptRow::PairLeft(a) => widgets.push((*a, left_x, small_w)),
+            }
+            for (label, bx, bw) in widgets {
                 if let Some((prefix, value)) = sliders.iter().find(|(p, _)| label.starts_with(p)) {
                     let is_active = self.active_slider == Some(*prefix);
                     let result = common::push_slider(
@@ -593,7 +631,7 @@ impl MainMenu {
                 }
                 if clicked && h {
                     any_clicked = true;
-                    if let Some((_, target)) = nav.iter().find(|(l, _)| *l == *label) {
+                    if let Some((_, target)) = nav.iter().find(|(l, _)| *l == label) {
                         if matches!(target, Screen::OptionsResourcePacks) {
                             self.rescan_packs = true;
                         }
@@ -660,6 +698,7 @@ impl MainMenu {
                     }
                 }
             }
+            y_cursor += row_advance(i, row);
         }
 
         for (prefix, value) in &slider_results {

--- a/pomme-client/src/ui/menu/servers.rs
+++ b/pomme-client/src/ui/menu/servers.rs
@@ -886,12 +886,14 @@ impl MainMenu {
             (Screen::AddServer | Screen::EditServer(_), 1) => TextTarget::EditAddress,
             (Screen::DirectConnect, 0) => TextTarget::EditAddress,
             (Screen::OptionsResourcePacks, 0) => TextTarget::PackSearch,
+            (Screen::Friends, 0) => TextTarget::AddFriend,
             _ => return,
         };
         let text: &mut String = match target {
             TextTarget::EditName => &mut self.edit_name,
             TextTarget::EditAddress => &mut self.edit_address,
             TextTarget::PackSearch => &mut self.pack_search,
+            TextTarget::AddFriend => &mut self.add_friend_name,
         };
 
         if input.copy && !text.is_empty() {
@@ -1023,6 +1025,7 @@ enum TextTarget {
     EditName,
     EditAddress,
     PackSearch,
+    AddFriend,
 }
 
 fn push_undo(stack: &mut Vec<(u8, String)>, field_idx: u8, prev: String) {
@@ -1032,7 +1035,7 @@ fn push_undo(stack: &mut Vec<(u8, String)>, field_idx: u8, prev: String) {
     stack.push((field_idx, prev));
 }
 
-fn write_clipboard(text: &str) -> bool {
+pub(super) fn write_clipboard(text: &str) -> bool {
     arboard::Clipboard::new()
         .and_then(|mut cb| cb.set_text(text.to_string()))
         .is_ok()

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod creative_tab_data;
 pub mod death;
 #[allow(dead_code)]
 pub mod font;
+pub mod friends;
 pub mod hud;
 pub mod inventory;
 pub mod menu;

--- a/pomme-client/src/ui/pause.rs
+++ b/pomme-client/src/ui/pause.rs
@@ -49,7 +49,7 @@ pub fn build_pause_menu(
     elements.push(MenuElement::Text {
         x: screen_w / 2.0,
         y: grid_y + 40.0 * gs - top_pad,
-        text: "Game Menu".into(),
+        text: "Game".into(),
         scale: fs,
         color: WHITE,
         centered: true,
@@ -64,7 +64,7 @@ pub fn build_pause_menu(
         btn_h,
         gs,
         fs,
-        "Back to Game",
+        "Return to Game",
         true,
     ) && clicked
     {


### PR DESCRIPTION
Stacked on vsync-toggle.

**Friends screen** — Friends/Requests tabs, add-friend field, copy-able profile name, friend list with faces/status and per-row actions (remove, accept/decline, cancel), scrolling, empty state, manage-account footer, and remove-confirm dialog. Shows as a dialog over the blurred title screen. Swapchain now honors surface `current_extent` (fixes fullscreen letterbox/stretch).

**Menu / options** — fix Simulation Distance label, tidy labels (Game / Return to Game / You died!), fix death-screen title position, rebuild options sub-screens with proper list geometry.
