### PR TITLE
fix cursor grab when opening options from in-game pause menu

### DIFF
--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -143,7 +143,7 @@ impl InputState {
                     self.recent_actions.remove(&Action::ToggleInventory);
                 }
                 if self.action_just_pressed(Action::OpenMenu) {
-                    if !game.dead {
+                    if !game.dead && !game.options_from_game {
                         if game.inventory_open {
                             game.inventory_open = false;
                         } else {

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -764,7 +764,6 @@ pub fn update_game(
         PauseAction::Options => {
             core.menu.open_options();
             game.options_from_game = true;
-            game.paused = false;
             core.apply_cursor_grab(&gfx.window, Some(game));
         }
         PauseAction::Disconnect => {


### PR DESCRIPTION
opening options from the in-game pause menu re-grabbed the cursor, making the screen unusable until you pressed esc.

keep `paused = true` for the whole in-game options session, and gate the esc/openmenu handler with `!options_from_game` so back-navigation is handled by the menu instead of toggling `paused`.