### PR TITLE
Port more things to actions system, add controller rumble.

### DIFF
--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -1,14 +1,20 @@
 use std::collections::{HashMap, HashSet};
 
+use gilrs::ff::{BaseEffect, Effect, EffectBuilder, Repeat, Replay};
 use gilrs::{Button, GamepadId, Gilrs};
 use winit::event::{ElementState, Modifiers, MouseButton};
 use winit::keyboard::{KeyCode, PhysicalKey};
 
+use crate::app::TICK_RATE_MS;
 use crate::app::phases::AppPhase;
 use crate::app::state_slot::StateSlot;
 
 /// Left-stick deflection past which a direction counts as a digital press.
 pub const STICK_MOVEMENT_THRESHOLD: f32 = 0.25;
+
+/// Value in milliseconds for how long the controller should rumble to be only
+/// an "instant".
+pub const SHORT_RUMBLE_TIME: u32 = 5;
 
 #[derive(Hash, PartialEq, Eq, Clone)]
 pub enum Action {
@@ -21,6 +27,9 @@ pub enum Action {
     OpenMenu,
     ViewPlayerList,
     ChangePerspective,
+    OpenChat,
+    OpenCommands,
+    Close,
 }
 
 pub struct InputState {
@@ -44,7 +53,9 @@ pub struct InputState {
     copy_pressed: bool,
     cut_pressed: bool,
     undo_pressed: bool,
-    controller_manager: Option<Gilrs>,
+    gamepad_manager: Option<Gilrs>,
+    weak_rumble_effect: Option<Effect>,
+    strong_rumble_effect: Option<Effect>,
     active_gamepad_id: Option<GamepadId>,
     recent_actions: HashMap<Action, bool>,
 }
@@ -77,7 +88,25 @@ impl InputState {
         }
     }
 
-    fn with_controller(controller_manager: Option<Gilrs>) -> Self {
+    fn with_controller(mut gamepad_manager: Option<Gilrs>) -> Self {
+        // `Weak`/`Strong` pick the motor, not the intensity, so the weak motor
+        // at a higher `magnitude` is intentional.
+        let (weak_effect, strong_effect) = match gamepad_manager.as_mut() {
+            Some(manager) => (
+                build_rumble_effect(
+                    manager,
+                    gilrs::ff::BaseEffectType::Weak { magnitude: 60_000 },
+                    gilrs::ff::Ticks::from_ms(SHORT_RUMBLE_TIME),
+                ),
+                build_rumble_effect(
+                    manager,
+                    gilrs::ff::BaseEffectType::Strong { magnitude: 30_000 },
+                    gilrs::ff::Ticks::from_ms(TICK_RATE_MS + 50),
+                ),
+            ),
+            None => (None, None),
+        };
+
         Self {
             pressed: HashSet::new(),
             modifiers: Modifiers::default(),
@@ -99,14 +128,16 @@ impl InputState {
             copy_pressed: false,
             cut_pressed: false,
             undo_pressed: false,
-            controller_manager,
+            gamepad_manager,
+            weak_rumble_effect: weak_effect,
+            strong_rumble_effect: strong_effect,
             active_gamepad_id: None,
             recent_actions: HashMap::new(),
         }
     }
 
     pub fn update(&mut self, phase: &mut StateSlot<AppPhase>) -> bool {
-        let events: Vec<gilrs::Event> = match self.controller_manager.as_mut() {
+        let events: Vec<gilrs::Event> = match self.gamepad_manager.as_mut() {
             Some(manager) => std::iter::from_fn(|| manager.next_event()).collect(),
             None => Vec::new(),
         };
@@ -172,10 +203,39 @@ impl InputState {
 
                     self.recent_actions.remove(&Action::OpenMenu);
                 }
+                if self.action_just_pressed(Action::Close) {
+                    if !game.dead && game.inventory_open {
+                        game.inventory_open = false;
+                        should_apply_cursor_grab = true;
+                    }
+
+                    if game.chat.is_open() {
+                        game.chat.close();
+                        should_apply_cursor_grab = true;
+                    }
+
+                    self.recent_actions.remove(&Action::Close);
+                }
                 if self.action_just_pressed(Action::ChangePerspective) {
                     gfx.renderer.cycle_camera_mode();
 
                     self.recent_actions.remove(&Action::ChangePerspective);
+                }
+                if self.action_just_pressed(Action::OpenChat) {
+                    if !game.paused && !game.gui_open() {
+                        game.chat.open();
+                        should_apply_cursor_grab = true;
+                    }
+
+                    self.recent_actions.remove(&Action::OpenChat);
+                }
+                if self.action_just_pressed(Action::OpenCommands) {
+                    if !game.paused && !game.gui_open() {
+                        game.chat.open_with_slash();
+                        should_apply_cursor_grab = true;
+                    }
+
+                    self.recent_actions.remove(&Action::OpenCommands);
                 }
             }
 
@@ -186,7 +246,7 @@ impl InputState {
     }
 
     pub fn get_active_gamepad(&self) -> Option<gilrs::Gamepad<'_>> {
-        let manager = self.controller_manager.as_ref()?;
+        let manager = self.gamepad_manager.as_ref()?;
         self.active_gamepad_id.map(|id| manager.gamepad(id))
     }
 
@@ -230,6 +290,14 @@ impl InputState {
                     self.recent_actions.insert(Action::ChangePerspective, true);
                 }
 
+                Button::DPadRight => {
+                    self.recent_actions.insert(Action::OpenChat, true);
+                }
+
+                Button::East => {
+                    self.recent_actions.insert(Action::Close, true);
+                }
+
                 _ => {}
             },
             gilrs::EventType::ButtonReleased(button, _) => match button {
@@ -249,6 +317,14 @@ impl InputState {
 
                 Button::DPadUp => {
                     self.recent_actions.insert(Action::ChangePerspective, false);
+                }
+
+                Button::DPadRight => {
+                    self.recent_actions.insert(Action::OpenChat, false);
+                }
+
+                Button::East => {
+                    self.recent_actions.insert(Action::Close, false);
                 }
 
                 _ => {}
@@ -276,7 +352,7 @@ impl InputState {
                     || self.gamepad_button_down(Button::North)
             }
             Action::OpenMenu => {
-                self.key_pressed(KeyCode::Escape) || self.gamepad_button_down(Button::East)
+                self.key_pressed(KeyCode::Escape) || self.gamepad_button_down(Button::Start)
             }
             Action::ViewPlayerList => {
                 self.key_pressed(KeyCode::Tab) || self.gamepad_button_down(Button::Select)
@@ -284,6 +360,12 @@ impl InputState {
             Action::ChangePerspective => {
                 self.key_pressed(KeyCode::F5) || self.gamepad_button_down(Button::DPadUp)
             }
+            Action::OpenChat => {
+                self.key_pressed(KeyCode::KeyT) || self.gamepad_button_down(Button::DPadRight)
+            }
+            Action::OpenCommands => self.key_pressed(KeyCode::Slash),
+            // Controller-only; keyboard Escape closes via OpenMenu and the chat path.
+            Action::Close => self.gamepad_button_down(Button::East),
         }
     }
 
@@ -332,6 +414,18 @@ impl InputState {
         self.pressed.contains(&key)
     }
 
+    pub fn weak_rumble_for_instant(&self) -> Result<(), gilrs::ff::Error> {
+        self.weak_rumble_effect
+            .as_ref()
+            .map_or(Ok(()), Effect::play)
+    }
+
+    pub fn strong_rumble_for_tick(&self) -> Result<(), gilrs::ff::Error> {
+        self.strong_rumble_effect
+            .as_ref()
+            .map_or(Ok(()), Effect::play)
+    }
+
     pub fn on_key_event(&mut self, event: &winit::event::KeyEvent) {
         if let PhysicalKey::Code(code) = event.physical_key {
             match event.state {
@@ -350,6 +444,13 @@ impl InputState {
                         KeyCode::F5 => {
                             self.recent_actions.insert(Action::ChangePerspective, true);
                         }
+                        KeyCode::KeyT => {
+                            self.recent_actions.insert(Action::OpenChat, true);
+                        }
+                        KeyCode::Slash => {
+                            self.recent_actions.insert(Action::OpenCommands, true);
+                        }
+
                         _ => {}
                     }
                 }
@@ -568,4 +669,39 @@ fn hotbar_slot(code: KeyCode) -> Option<u8> {
         KeyCode::Digit9 => Some(8),
         _ => None,
     }
+}
+
+/// Build a single-motor force-feedback effect targeting the FF-capable gamepads
+/// connected right now. Rumble is best-effort: returns `None` if no controller
+/// supports it or the effect can't be created.
+///
+/// TODO: the effect is bound to the gamepads present when this runs (startup);
+/// a controller connected later won't rumble until this is rebuilt on hotplug.
+fn build_rumble_effect(
+    manager: &mut Gilrs,
+    kind: gilrs::ff::BaseEffectType,
+    duration: gilrs::ff::Ticks,
+) -> Option<Effect> {
+    let ff_supported = manager
+        .gamepads()
+        .filter_map(|(id, gp)| gp.is_ff_supported().then_some(id))
+        .collect::<Vec<_>>();
+    if ff_supported.is_empty() {
+        return None;
+    }
+
+    EffectBuilder::new()
+        .add_effect(BaseEffect {
+            kind,
+            scheduling: Replay {
+                play_for: duration,
+                ..Default::default()
+            },
+            envelope: Default::default(),
+        })
+        .repeat(Repeat::For(duration))
+        .gamepads(&ff_supported)
+        .finish(manager)
+        .map_err(|e| tracing::warn!("Failed to create rumble effect: {e}"))
+        .ok()
 }

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -38,6 +38,7 @@ pub enum WindowError {
 }
 
 const TICK_RATE: f32 = 1.0 / 20.0;
+const TICK_RATE_MS: u32 = 1000 / 20;
 const DEFAULT_RENDER_DISTANCE: u32 = 12;
 const POSITION_SEND_INTERVAL: u32 = 20;
 const POSITION_THRESHOLD_SQ: f64 = 4.0e-8;
@@ -374,16 +375,6 @@ impl ApplicationHandler for App {
                                         {
                                             game.death_confirm = false;
                                             self.core.send_respawn(&connection, &mut game);
-                                        }
-                                        KeyCode::KeyT if !game.paused && !game.gui_open() => {
-                                            game.chat.open();
-                                            self.core
-                                                .apply_cursor_grab(&gfx.window, Some(&mut game));
-                                        }
-                                        KeyCode::Slash if !game.paused && !game.gui_open() => {
-                                            game.chat.open_with_slash();
-                                            self.core
-                                                .apply_cursor_grab(&gfx.window, Some(&mut game));
                                         }
                                         KeyCode::F3 => {
                                             game.show_debug = !game.show_debug;

--- a/pomme-client/src/physics/movement.rs
+++ b/pomme-client/src/physics/movement.rs
@@ -203,7 +203,7 @@ fn apply_collision(
         chunk_store,
         &aabb,
         *player.velocity,
-        input.key_pressed(KeyCode::ShiftLeft),
+        input.performing_action(input::Action::Sneak),
         player.on_ground,
     );
     let step_height = if player.on_ground { STEP_HEIGHT } else { 0.0 };
@@ -252,7 +252,7 @@ fn update_sprint_state(
     if player.sprint_toggle_timer > 0 {
         player.sprint_toggle_timer -= 1;
     }
-    if input.key_pressed(KeyCode::ShiftLeft) {
+    if input.performing_action(input::Action::Sneak) {
         player.sprint_toggle_timer = 0;
     }
 
@@ -281,7 +281,7 @@ fn update_crouch_state(player: &mut LocalPlayer, input: &InputState, chunk_store
     player.crouching = player.game_mode != 3
         && !player.swimming
         && can_fit_with_height(chunk_store, player.position.into(), CROUCH_HEIGHT)
-        && (input.key_pressed(KeyCode::ShiftLeft)
+        && (input.performing_action(input::Action::Sneak)
             || !can_fit_with_height(chunk_store, player.position.into(), STANDING_HEIGHT));
 }
 

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -297,6 +297,7 @@ impl InteractionState {
                 chunks,
                 sender,
                 audio,
+                input,
                 player_pos,
                 on_ground,
                 creative,
@@ -319,10 +320,18 @@ impl InteractionState {
             self.stop_destroying(sender);
         }
 
+        if self.is_destroying {
+            let _ = input.strong_rumble_for_tick();
+        }
+
         if input.action_just_pressed(input::Action::Use)
             || (input.performing_action(input::Action::Use) && self.use_delay == 0)
         {
-            self.use_item_on(sender, chunks, player_pos, place_block, &mut dirty_chunks);
+            let success =
+                self.use_item_on(sender, chunks, player_pos, place_block, &mut dirty_chunks);
+            if success {
+                let _ = input.weak_rumble_for_instant();
+            }
         }
 
         if self.miss_time > 0 {
@@ -342,6 +351,7 @@ impl InteractionState {
         chunks: &ChunkStore,
         sender: &PacketSender,
         audio: &AudioEngine,
+        input: &InputState,
         player_pos: DVec3,
         on_ground: bool,
         creative: bool,
@@ -362,6 +372,7 @@ impl InteractionState {
                     entity_id: MinecraftEntityId(hit.entity_id),
                 }));
                 self.swing(sender);
+                let _ = input.weak_rumble_for_instant();
                 return;
             }
             Some(HitResult::Block(hit)) => hit,
@@ -428,6 +439,9 @@ impl InteractionState {
         self.swing(sender);
     }
 
+    /// Uses the currently selected item on the targeted block.
+    /// Returns `true` if a use interaction was sent, `false` if there was
+    /// nothing to act on (currently destroying, or no block target).
     fn use_item_on(
         &mut self,
         sender: &PacketSender,
@@ -435,15 +449,15 @@ impl InteractionState {
         player_pos: DVec3,
         place_block: Option<BlockState>,
         dirty_chunks: &mut Vec<BlockPos>,
-    ) {
+    ) -> bool {
         if self.is_destroying {
-            return;
+            return false;
         }
 
         self.use_delay = USE_DELAY;
 
         let Some(HitResult::Block(hit)) = self.target else {
-            return;
+            return false;
         };
 
         self.swing(sender);
@@ -462,6 +476,7 @@ impl InteractionState {
         }));
 
         self.predict_place(hit, place_block, chunks, player_pos, dirty_chunks);
+        true
     }
 
     /// Predicts placement locally for unambiguous single-state blocks,


### PR DESCRIPTION
Summary:
- More actions
  - Wired Action::Sneak up to sneak
  - New actions:
    - Close: Closes inventory & chat, bound to Escape or the B button.
    - OpenChat: Opens the chat interface, bound to T or Dpad Right
    - OpenCommands: Opens the chat interface to type commands, bound to Slash, no controller binding.
- Rumble
  - Controller rumbles when destroying blocks, and also when using a item or when an attack successfully lands.

Testing
- [x] works on my machine