### PR TITLE
Hostile mobs: zombie, skeleton, creeper, spider

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -666,6 +666,15 @@ impl AppCore {
                 NetworkEvent::EntityCustomName { id, name } => {
                     game.entity_store.set_custom_name(id, name);
                 }
+                NetworkEvent::EntityAggressive { id, aggressive } => {
+                    game.entity_store.set_aggressive(id, aggressive);
+                }
+                NetworkEvent::EntitySwing { id } => {
+                    game.entity_store.start_swing(id);
+                }
+                NetworkEvent::CreeperPowered { id, powered } => {
+                    game.entity_store.set_powered(id, powered);
+                }
                 NetworkEvent::EntityDamaged { id } => {
                     game.entity_store.mark_hurt(id);
                 }

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -590,6 +590,9 @@ pub fn update_game(
                 head_y_offset: extras.head_y_offset,
                 head_x_rot_deg_override: extras.head_x_rot_deg_override,
                 has_red_overlay: e.hurt_time > 0,
+                aggressive: e.aggressive,
+                age_in_ticks: e.age_in_ticks as f32 + partial_tick,
+                attack_time: e.swing_progress(partial_tick),
             }
         })
         .collect();
@@ -623,6 +626,9 @@ pub fn update_game(
             head_y_offset: 0.0,
             head_x_rot_deg_override: None,
             has_red_overlay: false,
+            aggressive: false,
+            age_in_ticks: 0.0,
+            attack_time: 0.0,
         });
     }
 
@@ -987,6 +993,16 @@ fn entity_extras(entity_id: i32, e: &crate::entity::LivingEntity, alpha: f32) ->
             ..EMPTY_EXTRAS
         },
         EntityKind::Sheep => sheep_extras(entity_id, e, alpha),
+        // Spider eyes overlay is always visible (slot 0).
+        EntityKind::Spider => EntityExtras {
+            overlay_tints: [Some(WHITE_TINT), None],
+            ..EMPTY_EXTRAS
+        },
+        // Charged-creeper aura overlay (slot 0) only when powered.
+        EntityKind::Creeper if e.powered => EntityExtras {
+            overlay_tints: [Some(WHITE_TINT), None],
+            ..EMPTY_EXTRAS
+        },
         _ => EMPTY_EXTRAS,
     }
 }

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -192,7 +192,6 @@ pub struct LivingEntity {
     /// (driven by the server `Animate` packet). Drives the zombie attack
     /// swing.
     pub swing_time: u8,
-    pub prev_swing_time: u8,
     interp_target: Position,
     interp_look_dir: LookDirection,
     interp_steps: i32,
@@ -235,7 +234,6 @@ impl LivingEntity {
             aggressive: false,
             powered: false,
             swing_time: 0,
-            prev_swing_time: 0,
             interp_target: position,
             interp_look_dir: look_dir,
             interp_steps: 0,
@@ -618,11 +616,12 @@ impl EntityStore {
         }
     }
 
-    /// Begins an arm swing (server `Animate` packet). Restarts only if not
-    /// already mid-swing, mirroring vanilla `LivingEntity.swing`.
+    /// Begins an arm swing (server `Animate` packet). Restarts when idle or
+    /// past the halfway point (vanilla `LivingEntity.swing`); `swing_time`
+    /// counts down, so that is `swing_time <= SWING_DURATION / 2`.
     pub fn start_swing(&mut self, id: i32) {
         if let Some(entity) = self.living.get_mut(&id)
-            && entity.swing_time == 0
+            && entity.swing_time <= SWING_DURATION / 2
         {
             entity.swing_time = SWING_DURATION;
         }
@@ -666,7 +665,6 @@ impl EntityStore {
             if entity.hurt_time > 0 {
                 entity.hurt_time -= 1;
             }
-            entity.prev_swing_time = entity.swing_time;
             if entity.swing_time > 0 {
                 entity.swing_time -= 1;
             }

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -154,7 +154,8 @@ fn sweep_axis_z(
 
 const INTERPOLATION_STEPS: i32 = 3;
 const HURT_DURATION: u8 = 10;
-/// Vanilla default arm-swing duration in ticks (`LivingEntity.getCurrentSwingDuration`).
+/// Vanilla default arm-swing duration in ticks
+/// (`LivingEntity.getCurrentSwingDuration`).
 const SWING_DURATION: u8 = 6;
 
 #[allow(dead_code)]
@@ -187,8 +188,9 @@ pub struct LivingEntity {
     pub aggressive: bool,
     /// Creeper charged/powered flag — shows the blue aura overlay.
     pub powered: bool,
-    /// Arm-swing animation timer, counts down from `SWING_DURATION` to 0 (driven by
-    /// the server `Animate` packet). Drives the zombie attack swing.
+    /// Arm-swing animation timer, counts down from `SWING_DURATION` to 0
+    /// (driven by the server `Animate` packet). Drives the zombie attack
+    /// swing.
     pub swing_time: u8,
     pub prev_swing_time: u8,
     interp_target: Position,
@@ -279,9 +281,10 @@ impl LivingEntity {
         self.prev_body_y_rot_deg = self.body_y_rot_deg;
     }
 
-    /// Arm-swing progress 0..1 for the current frame. `swing_time` counts down, so
-    /// progress rises 0→1 over the swing; idle clamps to 1 (where the attack pose
-    /// contribution is zero, like vanilla's attackTime endpoints).
+    /// Arm-swing progress 0..1 for the current frame. `swing_time` counts down,
+    /// so progress rises 0→1 over the swing; idle clamps to 1 (where the
+    /// attack pose contribution is zero, like vanilla's attackTime
+    /// endpoints).
     pub fn swing_progress(&self, partial: f32) -> f32 {
         ((SWING_DURATION as f32 - self.swing_time as f32 + partial) / SWING_DURATION as f32)
             .clamp(0.0, 1.0)
@@ -615,8 +618,8 @@ impl EntityStore {
         }
     }
 
-    /// Begins an arm swing (server `Animate` packet). Restarts only if not already
-    /// mid-swing, mirroring vanilla `LivingEntity.swing`.
+    /// Begins an arm swing (server `Animate` packet). Restarts only if not
+    /// already mid-swing, mirroring vanilla `LivingEntity.swing`.
     pub fn start_swing(&mut self, id: i32) {
         if let Some(entity) = self.living.get_mut(&id)
             && entity.swing_time == 0

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -154,6 +154,8 @@ fn sweep_axis_z(
 
 const INTERPOLATION_STEPS: i32 = 3;
 const HURT_DURATION: u8 = 10;
+/// Vanilla default arm-swing duration in ticks (`LivingEntity.getCurrentSwingDuration`).
+const SWING_DURATION: u8 = 6;
 
 #[allow(dead_code)]
 pub struct LivingEntity {
@@ -180,6 +182,15 @@ pub struct LivingEntity {
     pub hurt_time: u8,
     pub age_in_ticks: u32,
     pub custom_name: Option<String>,
+    /// Mob is targeting/attacking (metadata mob-flags bit 0x04). Raises
+    /// zombie/skeleton arms.
+    pub aggressive: bool,
+    /// Creeper charged/powered flag — shows the blue aura overlay.
+    pub powered: bool,
+    /// Arm-swing animation timer, counts down from `SWING_DURATION` to 0 (driven by
+    /// the server `Animate` packet). Drives the zombie attack swing.
+    pub swing_time: u8,
+    pub prev_swing_time: u8,
     interp_target: Position,
     interp_look_dir: LookDirection,
     interp_steps: i32,
@@ -219,6 +230,10 @@ impl LivingEntity {
             hurt_time: 0,
             age_in_ticks: 0,
             custom_name: None,
+            aggressive: false,
+            powered: false,
+            swing_time: 0,
+            prev_swing_time: 0,
             interp_target: position,
             interp_look_dir: look_dir,
             interp_steps: 0,
@@ -262,6 +277,14 @@ impl LivingEntity {
         }
 
         self.prev_body_y_rot_deg = self.body_y_rot_deg;
+    }
+
+    /// Arm-swing progress 0..1 for the current frame. `swing_time` counts down, so
+    /// progress rises 0→1 over the swing; idle clamps to 1 (where the attack pose
+    /// contribution is zero, like vanilla's attackTime endpoints).
+    pub fn swing_progress(&self, partial: f32) -> f32 {
+        ((SWING_DURATION as f32 - self.swing_time as f32 + partial) / SWING_DURATION as f32)
+            .clamp(0.0, 1.0)
     }
 
     pub fn tick_body_rotation(&mut self) {
@@ -578,6 +601,30 @@ impl EntityStore {
         }
     }
 
+    pub fn set_aggressive(&mut self, id: i32, aggressive: bool) {
+        if let Some(entity) = self.living.get_mut(&id) {
+            entity.aggressive = aggressive;
+        }
+    }
+
+    pub fn set_powered(&mut self, id: i32, powered: bool) {
+        if let Some(entity) = self.living.get_mut(&id)
+            && entity.entity_type == EntityKind::Creeper
+        {
+            entity.powered = powered;
+        }
+    }
+
+    /// Begins an arm swing (server `Animate` packet). Restarts only if not already
+    /// mid-swing, mirroring vanilla `LivingEntity.swing`.
+    pub fn start_swing(&mut self, id: i32) {
+        if let Some(entity) = self.living.get_mut(&id)
+            && entity.swing_time == 0
+        {
+            entity.swing_time = SWING_DURATION;
+        }
+    }
+
     pub fn update_living_rotation(&mut self, id: i32, y_rot_deg: f32, x_rot_deg: f32) {
         if let Some(entity) = self.living.get_mut(&id) {
             entity.interp_look_dir = LookDirection::new(y_rot_deg, x_rot_deg);
@@ -615,6 +662,10 @@ impl EntityStore {
             }
             if entity.hurt_time > 0 {
                 entity.hurt_time -= 1;
+            }
+            entity.prev_swing_time = entity.swing_time;
+            if entity.swing_time > 0 {
+                entity.swing_time -= 1;
             }
             entity.age_in_ticks = entity.age_in_ticks.wrapping_add(1);
         }

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -370,6 +370,15 @@ pub fn handle_game_packet(
                         score: *score,
                     });
                 }
+                // Index 15 = mob flags byte (AbstractInsentient): bit 0x04 = aggressive.
+                if item.index == 15
+                    && let azalea_entity::EntityDataValue::Byte(flags) = &item.value
+                {
+                    let _ = event_tx.try_send(NetworkEvent::EntityAggressive {
+                        id: p.id.0,
+                        aggressive: (*flags & 0x04) != 0,
+                    });
+                }
                 // Index 17 = sheep wool/sheared byte (low nibble = DyeColor, bit 4 = sheared).
                 // Emit unconditionally; consumer filters by entity type.
                 if item.index == 17
@@ -379,6 +388,16 @@ pub fn handle_game_packet(
                         id: p.id.0,
                         color: *packed & 0x0F,
                         sheared: (*packed & 0x10) != 0,
+                    });
+                }
+                // Index 17 (Boolean) = creeper "powered"/charged flag. Disambiguated
+                // from the sheep byte above by value type.
+                if item.index == 17
+                    && let azalea_entity::EntityDataValue::Boolean(powered) = &item.value
+                {
+                    let _ = event_tx.try_send(NetworkEvent::CreeperPowered {
+                        id: p.id.0,
+                        powered: *powered,
                     });
                 }
                 // Index 2 = custom name (Optional<Component>); needed for jeb_ sheep detection.
@@ -415,6 +434,17 @@ pub fn handle_game_packet(
         // Event id 10 = sheep eat-grass animation start (40-tick head-dip).
         ClientboundGamePacket::EntityEvent(p) if p.event_id == 10 => {
             let _ = event_tx.try_send(NetworkEvent::SheepEatStart { id: p.entity_id.0 });
+        }
+        // Arm-swing animation drives the zombie attack swing (skeleton aim uses the
+        // aggressive flag instead). Both hands trigger the same swing timer.
+        ClientboundGamePacket::Animate(p)
+            if matches!(
+                p.action,
+                azalea_protocol::packets::game::c_animate::AnimationAction::SwingMainHand
+                    | azalea_protocol::packets::game::c_animate::AnimationAction::SwingOffHand
+            ) =>
+        {
+            let _ = event_tx.try_send(NetworkEvent::EntitySwing { id: p.id.0 });
         }
         ClientboundGamePacket::TakeItemEntity(p) => {
             let _ = event_tx.try_send(NetworkEvent::ItemPickedUp {

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -191,6 +191,17 @@ pub enum NetworkEvent {
         id: i32,
         name: Option<String>,
     },
+    EntityAggressive {
+        id: i32,
+        aggressive: bool,
+    },
+    EntitySwing {
+        id: i32,
+    },
+    CreeperPowered {
+        id: i32,
+        powered: bool,
+    },
     EntityDamaged {
         id: i32,
     },

--- a/pomme-client/src/renderer/entity_model.rs
+++ b/pomme-client/src/renderer/entity_model.rs
@@ -396,14 +396,15 @@ fn humanoid_parts(
     leg_cube_right: ModelCube,
     right_leg_x: f32,
 ) -> Vec<EntityPart> {
-    let arm_cube_left = ModelCube {
+    // Pomme's `mirror` flag only flips UVs, so mirror the geometry origin across
+    // x=0 too (vanilla `.mirror()` does both, e.g. arm origin -3 -> -1).
+    let mirror_x = |c: ModelCube| ModelCube {
+        origin: Vec3::new(-(c.origin.x + c.size.x), c.origin.y, c.origin.z),
         mirror: true,
-        ..arm_cube_right
+        ..c
     };
-    let leg_cube_left = ModelCube {
-        mirror: true,
-        ..leg_cube_right
-    };
+    let arm_cube_left = mirror_x(arm_cube_right);
+    let leg_cube_left = mirror_x(leg_cube_right);
     vec![
         EntityPart {
             name: "head".into(),
@@ -1212,6 +1213,8 @@ fn bob_arm(age_in_ticks: f32, side: f32) -> (f32, f32) {
 /// Zombie: humanoid head/body/legs, but arms held out forward (the classic
 /// zombie pose) and raised higher when aggressive, plus the
 /// `AnimationUtils.animateZombieArms` attack swing driven by `attack_time`.
+// TODO: hardcodes vanilla's `raiseArms = true` path; a baby zombie holding an item
+// needs the `raiseArms = false` path. Implement once held items are rendered.
 #[allow(clippy::too_many_arguments)]
 pub fn compute_zombie_anim(
     model: &BakedEntityModel,
@@ -1257,6 +1260,9 @@ pub fn compute_zombie_anim(
 /// vanilla `HumanoidModel` `BOW_AND_ARROW` aim pose tracking the head (no held
 /// bow item is rendered). `age_in_ticks` is currently unused but kept for
 /// parity with the other humanoid anims.
+// TODO: aim pose is hardcoded right-handed and gated on `aggressive` alone;
+// vanilla keys it off the main arm and a held bow. Implement once held items
+// are rendered.
 pub fn compute_skeleton_anim(
     model: &BakedEntityModel,
     head_x_rot_deg: f32,

--- a/pomme-client/src/renderer/entity_model.rs
+++ b/pomme-client/src/renderer/entity_model.rs
@@ -49,17 +49,18 @@ pub struct BakedEntityModel {
     pub vertices: Vec<ChunkVertex>,
     pub part_ranges: Vec<(u32, u32)>,
     /// Per-part scale (parallel to `parts`), applied about each part's pivot at
-    /// transform time. Scales geometry only, never UVs — used for baby mobs whose
-    /// head and body shrink by different factors. Default 1.0 for every part.
+    /// transform time. Scales geometry only, never UVs — used for baby mobs
+    /// whose head and body shrink by different factors. Default 1.0 for
+    /// every part.
     pub part_scales: Vec<f32>,
 }
 
 #[derive(Default)]
 pub struct PartAnim {
     pub rotation: Vec<(usize, Vec3)>,
-    /// Quaternion rotation override; takes precedence over `rotation` for a part.
-    /// Used where the engine's fixed euler order can't reproduce vanilla's
-    /// composition (e.g. spider legs with combined yaw + tilt).
+    /// Quaternion rotation override; takes precedence over `rotation` for a
+    /// part. Used where the engine's fixed euler order can't reproduce
+    /// vanilla's composition (e.g. spider legs with combined yaw + tilt).
     pub rotation_quat: Vec<(usize, Quat)>,
     pub translation: Vec<(usize, Vec3)>,
 }
@@ -386,10 +387,10 @@ pub fn bake_player_model() -> BakedEntityModel {
 }
 
 /// Legacy single-arm humanoid layout (head/body/right_arm/left_arm/right_leg/
-/// left_leg), shared by zombie and skeleton. `limb` builds the four limb cubes so
-/// zombie (4-wide) and skeleton (2-wide thin) can differ while keeping identical
-/// part names/order (required for shared animation indexing). `tex_h` lets zombie
-/// use a 64-tall sheet and skeleton a 32-tall one.
+/// left_leg), shared by zombie and skeleton. `limb` builds the four limb cubes
+/// so zombie (4-wide) and skeleton (2-wide thin) can differ while keeping
+/// identical part names/order (required for shared animation indexing). `tex_h`
+/// lets zombie use a 64-tall sheet and skeleton a 32-tall one.
 fn humanoid_parts(
     arm_cube_right: ModelCube,
     leg_cube_right: ModelCube,
@@ -650,7 +651,14 @@ fn spider_parts() -> Vec<EntityPart> {
             }],
             parent: None,
         },
-        leg("right_hind_leg", -4.0, 2.0, FRAC_PI_4, -FRAC_PI_4, right_leg),
+        leg(
+            "right_hind_leg",
+            -4.0,
+            2.0,
+            FRAC_PI_4,
+            -FRAC_PI_4,
+            right_leg,
+        ),
         leg("left_hind_leg", 4.0, 2.0, -FRAC_PI_4, FRAC_PI_4, left_leg),
         leg(
             "right_middle_hind_leg",
@@ -1192,17 +1200,18 @@ fn head_rotation(head_x_rot_deg: f32, local_head_y_rot_deg: f32) -> Vec3 {
     Vec3::new(x, y, z)
 }
 
-/// Vanilla `AnimationUtils.bobModelPart`: a gentle idle sway added to undead arms.
-/// Returns the (xRot, zRot) delta; `side` is +1.0 for the right arm, -1.0 left.
+/// Vanilla `AnimationUtils.bobModelPart`: a gentle idle sway added to undead
+/// arms. Returns the (xRot, zRot) delta; `side` is +1.0 for the right arm, -1.0
+/// left.
 fn bob_arm(age_in_ticks: f32, side: f32) -> (f32, f32) {
     let z = side * ((age_in_ticks * 0.09).cos() * 0.05 + 0.05);
     let x = side * (age_in_ticks * 0.067).sin() * 0.05;
     (x, z)
 }
 
-/// Zombie: humanoid head/body/legs, but arms held out forward (the classic zombie
-/// pose) and raised higher when aggressive, plus the `AnimationUtils.animateZombieArms`
-/// attack swing driven by `attack_time`.
+/// Zombie: humanoid head/body/legs, but arms held out forward (the classic
+/// zombie pose) and raised higher when aggressive, plus the
+/// `AnimationUtils.animateZombieArms` attack swing driven by `attack_time`.
 #[allow(clippy::too_many_arguments)]
 pub fn compute_zombie_anim(
     model: &BakedEntityModel,
@@ -1235,11 +1244,7 @@ pub fn compute_zombie_anim(
                 Vec3::new(arm_drop + arm_swing_x + bx, 0.1 - attack_y * 0.6, bz)
             }
             "right_leg" => Vec3::new((walk_pos * 0.6662).cos() * 1.4 * walk_speed, 0.0, 0.0),
-            "left_leg" => Vec3::new(
-                (walk_pos * 0.6662 + PI).cos() * 1.4 * walk_speed,
-                0.0,
-                0.0,
-            ),
+            "left_leg" => Vec3::new((walk_pos * 0.6662 + PI).cos() * 1.4 * walk_speed, 0.0, 0.0),
             _ => continue,
         };
         anim.rotation.push((i, rot));
@@ -1249,9 +1254,9 @@ pub fn compute_zombie_anim(
 }
 
 /// Skeleton: standard humanoid limb swing; when aggressive the arms take the
-/// vanilla `HumanoidModel` `BOW_AND_ARROW` aim pose tracking the head (no held bow
-/// item is rendered). `age_in_ticks` is currently unused but kept for parity with
-/// the other humanoid anims.
+/// vanilla `HumanoidModel` `BOW_AND_ARROW` aim pose tracking the head (no held
+/// bow item is rendered). `age_in_ticks` is currently unused but kept for
+/// parity with the other humanoid anims.
 pub fn compute_skeleton_anim(
     model: &BakedEntityModel,
     head_x_rot_deg: f32,
@@ -1280,11 +1285,7 @@ pub fn compute_skeleton_anim(
             ),
             "left_arm" => Vec3::new((walk_pos * 0.6662).cos() * 2.0 * walk_speed * 0.5, 0.0, 0.0),
             "right_leg" => Vec3::new((walk_pos * 0.6662).cos() * 1.4 * walk_speed, 0.0, 0.0),
-            "left_leg" => Vec3::new(
-                (walk_pos * 0.6662 + PI).cos() * 1.4 * walk_speed,
-                0.0,
-                0.0,
-            ),
+            "left_leg" => Vec3::new((walk_pos * 0.6662 + PI).cos() * 1.4 * walk_speed, 0.0, 0.0),
             _ => continue,
         };
         anim.rotation.push((i, rot));
@@ -1316,9 +1317,8 @@ pub fn compute_spider_anim(
     // Each leg's exact render-space orientation = F·vanilla·F = Rz(-z)·Ry(+y)
     // (Y unchanged under the Y-flip; X/Z negate). Build it as a quaternion so the
     // engine reproduces vanilla's composition order exactly.
-    let leg_quat = |full_y: f32, full_z: f32| {
-        Quat::from_rotation_z(-full_z) * Quat::from_rotation_y(full_y)
-    };
+    let leg_quat =
+        |full_y: f32, full_z: f32| Quat::from_rotation_z(-full_z) * Quat::from_rotation_y(full_y);
 
     for (i, part) in model.parts.iter().enumerate() {
         let base = part.default_rotation;
@@ -1332,10 +1332,18 @@ pub fn compute_spider_anim(
             "left_hind_leg" => leg_quat(base.y - swing(0.0), base.z - step(0.0)),
             "right_middle_hind_leg" => leg_quat(base.y + swing(PI), base.z + step(PI)),
             "left_middle_hind_leg" => leg_quat(base.y - swing(PI), base.z - step(PI)),
-            "right_middle_front_leg" => leg_quat(base.y + swing(FRAC_PI_2), base.z + step(FRAC_PI_2)),
-            "left_middle_front_leg" => leg_quat(base.y - swing(FRAC_PI_2), base.z - step(FRAC_PI_2)),
-            "right_front_leg" => leg_quat(base.y + swing(three_half_pi), base.z + step(three_half_pi)),
-            "left_front_leg" => leg_quat(base.y - swing(three_half_pi), base.z - step(three_half_pi)),
+            "right_middle_front_leg" => {
+                leg_quat(base.y + swing(FRAC_PI_2), base.z + step(FRAC_PI_2))
+            }
+            "left_middle_front_leg" => {
+                leg_quat(base.y - swing(FRAC_PI_2), base.z - step(FRAC_PI_2))
+            }
+            "right_front_leg" => {
+                leg_quat(base.y + swing(three_half_pi), base.z + step(three_half_pi))
+            }
+            "left_front_leg" => {
+                leg_quat(base.y - swing(three_half_pi), base.z - step(three_half_pi))
+            }
             _ => continue,
         };
         anim.rotation_quat.push((i, q));

--- a/pomme-client/src/renderer/entity_model.rs
+++ b/pomme-client/src/renderer/entity_model.rs
@@ -48,11 +48,19 @@ pub struct BakedEntityModel {
     pub parts: Vec<EntityPart>,
     pub vertices: Vec<ChunkVertex>,
     pub part_ranges: Vec<(u32, u32)>,
+    /// Per-part scale (parallel to `parts`), applied about each part's pivot at
+    /// transform time. Scales geometry only, never UVs — used for baby mobs whose
+    /// head and body shrink by different factors. Default 1.0 for every part.
+    pub part_scales: Vec<f32>,
 }
 
 #[derive(Default)]
 pub struct PartAnim {
     pub rotation: Vec<(usize, Vec3)>,
+    /// Quaternion rotation override; takes precedence over `rotation` for a part.
+    /// Used where the engine's fixed euler order can't reproduce vanilla's
+    /// composition (e.g. spider legs with combined yaw + tilt).
+    pub rotation_quat: Vec<(usize, Quat)>,
     pub translation: Vec<(usize, Vec3)>,
 }
 
@@ -60,17 +68,24 @@ impl BakedEntityModel {
     pub fn compute_part_transforms(&self, anim: &PartAnim) -> Vec<Mat4> {
         let mut transforms = Vec::with_capacity(self.parts.len());
 
-        for part in &self.parts {
+        for (i, part) in self.parts.iter().enumerate() {
+            let mut quat_rot = None;
+            for &(idx, q) in &anim.rotation_quat {
+                if idx == i {
+                    quat_rot = Some(q);
+                    break;
+                }
+            }
             let mut rot = part.default_rotation;
             for &(idx, r) in &anim.rotation {
-                if idx == transforms.len() {
+                if idx == i {
                     rot = r;
                     break;
                 }
             }
             let mut extra_translation = Vec3::ZERO;
             for &(idx, t) in &anim.translation {
-                if idx == transforms.len() {
+                if idx == i {
                     extra_translation = t;
                     break;
                 }
@@ -81,10 +96,21 @@ impl BakedEntityModel {
             let offset_z = part.offset.z + extra_translation.z;
             let offset = Vec3::new(offset_x, offset_y, offset_z) / 16.0;
 
-            let local = Mat4::from_translation(offset)
-                * Mat4::from_rotation_x(-rot.x)
-                * Mat4::from_rotation_y(-rot.y)
-                * Mat4::from_rotation_z(rot.z);
+            // A quaternion override expresses the exact render-space orientation
+            // directly; otherwise use the legacy per-axis euler product (note the
+            // engine's mixed signs: -x, -y, +z).
+            let rot_mat = match quat_rot {
+                Some(q) => Mat4::from_quat(q),
+                None => {
+                    Mat4::from_rotation_x(-rot.x)
+                        * Mat4::from_rotation_y(-rot.y)
+                        * Mat4::from_rotation_z(rot.z)
+                }
+            };
+            let scale = self.part_scales.get(i).copied().unwrap_or(1.0);
+
+            let local =
+                Mat4::from_translation(offset) * rot_mat * Mat4::from_scale(Vec3::splat(scale));
 
             let transform = if let Some(parent_idx) = part.parent {
                 transforms[parent_idx] * local
@@ -112,10 +138,12 @@ pub fn bake_model(parts: Vec<EntityPart>, tex_w: u32, tex_h: u32) -> BakedEntity
         part_ranges.push((start, count));
     }
 
+    let part_scales = vec![1.0; parts.len()];
     BakedEntityModel {
         parts,
         vertices,
         part_ranges,
+        part_scales,
     }
 }
 
@@ -268,13 +296,23 @@ pub fn bake_player_model() -> BakedEntityModel {
             name: "head".into(),
             offset: Vec3::new(0.0, 0.0, 0.0),
             default_rotation: Vec3::ZERO,
-            cubes: vec![ModelCube {
-                origin: Vec3::new(-4.0, -8.0, -4.0),
-                size: Vec3::new(8.0, 8.0, 8.0),
-                tex_offset: (0, 0),
-                deformation: 0.0,
-                mirror: false,
-            }],
+            cubes: vec![
+                ModelCube {
+                    origin: Vec3::new(-4.0, -8.0, -4.0),
+                    size: Vec3::new(8.0, 8.0, 8.0),
+                    tex_offset: (0, 0),
+                    deformation: 0.0,
+                    mirror: false,
+                },
+                // Hat / headwear outer layer.
+                ModelCube {
+                    origin: Vec3::new(-4.0, -8.0, -4.0),
+                    size: Vec3::new(8.0, 8.0, 8.0),
+                    tex_offset: (32, 0),
+                    deformation: 0.5,
+                    mirror: false,
+                },
+            ],
             parent: None,
         },
         EntityPart {
@@ -345,6 +383,317 @@ pub fn bake_player_model() -> BakedEntityModel {
     ];
 
     bake_model(parts, 64, 64)
+}
+
+/// Legacy single-arm humanoid layout (head/body/right_arm/left_arm/right_leg/
+/// left_leg), shared by zombie and skeleton. `limb` builds the four limb cubes so
+/// zombie (4-wide) and skeleton (2-wide thin) can differ while keeping identical
+/// part names/order (required for shared animation indexing). `tex_h` lets zombie
+/// use a 64-tall sheet and skeleton a 32-tall one.
+fn humanoid_parts(
+    arm_cube_right: ModelCube,
+    leg_cube_right: ModelCube,
+    right_leg_x: f32,
+) -> Vec<EntityPart> {
+    let arm_cube_left = ModelCube {
+        mirror: true,
+        ..arm_cube_right
+    };
+    let leg_cube_left = ModelCube {
+        mirror: true,
+        ..leg_cube_right
+    };
+    vec![
+        EntityPart {
+            name: "head".into(),
+            offset: Vec3::new(0.0, 0.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![
+                ModelCube {
+                    origin: Vec3::new(-4.0, -8.0, -4.0),
+                    size: Vec3::new(8.0, 8.0, 8.0),
+                    tex_offset: (0, 0),
+                    deformation: 0.0,
+                    mirror: false,
+                },
+                // Hat / headwear outer layer (vanilla `HumanoidModel` head child).
+                ModelCube {
+                    origin: Vec3::new(-4.0, -8.0, -4.0),
+                    size: Vec3::new(8.0, 8.0, 8.0),
+                    tex_offset: (32, 0),
+                    deformation: 0.5,
+                    mirror: false,
+                },
+            ],
+            parent: None,
+        },
+        EntityPart {
+            name: "body".into(),
+            offset: Vec3::new(0.0, 0.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-4.0, 0.0, -2.0),
+                size: Vec3::new(8.0, 12.0, 4.0),
+                tex_offset: (16, 16),
+                deformation: 0.0,
+                mirror: false,
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "right_arm".into(),
+            offset: Vec3::new(-5.0, 2.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![arm_cube_right],
+            parent: None,
+        },
+        EntityPart {
+            name: "left_arm".into(),
+            offset: Vec3::new(5.0, 2.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![arm_cube_left],
+            parent: None,
+        },
+        EntityPart {
+            name: "right_leg".into(),
+            offset: Vec3::new(-right_leg_x, 12.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![leg_cube_right],
+            parent: None,
+        },
+        EntityPart {
+            name: "left_leg".into(),
+            offset: Vec3::new(right_leg_x, 12.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![leg_cube_left],
+            parent: None,
+        },
+    ]
+}
+
+/// Zombie mesh parts: `HumanoidModel.createMesh` layout with 4×12×4 limbs.
+fn zombie_parts() -> Vec<EntityPart> {
+    let arm = ModelCube {
+        origin: Vec3::new(-3.0, -2.0, -2.0),
+        size: Vec3::new(4.0, 12.0, 4.0),
+        tex_offset: (40, 16),
+        deformation: 0.0,
+        mirror: false,
+    };
+    let leg = ModelCube {
+        origin: Vec3::new(-2.0, 0.0, -2.0),
+        size: Vec3::new(4.0, 12.0, 4.0),
+        tex_offset: (0, 16),
+        deformation: 0.0,
+        mirror: false,
+    };
+    humanoid_parts(arm, leg, 1.9)
+}
+
+pub fn bake_zombie_model() -> BakedEntityModel {
+    bake_model(zombie_parts(), 64, 64)
+}
+
+/// Baby zombie: adult mesh transformed per vanilla `BabyModelTransform` — head
+/// scales 0.75, body/limbs 0.5, each pivot shifted so the feet stay grounded.
+/// Per-part scaling is geometry-only, so UVs are untouched.
+pub fn bake_baby_zombie_model() -> BakedEntityModel {
+    const HEAD_SCALE: f32 = 0.75;
+    const BODY_SCALE: f32 = 0.5;
+    let mut parts = zombie_parts();
+    let mut scales = Vec::with_capacity(parts.len());
+    for part in &mut parts {
+        let (scale, lift) = if part.name == "head" {
+            (HEAD_SCALE, 16.0)
+        } else {
+            (BODY_SCALE, 24.0)
+        };
+        part.offset = (part.offset + Vec3::new(0.0, lift, 0.0)) * scale;
+        scales.push(scale);
+    }
+    let mut model = bake_model(parts, 64, 64);
+    model.part_scales = scales;
+    model
+}
+
+/// Skeleton: humanoid layout with thin 2×12×2 limbs, 64×32 sheet
+/// (`SkeletonModel.createDefaultSkeletonMesh`).
+pub fn bake_skeleton_model() -> BakedEntityModel {
+    let arm = ModelCube {
+        origin: Vec3::new(-1.0, -2.0, -1.0),
+        size: Vec3::new(2.0, 12.0, 2.0),
+        tex_offset: (40, 16),
+        deformation: 0.0,
+        mirror: false,
+    };
+    let leg = ModelCube {
+        origin: Vec3::new(-1.0, 0.0, -1.0),
+        size: Vec3::new(2.0, 12.0, 2.0),
+        tex_offset: (0, 16),
+        deformation: 0.0,
+        mirror: false,
+    };
+    bake_model(humanoid_parts(arm, leg, 2.0), 64, 32)
+}
+
+/// Creeper: head + upright body + four legs, animated as a quadruped
+/// (`CreeperModel.createBodyLayer`). 64×32 sheet.
+pub fn bake_creeper_model() -> BakedEntityModel {
+    let mut parts = vec![
+        EntityPart {
+            name: "head".into(),
+            offset: Vec3::new(0.0, 6.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-4.0, -8.0, -4.0),
+                size: Vec3::new(8.0, 8.0, 8.0),
+                tex_offset: (0, 0),
+                deformation: 0.0,
+                mirror: false,
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "body".into(),
+            offset: Vec3::new(0.0, 6.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-4.0, 0.0, -2.0),
+                size: Vec3::new(8.0, 12.0, 4.0),
+                tex_offset: (16, 16),
+                deformation: 0.0,
+                mirror: false,
+            }],
+            parent: None,
+        },
+    ];
+    let leg = ModelCube {
+        origin: Vec3::new(-2.0, 0.0, -2.0),
+        size: Vec3::new(4.0, 6.0, 4.0),
+        tex_offset: (0, 16),
+        deformation: 0.0,
+        mirror: false,
+    };
+    parts.extend(quadruped_legs(2.0, 18.0, -4.0, 4.0, leg, leg));
+    bake_model(parts, 64, 32)
+}
+
+/// Spider: head, two body segments, and eight legs with per-leg base rotations.
+/// `SpiderModel.createSpiderBodyLayer`, 64×32 sheet.
+pub fn bake_spider_model() -> BakedEntityModel {
+    bake_model(spider_parts(), 64, 32)
+}
+
+fn spider_parts() -> Vec<EntityPart> {
+    use std::f32::consts::{FRAC_PI_4, FRAC_PI_8};
+    // Vanilla middle-leg z-rotation; not a named constant.
+    const MID_Z_ROT: f32 = 0.58119464;
+    let right_leg = ModelCube {
+        origin: Vec3::new(-15.0, -1.0, -1.0),
+        size: Vec3::new(16.0, 2.0, 2.0),
+        tex_offset: (18, 0),
+        deformation: 0.0,
+        mirror: false,
+    };
+    let left_leg = ModelCube {
+        origin: Vec3::new(-1.0, -1.0, -1.0),
+        size: Vec3::new(16.0, 2.0, 2.0),
+        tex_offset: (18, 0),
+        deformation: 0.0,
+        mirror: true,
+    };
+    // Base leg poses (x, z) and rotations (yRot, zRot) from vanilla PartPose.
+    let leg = |name: &str, x: f32, z: f32, y_rot: f32, z_rot: f32, cube: ModelCube| EntityPart {
+        name: name.into(),
+        offset: Vec3::new(x, 15.0, z),
+        default_rotation: Vec3::new(0.0, y_rot, z_rot),
+        cubes: vec![cube],
+        parent: None,
+    };
+    vec![
+        EntityPart {
+            name: "head".into(),
+            offset: Vec3::new(0.0, 15.0, -3.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-4.0, -4.0, -8.0),
+                size: Vec3::new(8.0, 8.0, 8.0),
+                tex_offset: (32, 4),
+                deformation: 0.0,
+                mirror: false,
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "body0".into(),
+            offset: Vec3::new(0.0, 15.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-3.0, -3.0, -3.0),
+                size: Vec3::new(6.0, 6.0, 6.0),
+                tex_offset: (0, 0),
+                deformation: 0.0,
+                mirror: false,
+            }],
+            parent: None,
+        },
+        EntityPart {
+            name: "body1".into(),
+            offset: Vec3::new(0.0, 15.0, 9.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![ModelCube {
+                origin: Vec3::new(-5.0, -4.0, -6.0),
+                size: Vec3::new(10.0, 8.0, 12.0),
+                tex_offset: (0, 12),
+                deformation: 0.0,
+                mirror: false,
+            }],
+            parent: None,
+        },
+        leg("right_hind_leg", -4.0, 2.0, FRAC_PI_4, -FRAC_PI_4, right_leg),
+        leg("left_hind_leg", 4.0, 2.0, -FRAC_PI_4, FRAC_PI_4, left_leg),
+        leg(
+            "right_middle_hind_leg",
+            -4.0,
+            1.0,
+            FRAC_PI_8,
+            -MID_Z_ROT,
+            right_leg,
+        ),
+        leg(
+            "left_middle_hind_leg",
+            4.0,
+            1.0,
+            -FRAC_PI_8,
+            MID_Z_ROT,
+            left_leg,
+        ),
+        leg(
+            "right_middle_front_leg",
+            -4.0,
+            0.0,
+            -FRAC_PI_8,
+            -MID_Z_ROT,
+            right_leg,
+        ),
+        leg(
+            "left_middle_front_leg",
+            4.0,
+            0.0,
+            FRAC_PI_8,
+            MID_Z_ROT,
+            left_leg,
+        ),
+        leg(
+            "right_front_leg",
+            -4.0,
+            -1.0,
+            -FRAC_PI_4,
+            -FRAC_PI_4,
+            right_leg,
+        ),
+        leg("left_front_leg", 4.0, -1.0, FRAC_PI_4, FRAC_PI_4, left_leg),
+    ]
 }
 
 pub fn bake_cow_model() -> BakedEntityModel {
@@ -831,6 +1180,165 @@ pub fn compute_quadruped_anim(
                 .push((i, Vec3::new(0.0, head_y_offset, 0.0)));
         }
         anim.rotation.push((i, rot));
+    }
+
+    anim
+}
+
+fn head_rotation(head_x_rot_deg: f32, local_head_y_rot_deg: f32) -> Vec3 {
+    let rot = Quat::from_rotation_y(local_head_y_rot_deg.to_radians())
+        * Quat::from_rotation_x(head_x_rot_deg.to_radians());
+    let (x, y, z) = rot.to_euler(glam::EulerRot::XYZ);
+    Vec3::new(x, y, z)
+}
+
+/// Vanilla `AnimationUtils.bobModelPart`: a gentle idle sway added to undead arms.
+/// Returns the (xRot, zRot) delta; `side` is +1.0 for the right arm, -1.0 left.
+fn bob_arm(age_in_ticks: f32, side: f32) -> (f32, f32) {
+    let z = side * ((age_in_ticks * 0.09).cos() * 0.05 + 0.05);
+    let x = side * (age_in_ticks * 0.067).sin() * 0.05;
+    (x, z)
+}
+
+/// Zombie: humanoid head/body/legs, but arms held out forward (the classic zombie
+/// pose) and raised higher when aggressive, plus the `AnimationUtils.animateZombieArms`
+/// attack swing driven by `attack_time`.
+#[allow(clippy::too_many_arguments)]
+pub fn compute_zombie_anim(
+    model: &BakedEntityModel,
+    head_x_rot_deg: f32,
+    local_head_y_rot_deg: f32,
+    walk_pos: f32,
+    walk_speed: f32,
+    aggressive: bool,
+    age_in_ticks: f32,
+    attack_time: f32,
+) -> PartAnim {
+    use std::f32::consts::PI;
+    let mut anim = PartAnim::default();
+    let arm_drop = if aggressive { -PI / 1.5 } else { -PI / 2.25 };
+    // Vanilla `AnimationUtils.animateZombieArms` attack swing (0 at both endpoints,
+    // peaks mid-swing). Added on top of the held-out idle pose.
+    let attack_y = (attack_time * PI).sin();
+    let attack_x = ((1.0 - (1.0 - attack_time) * (1.0 - attack_time)) * PI).sin();
+    let arm_swing_x = attack_y * 1.2 - attack_x * 0.4;
+
+    for (i, part) in model.parts.iter().enumerate() {
+        let rot = match part.name.as_str() {
+            "head" => head_rotation(head_x_rot_deg, local_head_y_rot_deg),
+            "right_arm" => {
+                let (bx, bz) = bob_arm(age_in_ticks, 1.0);
+                Vec3::new(arm_drop + arm_swing_x + bx, -0.1 + attack_y * 0.6, bz)
+            }
+            "left_arm" => {
+                let (bx, bz) = bob_arm(age_in_ticks, -1.0);
+                Vec3::new(arm_drop + arm_swing_x + bx, 0.1 - attack_y * 0.6, bz)
+            }
+            "right_leg" => Vec3::new((walk_pos * 0.6662).cos() * 1.4 * walk_speed, 0.0, 0.0),
+            "left_leg" => Vec3::new(
+                (walk_pos * 0.6662 + PI).cos() * 1.4 * walk_speed,
+                0.0,
+                0.0,
+            ),
+            _ => continue,
+        };
+        anim.rotation.push((i, rot));
+    }
+
+    anim
+}
+
+/// Skeleton: standard humanoid limb swing; when aggressive the arms take the
+/// vanilla `HumanoidModel` `BOW_AND_ARROW` aim pose tracking the head (no held bow
+/// item is rendered). `age_in_ticks` is currently unused but kept for parity with
+/// the other humanoid anims.
+pub fn compute_skeleton_anim(
+    model: &BakedEntityModel,
+    head_x_rot_deg: f32,
+    local_head_y_rot_deg: f32,
+    walk_pos: f32,
+    walk_speed: f32,
+    aggressive: bool,
+    _age_in_ticks: f32,
+) -> PartAnim {
+    use std::f32::consts::{FRAC_PI_2, PI};
+    let mut anim = PartAnim::default();
+    let head_x = head_x_rot_deg.to_radians();
+    let head_y = local_head_y_rot_deg.to_radians();
+
+    for (i, part) in model.parts.iter().enumerate() {
+        let rot = match part.name.as_str() {
+            "head" => head_rotation(head_x_rot_deg, local_head_y_rot_deg),
+            // `poseRightArm` BOW_AND_ARROW (right-handed): both arms point where the
+            // head looks, the off hand swung slightly inward.
+            "right_arm" if aggressive => Vec3::new(-FRAC_PI_2 + head_x, -0.1 + head_y, 0.0),
+            "left_arm" if aggressive => Vec3::new(-FRAC_PI_2 + head_x, 0.1 + head_y + 0.4, 0.0),
+            "right_arm" => Vec3::new(
+                (walk_pos * 0.6662 + PI).cos() * 2.0 * walk_speed * 0.5,
+                0.0,
+                0.0,
+            ),
+            "left_arm" => Vec3::new((walk_pos * 0.6662).cos() * 2.0 * walk_speed * 0.5, 0.0, 0.0),
+            "right_leg" => Vec3::new((walk_pos * 0.6662).cos() * 1.4 * walk_speed, 0.0, 0.0),
+            "left_leg" => Vec3::new(
+                (walk_pos * 0.6662 + PI).cos() * 1.4 * walk_speed,
+                0.0,
+                0.0,
+            ),
+            _ => continue,
+        };
+        anim.rotation.push((i, rot));
+    }
+
+    anim
+}
+
+/// Spider: head tracking plus the eight-leg gait from `SpiderModel.setupAnim`.
+/// Each leg's final rotation is its base pose (`default_rotation`) plus a swing
+/// (yRot) and step (zRot) term; four phase offsets stagger the legs.
+pub fn compute_spider_anim(
+    model: &BakedEntityModel,
+    head_x_rot_deg: f32,
+    local_head_y_rot_deg: f32,
+    walk_pos: f32,
+    walk_speed: f32,
+) -> PartAnim {
+    use std::f32::consts::{FRAC_PI_2, PI};
+    let mut anim = PartAnim::default();
+
+    let pos = walk_pos * 0.6662;
+    // Per-leg-group swing (yaw) and step (vertical) terms; right legs add, left
+    // legs subtract (vanilla `+=`/`-=`).
+    let swing = |phase: f32| -((pos * 2.0 + phase).cos() * 0.4) * walk_speed;
+    let step = |phase: f32| ((pos + phase).sin() * 0.4).abs() * walk_speed;
+    let three_half_pi = 3.0 * FRAC_PI_2;
+
+    // Each leg's exact render-space orientation = F·vanilla·F = Rz(-z)·Ry(+y)
+    // (Y unchanged under the Y-flip; X/Z negate). Build it as a quaternion so the
+    // engine reproduces vanilla's composition order exactly.
+    let leg_quat = |full_y: f32, full_z: f32| {
+        Quat::from_rotation_z(-full_z) * Quat::from_rotation_y(full_y)
+    };
+
+    for (i, part) in model.parts.iter().enumerate() {
+        let base = part.default_rotation;
+        let q = match part.name.as_str() {
+            "head" => {
+                anim.rotation
+                    .push((i, head_rotation(head_x_rot_deg, local_head_y_rot_deg)));
+                continue;
+            }
+            "right_hind_leg" => leg_quat(base.y + swing(0.0), base.z + step(0.0)),
+            "left_hind_leg" => leg_quat(base.y - swing(0.0), base.z - step(0.0)),
+            "right_middle_hind_leg" => leg_quat(base.y + swing(PI), base.z + step(PI)),
+            "left_middle_hind_leg" => leg_quat(base.y - swing(PI), base.z - step(PI)),
+            "right_middle_front_leg" => leg_quat(base.y + swing(FRAC_PI_2), base.z + step(FRAC_PI_2)),
+            "left_middle_front_leg" => leg_quat(base.y - swing(FRAC_PI_2), base.z - step(FRAC_PI_2)),
+            "right_front_leg" => leg_quat(base.y + swing(three_half_pi), base.z + step(three_half_pi)),
+            "left_front_leg" => leg_quat(base.y - swing(three_half_pi), base.z - step(three_half_pi)),
+            _ => continue,
+        };
+        anim.rotation_quat.push((i, q));
     }
 
     anim

--- a/pomme-client/src/renderer/pipelines/block_entity.rs
+++ b/pomme-client/src/renderer/pipelines/block_entity.rs
@@ -12,7 +12,9 @@ use crate::assets::{AssetIndex, resolve_asset_path};
 use crate::renderer::camera::CameraUniform;
 use crate::renderer::chunk::mesher::ChunkVertex;
 use crate::renderer::entity_model::{BakedEntityModel, PartAnim};
-use crate::renderer::pipelines::entity_renderer::{WHITE_TINT, create_pipeline, fallback_texture};
+use crate::renderer::pipelines::entity_renderer::{
+    BlendMode, WHITE_TINT, create_pipeline, fallback_texture,
+};
 use crate::renderer::{MAX_FRAMES_IN_FLIGHT, block_entity_model, util};
 
 pub struct BlockEntityRenderInfo {
@@ -135,6 +137,7 @@ fn lid_anim(kind: BlockEntityKind, openness: f32) -> PartAnim {
         BlockEntityKind::ShulkerBox => PartAnim {
             rotation: vec![(0, glam::Vec3::new(0.0, eased * 270.0f32.to_radians(), 0.0))],
             translation: vec![(0, glam::Vec3::new(0.0, -eased * 8.0, 0.0))],
+            ..Default::default()
         },
         _ => PartAnim::default(),
     }
@@ -239,7 +242,7 @@ impl BlockEntityPipeline {
         let push_constant_range = vk::PushConstantRange {
             stage_flags: vk::ShaderStageFlags::Vertex,
             offset: 0,
-            size: 80,
+            size: 112,
         };
         let layouts = [camera_layout, texture_layout];
         let layout_info = vk::PipelineLayoutCreateInfo {
@@ -253,7 +256,7 @@ impl BlockEntityPipeline {
             .create_pipeline_layout(&layout_info, None)
             .expect("failed to create block-entity pipeline layout");
 
-        let pipeline = create_pipeline(device, render_pass, pipeline_layout);
+        let pipeline = create_pipeline(device, render_pass, pipeline_layout, BlendMode::Opaque);
 
         let defs = kind_definitions();
         let tex_count = defs
@@ -423,9 +426,15 @@ impl BlockEntityPipeline {
                 }
                 let part_mat = model_mat * part_transforms[i];
                 let cols = part_mat.to_cols_array();
-                let mut bytes = [0u8; 80];
+                // Shared entity shader push block: mat, tint, overlay_color, uv_params.
+                // Block entities are opaque with no hurt flash or UV scroll.
+                let no_overlay = [0.0f32, 0.0, 0.0, 1.0];
+                let uv_params = [0.0f32; 4];
+                let mut bytes = [0u8; 112];
                 bytes[..64].copy_from_slice(bytemuck::cast_slice(&cols));
-                bytes[64..].copy_from_slice(bytemuck::cast_slice(&WHITE_TINT));
+                bytes[64..80].copy_from_slice(bytemuck::cast_slice(&WHITE_TINT));
+                bytes[80..96].copy_from_slice(bytemuck::cast_slice(&no_overlay));
+                bytes[96..112].copy_from_slice(bytemuck::cast_slice(&uv_params));
                 cmd.push_constants(
                     self.pipeline_layout,
                     vk::ShaderStageFlags::Vertex,
@@ -439,7 +448,8 @@ impl BlockEntityPipeline {
 
     pub fn recreate_pipeline(&mut self, device: &vk::Device, render_pass: vk::RenderPass) {
         device.destroy_pipeline(self.pipeline, None);
-        self.pipeline = create_pipeline(device, render_pass, self.pipeline_layout);
+        self.pipeline =
+            create_pipeline(device, render_pass, self.pipeline_layout, BlendMode::Opaque);
     }
 
     pub fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -46,7 +46,8 @@ enum OverlayKind {
     Opaque,
     /// Translucent, full-bright, depth-write off — spider glowing eyes.
     EyesTranslucent,
-    /// Additive, full-bright, depth-write off, scrolling UV — charged creeper swirl.
+    /// Additive, full-bright, depth-write off, scrolling UV — charged creeper
+    /// swirl.
     SwirlAdditive,
 }
 
@@ -248,7 +249,11 @@ fn mob_definitions() -> Vec<MobDef> {
             kind: EntityKind::Pig,
             anim: AnimationType::Quadruped,
             adult: opaque(entity_model::bake_pig_model(), PIG_ADULT_TEX, 64),
-            baby: Some(opaque(entity_model::bake_baby_pig_model(), PIG_BABY_TEX, 32)),
+            baby: Some(opaque(
+                entity_model::bake_baby_pig_model(),
+                PIG_BABY_TEX,
+                32,
+            )),
             adult_overlays: vec![],
             baby_overlays: vec![],
         },
@@ -256,7 +261,11 @@ fn mob_definitions() -> Vec<MobDef> {
             kind: EntityKind::Cow,
             anim: AnimationType::Quadruped,
             adult: opaque(entity_model::bake_cow_model(), COW_ADULT_TEX, 64),
-            baby: Some(opaque(entity_model::bake_baby_cow_model(), COW_BABY_TEX, 64)),
+            baby: Some(opaque(
+                entity_model::bake_baby_cow_model(),
+                COW_BABY_TEX,
+                64,
+            )),
             adult_overlays: vec![],
             baby_overlays: vec![],
         },
@@ -678,9 +687,10 @@ impl EntityRenderer {
                 continue;
             };
             let overlays = entry.overlays(info.is_baby);
-            let has_visible = overlays.iter().enumerate().any(|(slot, ov)| {
-                ov.overlay_kind == kind && info.overlay_tints[slot].is_some()
-            });
+            let has_visible = overlays
+                .iter()
+                .enumerate()
+                .any(|(slot, ov)| ov.overlay_kind == kind && info.overlay_tints[slot].is_some());
             if !has_visible {
                 continue;
             }

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -31,6 +31,23 @@ pub struct EntityRenderInfo {
     pub head_y_offset: f32,
     pub head_x_rot_deg_override: Option<f32>,
     pub has_red_overlay: bool,
+    /// Mob is targeting/attacking — raises zombie/skeleton arms.
+    pub aggressive: bool,
+    /// Interpolated entity age in ticks; drives the undead idle arm bob.
+    pub age_in_ticks: f32,
+    /// Arm-swing progress 0..1; drives the zombie attack swing.
+    pub attack_time: f32,
+}
+
+/// How an overlay layer is blended. Base/baby variants are always `Opaque`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OverlayKind {
+    /// Cutout, depth-writing — sheep wool and all base models.
+    Opaque,
+    /// Translucent, full-bright, depth-write off — spider glowing eyes.
+    EyesTranslucent,
+    /// Additive, full-bright, depth-write off, scrolling UV — charged creeper swirl.
+    SwirlAdditive,
 }
 
 struct MobVariant {
@@ -41,6 +58,7 @@ struct MobVariant {
     texture_view: vk::ImageView,
     texture_allocation: Allocation,
     texture_set: vk::DescriptorSet,
+    overlay_kind: OverlayKind,
 }
 
 struct MobEntry {
@@ -125,6 +143,10 @@ pub fn jeb_sheep_tint(entity_id: i32, age_in_ticks: u32) -> [f32; 4] {
 
 pub struct EntityRenderer {
     pipeline: vk::Pipeline,
+    /// Translucent, depth-write off — spider eyes.
+    eyes_pipeline: vk::Pipeline,
+    /// Additive, depth-write off — charged-creeper energy swirl.
+    swirl_pipeline: vk::Pipeline,
     pipeline_layout: vk::PipelineLayout,
     camera_layout: vk::DescriptorSetLayout,
     texture_layout: vk::DescriptorSetLayout,
@@ -133,13 +155,25 @@ pub struct EntityRenderer {
     camera_buffers: Vec<vk::Buffer>,
     camera_allocations: Vec<Allocation>,
     texture_sampler: vk::Sampler,
+    /// REPEAT-wrap sampler for the scrolling swirl overlay.
+    texture_sampler_repeat: vk::Sampler,
     mobs: HashMap<EntityKind, MobEntry>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum BlendMode {
+    Opaque,
+    Translucent,
+    Additive,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum AnimationType {
     Quadruped,
     Humanoid,
+    Zombie,
+    Skeleton,
+    Spider,
 }
 
 struct VariantDef {
@@ -148,6 +182,7 @@ struct VariantDef {
     /// fallback chain of asset keys.
     tex_variants: &'static [&'static [&'static str]],
     tex_size: u32,
+    overlay_kind: OverlayKind,
 }
 
 struct MobDef {
@@ -186,81 +221,123 @@ fn mob_definitions() -> Vec<MobDef> {
     const SHEEP_BABY_WOOL_TEX: &[&[&str]] =
         &[&["minecraft/textures/entity/sheep/sheep_wool_baby.png"]];
     const PLAYER_TEX: &[&[&str]] = &[&["minecraft/textures/entity/player/wide/steve.png"]];
+    const ZOMBIE_TEX: &[&[&str]] = &[&["minecraft/textures/entity/zombie/zombie.png"]];
+    const SKELETON_TEX: &[&[&str]] = &[&["minecraft/textures/entity/skeleton/skeleton.png"]];
+    const CREEPER_TEX: &[&[&str]] = &[&["minecraft/textures/entity/creeper/creeper.png"]];
+    const CREEPER_ARMOR_TEX: &[&[&str]] =
+        &[&["minecraft/textures/entity/creeper/creeper_armor.png"]];
+    const SPIDER_TEX: &[&[&str]] = &[&["minecraft/textures/entity/spider/spider.png"]];
+    const SPIDER_EYES_TEX: &[&[&str]] = &[&["minecraft/textures/entity/spider/spider_eyes.png"]];
+
+    // Base and baby models, plus opaque overlays (sheep wool), are all Opaque.
+    fn opaque(
+        model: BakedEntityModel,
+        tex_variants: &'static [&'static [&'static str]],
+        tex_size: u32,
+    ) -> VariantDef {
+        VariantDef {
+            model,
+            tex_variants,
+            tex_size,
+            overlay_kind: OverlayKind::Opaque,
+        }
+    }
 
     vec![
         MobDef {
             kind: EntityKind::Pig,
             anim: AnimationType::Quadruped,
-            adult: VariantDef {
-                model: entity_model::bake_pig_model(),
-                tex_variants: PIG_ADULT_TEX,
-                tex_size: 64,
-            },
-            baby: Some(VariantDef {
-                model: entity_model::bake_baby_pig_model(),
-                tex_variants: PIG_BABY_TEX,
-                tex_size: 32,
-            }),
+            adult: opaque(entity_model::bake_pig_model(), PIG_ADULT_TEX, 64),
+            baby: Some(opaque(entity_model::bake_baby_pig_model(), PIG_BABY_TEX, 32)),
             adult_overlays: vec![],
             baby_overlays: vec![],
         },
         MobDef {
             kind: EntityKind::Cow,
             anim: AnimationType::Quadruped,
-            adult: VariantDef {
-                model: entity_model::bake_cow_model(),
-                tex_variants: COW_ADULT_TEX,
-                tex_size: 64,
-            },
-            baby: Some(VariantDef {
-                model: entity_model::bake_baby_cow_model(),
-                tex_variants: COW_BABY_TEX,
-                tex_size: 64,
-            }),
+            adult: opaque(entity_model::bake_cow_model(), COW_ADULT_TEX, 64),
+            baby: Some(opaque(entity_model::bake_baby_cow_model(), COW_BABY_TEX, 64)),
             adult_overlays: vec![],
             baby_overlays: vec![],
         },
         MobDef {
             kind: EntityKind::Sheep,
             anim: AnimationType::Quadruped,
-            adult: VariantDef {
-                model: entity_model::bake_sheep_model(),
-                tex_variants: SHEEP_ADULT_TEX,
-                tex_size: 64,
-            },
-            baby: Some(VariantDef {
-                model: entity_model::bake_baby_sheep_model(),
-                tex_variants: SHEEP_BABY_TEX,
-                tex_size: 64,
-            }),
+            adult: opaque(entity_model::bake_sheep_model(), SHEEP_ADULT_TEX, 64),
+            baby: Some(opaque(
+                entity_model::bake_baby_sheep_model(),
+                SHEEP_BABY_TEX,
+                64,
+            )),
             adult_overlays: vec![
-                VariantDef {
-                    model: entity_model::bake_sheep_wool_undercoat_model(),
-                    tex_variants: SHEEP_WOOL_UNDERCOAT_TEX,
-                    tex_size: 64,
-                },
-                VariantDef {
-                    model: entity_model::bake_sheep_wool_model(),
-                    tex_variants: SHEEP_WOOL_TEX,
-                    tex_size: 64,
-                },
+                opaque(
+                    entity_model::bake_sheep_wool_undercoat_model(),
+                    SHEEP_WOOL_UNDERCOAT_TEX,
+                    64,
+                ),
+                opaque(entity_model::bake_sheep_wool_model(), SHEEP_WOOL_TEX, 64),
             ],
-            baby_overlays: vec![VariantDef {
-                model: entity_model::bake_baby_sheep_wool_model(),
-                tex_variants: SHEEP_BABY_WOOL_TEX,
-                tex_size: 64,
-            }],
+            baby_overlays: vec![opaque(
+                entity_model::bake_baby_sheep_wool_model(),
+                SHEEP_BABY_WOOL_TEX,
+                64,
+            )],
         },
         MobDef {
             kind: EntityKind::Player,
             anim: AnimationType::Humanoid,
-            adult: VariantDef {
-                model: entity_model::bake_player_model(),
-                tex_variants: PLAYER_TEX,
-                tex_size: 64,
-            },
+            adult: opaque(entity_model::bake_player_model(), PLAYER_TEX, 64),
             baby: None,
             adult_overlays: vec![],
+            baby_overlays: vec![],
+        },
+        MobDef {
+            kind: EntityKind::Zombie,
+            anim: AnimationType::Zombie,
+            adult: opaque(entity_model::bake_zombie_model(), ZOMBIE_TEX, 64),
+            baby: Some(opaque(
+                entity_model::bake_baby_zombie_model(),
+                ZOMBIE_TEX,
+                64,
+            )),
+            adult_overlays: vec![],
+            baby_overlays: vec![],
+        },
+        MobDef {
+            kind: EntityKind::Skeleton,
+            anim: AnimationType::Skeleton,
+            adult: opaque(entity_model::bake_skeleton_model(), SKELETON_TEX, 64),
+            baby: None,
+            adult_overlays: vec![],
+            baby_overlays: vec![],
+        },
+        MobDef {
+            kind: EntityKind::Creeper,
+            anim: AnimationType::Quadruped,
+            adult: opaque(entity_model::bake_creeper_model(), CREEPER_TEX, 64),
+            baby: None,
+            // Slot 0: charged-creeper energy swirl (additive, scrolling), shown only
+            // when `powered` (gated via overlay_tints in entity_extras).
+            adult_overlays: vec![VariantDef {
+                model: entity_model::bake_creeper_model(),
+                tex_variants: CREEPER_ARMOR_TEX,
+                tex_size: 64,
+                overlay_kind: OverlayKind::SwirlAdditive,
+            }],
+            baby_overlays: vec![],
+        },
+        MobDef {
+            kind: EntityKind::Spider,
+            anim: AnimationType::Spider,
+            adult: opaque(entity_model::bake_spider_model(), SPIDER_TEX, 64),
+            baby: None,
+            // Slot 0: glowing eyes (translucent, full-bright), always visible.
+            adult_overlays: vec![VariantDef {
+                model: entity_model::bake_spider_model(),
+                tex_variants: SPIDER_EYES_TEX,
+                tex_size: 64,
+                overlay_kind: OverlayKind::EyesTranslucent,
+            }],
             baby_overlays: vec![],
         },
     ]
@@ -291,7 +368,7 @@ impl EntityRenderer {
         let push_constant_range = vk::PushConstantRange {
             stage_flags: vk::ShaderStageFlags::Vertex,
             offset: 0,
-            size: 96,
+            size: 112,
         };
 
         let layouts = [camera_layout, texture_layout];
@@ -307,7 +384,8 @@ impl EntityRenderer {
             .create_pipeline_layout(&layout_info, None)
             .expect("failed to create entity pipeline layout");
 
-        let pipeline = create_pipeline(device, render_pass, pipeline_layout);
+        let [pipeline, eyes_pipeline, swirl_pipeline] =
+            create_pipelines(device, render_pass, pipeline_layout);
 
         let defs = mob_definitions();
         let tex_count: u32 = defs
@@ -390,6 +468,7 @@ impl EntityRenderer {
         }
 
         let texture_sampler = unsafe { util::create_nearest_sampler(device) };
+        let texture_sampler_repeat = unsafe { util::create_nearest_repeat_sampler(device) };
 
         let mut mobs = HashMap::new();
 
@@ -403,6 +482,7 @@ impl EntityRenderer {
                     descriptor_pool,
                     texture_layout,
                     texture_sampler,
+                    texture_sampler_repeat,
                     jar_assets_dir,
                     asset_index,
                     v,
@@ -440,6 +520,8 @@ impl EntityRenderer {
 
         Self {
             pipeline,
+            eyes_pipeline,
+            swirl_pipeline,
             pipeline_layout,
             camera_layout,
             texture_layout,
@@ -448,6 +530,7 @@ impl EntityRenderer {
             camera_buffers,
             camera_allocations,
             texture_sampler,
+            texture_sampler_repeat,
             mobs,
         }
     }
@@ -458,43 +541,80 @@ impl EntityRenderer {
             .copy_from_slice(bytes);
     }
 
+    fn compute_anim(
+        &self,
+        anim_type: AnimationType,
+        model: &BakedEntityModel,
+        info: &EntityRenderInfo,
+    ) -> entity_model::PartAnim {
+        let local_head_y = info.head_y_rot_deg - info.body_y_rot_deg;
+        match anim_type {
+            AnimationType::Quadruped => entity_model::compute_quadruped_anim(
+                model,
+                info.head_x_rot_deg,
+                local_head_y,
+                info.walk_anim_pos,
+                info.walk_anim_speed,
+                info.head_y_offset,
+                info.head_x_rot_deg_override,
+            ),
+            AnimationType::Humanoid => entity_model::compute_humanoid_anim(
+                model,
+                info.head_x_rot_deg,
+                local_head_y,
+                info.walk_anim_pos,
+                info.walk_anim_speed,
+                info.is_crouching,
+            ),
+            AnimationType::Zombie => entity_model::compute_zombie_anim(
+                model,
+                info.head_x_rot_deg,
+                local_head_y,
+                info.walk_anim_pos,
+                info.walk_anim_speed,
+                info.aggressive,
+                info.age_in_ticks,
+                info.attack_time,
+            ),
+            AnimationType::Skeleton => entity_model::compute_skeleton_anim(
+                model,
+                info.head_x_rot_deg,
+                local_head_y,
+                info.walk_anim_pos,
+                info.walk_anim_speed,
+                info.aggressive,
+                info.age_in_ticks,
+            ),
+            AnimationType::Spider => entity_model::compute_spider_anim(
+                model,
+                info.head_x_rot_deg,
+                local_head_y,
+                info.walk_anim_pos,
+                info.walk_anim_speed,
+            ),
+        }
+    }
+
+    fn entity_matrix(info: &EntityRenderInfo) -> glam::Mat4 {
+        glam::Mat4::from_translation(info.position.as_vec3())
+            * glam::Mat4::from_rotation_y((180.0 - info.body_y_rot_deg).to_radians())
+    }
+
     pub fn draw(&self, cmd: vk::CommandBuffer, frame: usize, entities: &[EntityRenderInfo]) {
         if entities.is_empty() {
             return;
         }
 
+        // Pass 1: opaque base models + opaque overlays (sheep wool).
         cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, self.pipeline);
-
         let mut last_variant: *const MobVariant = std::ptr::null();
         for info in entities {
             let Some(entry) = self.mobs.get(&info.entity_kind) else {
                 continue;
             };
             let variant = entry.base_variant(info.is_baby, info.variant_index);
-
-            let entity_mat = glam::Mat4::from_translation(info.position.as_vec3())
-                * glam::Mat4::from_rotation_y((180.0 - info.body_y_rot_deg).to_radians());
-
-            let anim = match entry.anim {
-                AnimationType::Quadruped => entity_model::compute_quadruped_anim(
-                    &variant.model,
-                    info.head_x_rot_deg,
-                    info.head_y_rot_deg - info.body_y_rot_deg,
-                    info.walk_anim_pos,
-                    info.walk_anim_speed,
-                    info.head_y_offset,
-                    info.head_x_rot_deg_override,
-                ),
-                AnimationType::Humanoid => entity_model::compute_humanoid_anim(
-                    &variant.model,
-                    info.head_x_rot_deg,
-                    info.head_y_rot_deg - info.body_y_rot_deg,
-                    info.walk_anim_pos,
-                    info.walk_anim_speed,
-                    info.is_crouching,
-                ),
-            };
-
+            let entity_mat = Self::entity_matrix(info);
+            let anim = self.compute_anim(entry.anim, &variant.model, info);
             let overlay_color = if info.has_red_overlay {
                 HURT_OVERLAY
             } else {
@@ -509,10 +629,14 @@ impl EntityRenderer {
                 &anim,
                 WHITE_TINT,
                 overlay_color,
+                [0.0, 0.0],
                 &mut last_variant,
             );
 
             for (slot, overlay) in entry.overlays(info.is_baby).iter().enumerate() {
+                if overlay.overlay_kind != OverlayKind::Opaque {
+                    continue;
+                }
                 let Some(tint) = info.overlay_tints[slot] else {
                     continue;
                 };
@@ -524,6 +648,72 @@ impl EntityRenderer {
                     &anim,
                     tint,
                     overlay_color,
+                    [0.0, 0.0],
+                    &mut last_variant,
+                );
+            }
+        }
+
+        // Pass 2: full-bright, depth-write-off emissive overlays.
+        self.draw_emissive_pass(cmd, frame, entities, OverlayKind::EyesTranslucent);
+        self.draw_emissive_pass(cmd, frame, entities, OverlayKind::SwirlAdditive);
+    }
+
+    fn draw_emissive_pass(
+        &self,
+        cmd: vk::CommandBuffer,
+        frame: usize,
+        entities: &[EntityRenderInfo],
+        kind: OverlayKind,
+    ) {
+        let pipeline = match kind {
+            OverlayKind::EyesTranslucent => self.eyes_pipeline,
+            OverlayKind::SwirlAdditive => self.swirl_pipeline,
+            OverlayKind::Opaque => return,
+        };
+        let mut bound = false;
+        let mut last_variant: *const MobVariant = std::ptr::null();
+        for info in entities {
+            let Some(entry) = self.mobs.get(&info.entity_kind) else {
+                continue;
+            };
+            let overlays = entry.overlays(info.is_baby);
+            let has_visible = overlays.iter().enumerate().any(|(slot, ov)| {
+                ov.overlay_kind == kind && info.overlay_tints[slot].is_some()
+            });
+            if !has_visible {
+                continue;
+            }
+            if !bound {
+                cmd.bind_pipeline(vk::PipelineBindPoint::Graphics, pipeline);
+                bound = true;
+            }
+            let variant = entry.base_variant(info.is_baby, info.variant_index);
+            let entity_mat = Self::entity_matrix(info);
+            let anim = self.compute_anim(entry.anim, &variant.model, info);
+            // Energy swirl scrolls its UVs over time (vanilla `EnergySwirlLayer`).
+            let uv_offset = if kind == OverlayKind::SwirlAdditive {
+                let o = (info.age_in_ticks * 0.01).rem_euclid(1.0);
+                [o, o]
+            } else {
+                [0.0, 0.0]
+            };
+            for (slot, overlay) in overlays.iter().enumerate() {
+                if overlay.overlay_kind != kind {
+                    continue;
+                }
+                let Some(tint) = info.overlay_tints[slot] else {
+                    continue;
+                };
+                self.draw_variant(
+                    cmd,
+                    frame,
+                    overlay,
+                    entity_mat,
+                    &anim,
+                    tint,
+                    NO_OVERLAY,
+                    uv_offset,
                     &mut last_variant,
                 );
             }
@@ -540,6 +730,7 @@ impl EntityRenderer {
         anim: &entity_model::PartAnim,
         tint: [f32; 4],
         overlay_color: [f32; 4],
+        uv_offset: [f32; 2],
         last_variant: &mut *const MobVariant,
     ) {
         let ptr: *const MobVariant = variant;
@@ -555,6 +746,7 @@ impl EntityRenderer {
             *last_variant = ptr;
         }
 
+        let uv_params = [uv_offset[0], uv_offset[1], 0.0, 0.0];
         let part_transforms = variant.model.compute_part_transforms(anim);
         for (i, (start, count)) in variant.model.part_ranges.iter().enumerate() {
             if *count == 0 {
@@ -562,10 +754,11 @@ impl EntityRenderer {
             }
             let part_mat = entity_mat * part_transforms[i];
             let mat_array = part_mat.to_cols_array();
-            let mut bytes = [0u8; 96];
+            let mut bytes = [0u8; 112];
             bytes[..64].copy_from_slice(bytemuck::cast_slice(&mat_array));
             bytes[64..80].copy_from_slice(bytemuck::cast_slice(&tint));
-            bytes[80..].copy_from_slice(bytemuck::cast_slice(&overlay_color));
+            bytes[80..96].copy_from_slice(bytemuck::cast_slice(&overlay_color));
+            bytes[96..112].copy_from_slice(bytemuck::cast_slice(&uv_params));
             cmd.push_constants(
                 self.pipeline_layout,
                 vk::ShaderStageFlags::Vertex,
@@ -578,7 +771,10 @@ impl EntityRenderer {
 
     pub fn recreate_pipeline(&mut self, device: &vk::Device, render_pass: vk::RenderPass) {
         device.destroy_pipeline(self.pipeline, None);
-        self.pipeline = create_pipeline(device, render_pass, self.pipeline_layout);
+        device.destroy_pipeline(self.eyes_pipeline, None);
+        device.destroy_pipeline(self.swirl_pipeline, None);
+        [self.pipeline, self.eyes_pipeline, self.swirl_pipeline] =
+            create_pipelines(device, render_pass, self.pipeline_layout);
     }
 
     pub fn destroy(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
@@ -593,6 +789,7 @@ impl EntityRenderer {
         }
 
         device.destroy_sampler(self.texture_sampler, None);
+        device.destroy_sampler(self.texture_sampler_repeat, None);
 
         for entry in self.mobs.values_mut() {
             let variants: Vec<&mut MobVariant> = entry
@@ -622,6 +819,8 @@ impl EntityRenderer {
         drop(alloc);
 
         device.destroy_pipeline(self.pipeline, None);
+        device.destroy_pipeline(self.eyes_pipeline, None);
+        device.destroy_pipeline(self.swirl_pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
         device.destroy_descriptor_pool(self.descriptor_pool, None);
         device.destroy_descriptor_set_layout(self.camera_layout, None);
@@ -662,6 +861,7 @@ fn build_variants(
     descriptor_pool: vk::DescriptorPool,
     texture_layout: vk::DescriptorSetLayout,
     texture_sampler: vk::Sampler,
+    texture_sampler_repeat: vk::Sampler,
     jar_assets_dir: &Path,
     asset_index: &Option<AssetIndex>,
     variant: VariantDef,
@@ -670,7 +870,13 @@ fn build_variants(
         model,
         tex_variants,
         tex_size,
+        overlay_kind,
     } = variant;
+    // The scrolling swirl needs REPEAT wrapping; everything else clamps.
+    let sampler = match overlay_kind {
+        OverlayKind::SwirlAdditive => texture_sampler_repeat,
+        _ => texture_sampler,
+    };
     let vert_bytes = bytemuck::cast_slice::<ChunkVertex, u8>(&model.vertices);
 
     tex_variants
@@ -707,7 +913,7 @@ fn build_variants(
                 .expect("failed to allocate entity texture descriptor set");
 
             let image_info = vk::DescriptorImageInfo {
-                sampler: texture_sampler,
+                sampler,
                 image_view: texture_view,
                 image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
             };
@@ -729,6 +935,7 @@ fn build_variants(
                 texture_view,
                 texture_allocation,
                 texture_set,
+                overlay_kind,
             }
         })
         .collect()
@@ -785,10 +992,25 @@ pub(super) fn fallback_texture(size: u32) -> (Vec<u8>, u32, u32) {
     (pixels, size, size)
 }
 
+/// The entity render pipelines, in draw order: opaque base, translucent eyes,
+/// additive swirl.
+fn create_pipelines(
+    device: &vk::Device,
+    render_pass: vk::RenderPass,
+    layout: vk::PipelineLayout,
+) -> [vk::Pipeline; 3] {
+    [
+        create_pipeline(device, render_pass, layout, BlendMode::Opaque),
+        create_pipeline(device, render_pass, layout, BlendMode::Translucent),
+        create_pipeline(device, render_pass, layout, BlendMode::Additive),
+    ]
+}
+
 pub(super) fn create_pipeline(
     device: &vk::Device,
     render_pass: vk::RenderPass,
     layout: vk::PipelineLayout,
+    blend: BlendMode,
 ) -> vk::Pipeline {
     let vert_spv = shader::include_spirv!("entity.vert.spv");
     let frag_spv = shader::include_spirv!("entity.frag.spv");
@@ -846,17 +1068,48 @@ pub(super) fn create_pipeline(
         ..Default::default()
     };
 
+    // Emissive overlays (eyes, swirl) blend over the opaque pass and must not write
+    // depth, or they'd occlude later geometry.
+    let depth_write = if blend == BlendMode::Opaque {
+        vk::TRUE
+    } else {
+        vk::FALSE
+    };
     let depth_stencil = vk::PipelineDepthStencilStateCreateInfo {
         depth_test_enable: vk::TRUE,
-        depth_write_enable: vk::TRUE,
+        depth_write_enable: depth_write,
         depth_compare_op: vk::CompareOp::LessOrEqual,
         ..Default::default()
     };
 
-    let blend_attachment = vk::PipelineColorBlendAttachmentState {
-        blend_enable: vk::FALSE,
-        color_write_mask: vk::ColorComponentFlags::RGBA,
-        ..Default::default()
+    let blend_attachment = match blend {
+        BlendMode::Opaque => vk::PipelineColorBlendAttachmentState {
+            blend_enable: vk::FALSE,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
+            ..Default::default()
+        },
+        // Standard src-alpha over (glowing eyes).
+        BlendMode::Translucent => vk::PipelineColorBlendAttachmentState {
+            blend_enable: vk::TRUE,
+            src_color_blend_factor: vk::BlendFactor::SrcAlpha,
+            dst_color_blend_factor: vk::BlendFactor::OneMinusSrcAlpha,
+            color_blend_op: vk::BlendOp::Add,
+            src_alpha_blend_factor: vk::BlendFactor::One,
+            dst_alpha_blend_factor: vk::BlendFactor::OneMinusSrcAlpha,
+            alpha_blend_op: vk::BlendOp::Add,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
+        },
+        // Additive (energy swirl glow).
+        BlendMode::Additive => vk::PipelineColorBlendAttachmentState {
+            blend_enable: vk::TRUE,
+            src_color_blend_factor: vk::BlendFactor::SrcAlpha,
+            dst_color_blend_factor: vk::BlendFactor::One,
+            color_blend_op: vk::BlendOp::Add,
+            src_alpha_blend_factor: vk::BlendFactor::One,
+            dst_alpha_blend_factor: vk::BlendFactor::One,
+            alpha_blend_op: vk::BlendOp::Add,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
+        },
     };
     let color_blending = vk::PipelineColorBlendStateCreateInfo {
         attachment_count: 1,

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -1078,12 +1078,12 @@ pub(super) fn create_pipeline(
         ..Default::default()
     };
 
-    // Emissive overlays (eyes, swirl) blend over the opaque pass and must not write
-    // depth, or they'd occlude later geometry.
-    let depth_write = if blend == BlendMode::Opaque {
-        vk::TRUE
-    } else {
+    // Only the translucent eyes overlay skips depth-write (vanilla `EYES`); the
+    // opaque base and additive swirl write depth (vanilla `ENERGY_SWIRL`).
+    let depth_write = if blend == BlendMode::Translucent {
         vk::FALSE
+    } else {
+        vk::TRUE
     };
     let depth_stencil = vk::PipelineDepthStencilStateCreateInfo {
         depth_test_enable: vk::TRUE,

--- a/pomme-client/src/renderer/shaders/entity.vert
+++ b/pomme-client/src/renderer/shaders/entity.vert
@@ -12,6 +12,8 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
     vec4 tint;
     vec4 overlay_color;
+    // xy = texture-coordinate scroll offset (energy swirl); zw unused.
+    vec4 uv_params;
 };
 
 layout(location = 0) in vec3 position;
@@ -28,7 +30,7 @@ void main() {
     vec4 world_pos = model * vec4(position, 1.0);
     vec3 rel = world_pos.xyz - camera_pos.xyz;
     gl_Position = view_proj * vec4(rel, 1.0);
-    v_tex_coords = tex_coords;
+    v_tex_coords = tex_coords + uv_params.xy;
     v_tint = tint;
     v_overlay = overlay_color;
     v_fog = fog_factor(rel, camera_pos.w, fog_color.w);

--- a/pomme-client/src/renderer/util.rs
+++ b/pomme-client/src/renderer/util.rs
@@ -434,6 +434,22 @@ pub unsafe fn create_nearest_sampler(device: &vk::Device) -> vk::Sampler {
     unsafe { create_nearest_sampler_mipmapped(device, 1) }
 }
 
+/// Nearest sampler with REPEAT wrapping, for scrolling/tiling textures such as the
+/// charged-creeper energy swirl.
+pub unsafe fn create_nearest_repeat_sampler(device: &vk::Device) -> vk::Sampler {
+    let info = vk::SamplerCreateInfo {
+        mag_filter: vk::Filter::Nearest,
+        min_filter: vk::Filter::Nearest,
+        address_mode_u: vk::SamplerAddressMode::Repeat,
+        address_mode_v: vk::SamplerAddressMode::Repeat,
+        address_mode_w: vk::SamplerAddressMode::Repeat,
+        ..Default::default()
+    };
+    device
+        .create_sampler(&info, None)
+        .expect("failed to create repeat sampler")
+}
+
 pub unsafe fn create_linear_sampler(device: &vk::Device) -> vk::Sampler {
     let info = vk::SamplerCreateInfo {
         mag_filter: vk::Filter::Linear,

--- a/pomme-client/src/renderer/util.rs
+++ b/pomme-client/src/renderer/util.rs
@@ -434,8 +434,8 @@ pub unsafe fn create_nearest_sampler(device: &vk::Device) -> vk::Sampler {
     unsafe { create_nearest_sampler_mipmapped(device, 1) }
 }
 
-/// Nearest sampler with REPEAT wrapping, for scrolling/tiling textures such as the
-/// charged-creeper energy swirl.
+/// Nearest sampler with REPEAT wrapping, for scrolling/tiling textures such as
+/// the charged-creeper energy swirl.
 pub unsafe fn create_nearest_repeat_sampler(device: &vk::Device) -> vk::Sampler {
     let info = vk::SamplerCreateInfo {
         mag_filter: vk::Filter::Nearest,


### PR DESCRIPTION
Adds rendering for zombie, skeleton, creeper, and spider: models, animations, and textures. Includes baby zombie, attack/bow animations, glowing spider eyes, and the charged-creeper energy swirl.