### PR TITLE
launcher downloads the client

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -57,7 +57,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libvulkan-dev cmake libasound2-dev
+          sudo apt-get install -y libvulkan-dev cmake libxkbcommon-dev libwayland-dev libasound2-dev libudev-dev
 
       - name: Build
         run: cargo build -p pomme-client --release --target ${{ matrix.target }}

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -3,10 +3,18 @@ name: Release client
 on:
   push:
     tags: ["client-v*"]
+  schedule:
+    - cron: "7 18 * * 0" # Sundays 18:07 UTC (weekly pre-alpha snapshot of master)
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version core, e.g. 0.2.0 (blank = bump patch from latest)"
+        required: false
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
+  MC_VERSION: "26.2"
 
 permissions:
   contents: write
@@ -83,17 +91,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get previous client tag
-        id: prev
+      - name: Resolve release tag
+        id: rel
         shell: bash
         run: |
           git fetch --tags --force
-          PREV=$(git tag --list "client-v*" --sort=-v:refname | sed -n '2p')
-          if [ -z "$PREV" ]; then
-            echo "tag=" >> $GITHUB_OUTPUT
+          tags=$(git tag --list 'client-v*')
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${{ github.ref_name }}"
+            prerelease="false"
           else
-            echo "tag=$PREV" >> $GITHUB_OUTPUT
+            core="${{ inputs.version }}"
+            if [ -z "$core" ]; then
+              latest=$(echo "$tags" \
+                | sed -nE 's/^client-v([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' \
+                | sort -V | tail -n1)
+              if [ -z "$latest" ]; then
+                core="0.1.0"
+              else
+                IFS=. read -r ma mi pa <<< "$latest"
+                core="$ma.$mi.$((pa + 1))"
+              fi
+            fi
+            tag="client-v${core}+${MC_VERSION}"
+            prerelease="true"
           fi
+          prev=$(echo "$tags" | grep -vFx "$tag" | sort -V | tail -n1 || true)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v8
         with:
@@ -107,7 +133,8 @@ jobs:
 
       - uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
-          previous_tag: ${{ steps.prev.outputs.tag || '' }}
+          tag_name: ${{ steps.rel.outputs.tag }}
+          prerelease: ${{ steps.rel.outputs.prerelease }}
+          previous_tag: ${{ steps.rel.outputs.prev }}
           files: dist/*
-          generate_release_notes: ${{ steps.prev.outputs.tag != '' }}
+          generate_release_notes: ${{ steps.rel.outputs.prev != '' }}

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          tar czf "dist/${{ matrix.name }}.tar.gz" -C "target/${{ matrix.target }}/release" "${{ matrix.artifact }}"
+          zip -j "dist/${{ matrix.name }}.zip" "target/${{ matrix.target }}/release/${{ matrix.artifact }}"
 
       - name: Package (Windows)
         if: matrix.os == 'windows-latest'
@@ -99,6 +99,11 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum *.zip > sha256sums.txt
 
       - uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -66,8 +66,26 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          mkdir -p dist
-          zip -j "dist/${{ matrix.name }}.zip" "target/${{ matrix.target }}/release/${{ matrix.artifact }}"
+          mkdir -p dist bundle
+          cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" bundle/
+
+          # macOS has no system Vulkan, so ship the loader + MoltenVK + ICD next
+          # to the binary (build.rs gives it an @executable_path rpath).
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            findlib() { find "$VULKAN_SDK" -name "$1" | head -n1; }
+            loader=$(findlib libvulkan.1.dylib)
+            mvk=$(findlib libMoltenVK.dylib)
+            icd=$(findlib MoltenVK_icd.json)
+            if [ -z "$loader" ] || [ -z "$mvk" ] || [ -z "$icd" ]; then
+              echo "::error::Vulkan runtime not found under VULKAN_SDK=$VULKAN_SDK (loader='$loader' mvk='$mvk' icd='$icd')"
+              exit 1
+            fi
+            cp "$loader" "$mvk" bundle/
+            sed -E 's#("library_path"[[:space:]]*:[[:space:]]*)"[^"]*"#\1"./libMoltenVK.dylib"#' \
+              "$icd" > bundle/MoltenVK_icd.json
+          fi
+
+          (cd bundle && zip -j "../dist/${{ matrix.name }}.zip" ./*)
 
       - name: Package (Windows)
         if: matrix.os == 'windows-latest'

--- a/pomme-client/Cargo.toml
+++ b/pomme-client/Cargo.toml
@@ -16,7 +16,7 @@ sha1_smol = { workspace = true }
 open = { workspace = true }
 base64 = { workspace = true }
 zip = { workspace = true }
-tokio = { workspace = true, features = ["tracing"] }
+tokio = { workspace = true, features = ["tracing", "net", "time"] }
 reqwest = { workspace = true, features = ["blocking"] }
 pyronyx = { workspace = true, features = ["rwh_06"] }
 tracing = { workspace = true }

--- a/pomme-client/build.rs
+++ b/pomme-client/build.rs
@@ -2,6 +2,12 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
+    // Releases bundle the Vulkan loader (libvulkan.1.dylib) next to the binary,
+    // since macOS has no system Vulkan; this rpath lets it be found at runtime.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
+    }
+
     let shader_dir = Path::new("src/renderer/shaders");
     let out_dir = std::env::var("OUT_DIR").unwrap();
 

--- a/pomme-client/src/main.rs
+++ b/pomme-client/src/main.rs
@@ -28,8 +28,12 @@ use crate::user::UserData;
 /// Maps all supported versions to their protocol version.
 /// Snapshots encode as `(1 << 30) | base_protocol`.
 /// KEEP IN SYNC WITH pomme-launcher/src-tauri/src/lib.rs
-const VERSION_PROTOCOL_MAP: [(&str, i32); 3] =
-    [("26.1", 775), ("26.1.1-rc-1", 0x40000130), ("26.1.1", 775)];
+const VERSION_PROTOCOL_MAP: [(&str, i32); 4] = [
+    ("26.2", 776),
+    ("26.1", 775),
+    ("26.1.1-rc-1", 0x40000130),
+    ("26.1.1", 775),
+];
 
 fn main() {
     let args = args::LaunchArgs::parse();

--- a/pomme-client/src/net/connection.rs
+++ b/pomme-client/src/net/connection.rs
@@ -1,14 +1,13 @@
 use azalea_protocol::address::ServerAddr;
 use azalea_protocol::connect::{Connection, ReadConnection, WriteConnection};
+use azalea_protocol::packets::ClientIntention;
 use azalea_protocol::packets::config::{ClientboundConfigPacket, ServerboundConfigPacket};
 use azalea_protocol::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
-use azalea_protocol::packets::handshake::s_intention::ServerboundIntention;
 use azalea_protocol::packets::login::c_hello::ClientboundHello;
 use azalea_protocol::packets::login::s_hello::ServerboundHello;
 use azalea_protocol::packets::login::s_key::ServerboundKey;
 use azalea_protocol::packets::login::s_login_acknowledged::ServerboundLoginAcknowledged;
 use azalea_protocol::packets::login::{ClientboundLoginPacket, ServerboundLoginPacket};
-use azalea_protocol::packets::{ClientIntention, PROTOCOL_VERSION};
 use azalea_protocol::read::ReadPacketError;
 use crossbeam_channel::Sender;
 use thiserror::Error;
@@ -40,6 +39,17 @@ pub enum ConnectionError {
 
     #[error("encryption failed: {0}")]
     Encryption(String),
+}
+
+impl From<super::resolve::ConnectError> for ConnectionError {
+    fn from(e: super::resolve::ConnectError) -> Self {
+        use super::resolve::ConnectError;
+        match e {
+            ConnectError::Resolve(e) => Self::InvalidAddress(e.to_string()),
+            ConnectError::Unreachable(e) => Self::Connect(e.into()),
+            ConnectError::Handshake(e) => Self::Connect(e),
+        }
+    }
 }
 
 pub struct ConnectArgs {
@@ -98,21 +108,7 @@ pub async fn connect_to_server(
         .as_str()
         .try_into()
         .map_err(|_| ConnectionError::InvalidAddress(args.server.clone()))?;
-    let addr = azalea_protocol::resolve::resolve_address(&server_addr)
-        .await
-        .map_err(|e| ConnectionError::InvalidAddress(format!("{}: {e}", args.server)))?;
-    tracing::info!("Connecting to {} (resolved: {addr})...", args.server);
-
-    let mut conn: Connection<_, _> = Connection::new(&addr).await?;
-
-    conn.write(ServerboundIntention {
-        protocol_version: PROTOCOL_VERSION,
-        hostname: server_addr.host.clone(),
-        port: server_addr.port,
-        intention: ClientIntention::Login,
-    })
-    .await?;
-
+    let conn = super::resolve::connect(&server_addr, ClientIntention::Login).await?;
     let mut conn = conn.login();
 
     conn.write(ServerboundHello {

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 pub mod connection;
 pub mod handler;
+pub mod resolve;
 pub mod sender;
 
 use std::sync::Arc;

--- a/pomme-client/src/net/resolve.rs
+++ b/pomme-client/src/net/resolve.rs
@@ -1,0 +1,110 @@
+//! Resolve a server address to connectable socket addresses, IPv4 first.
+//!
+//! azalea uses the single "first" resolved IP, which on a dual-stack host can
+//! be an unreachable IPv6, such as a NAT64-synthesized AAAA whose gateway
+//! doesn't route while the plain IPv4 is fine. We gather every address we can,
+//! prefer IPv4, and let the caller try them in order so a dead IPv6 doesn't
+//! blackhole the connection.
+
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use azalea_protocol::address::ServerAddr;
+use azalea_protocol::connect::{Connection, ConnectionError};
+use azalea_protocol::packets::handshake::s_intention::ServerboundIntention;
+use azalea_protocol::packets::handshake::{ClientboundHandshakePacket, ServerboundHandshakePacket};
+use azalea_protocol::packets::{ClientIntention, PROTOCOL_VERSION};
+use azalea_protocol::resolve::{ResolveError, resolve_address};
+use thiserror::Error;
+use tokio::net::TcpStream;
+
+/// Socket addresses to try in order: IPv4 first, the SRV-correct ones (derived
+/// from azalea's resolution) ahead of the system-resolver fallbacks.
+pub async fn resolve_candidates(server: &ServerAddr) -> Result<Vec<SocketAddr>, ResolveError> {
+    let primary = resolve_address(server).await?;
+    let mut candidates: Vec<SocketAddr> = Vec::new();
+
+    // A NAT64-mapped IPv6 (well-known 64:ff9b::/96 prefix) embeds the real IPv4
+    // in its low 32 bits; that IPv4 is reachable even when the NAT64 gateway
+    // isn't. Prefer it, keeping azalea's (SRV-resolved) port.
+    if let IpAddr::V6(v6) = primary.ip()
+        && let Some(v4) = nat64_embedded_ipv4(v6)
+    {
+        candidates.push(SocketAddr::new(IpAddr::V4(v4), primary.port()));
+    }
+    candidates.push(primary);
+
+    // System resolver as a general fallback (covers normal dual-stack hosts).
+    if let Ok(extra) = tokio::net::lookup_host((server.host.as_str(), server.port)).await {
+        candidates.extend(extra);
+    }
+
+    // IPv4 before IPv6 (stable, so the SRV-correct entries stay ahead), deduped.
+    candidates.sort_by_key(SocketAddr::is_ipv6);
+    let mut seen = HashSet::new();
+    candidates.retain(|a| seen.insert(*a));
+    Ok(candidates)
+}
+
+/// The IPv4 embedded in a well-known-prefix (`64:ff9b::/96`) NAT64 address.
+fn nat64_embedded_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
+    let o = addr.octets();
+    (o[..12] == [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0])
+        .then(|| Ipv4Addr::new(o[12], o[13], o[14], o[15]))
+}
+
+pub type HandshakeConnection = Connection<ClientboundHandshakePacket, ServerboundHandshakePacket>;
+
+#[derive(Debug, Error)]
+pub enum ConnectError {
+    #[error("{0}")]
+    Resolve(ResolveError),
+    #[error("{0}")]
+    Unreachable(std::io::Error),
+    #[error("{0}")]
+    Handshake(ConnectionError),
+}
+
+/// Resolve `server` and open a handshake-stage connection with the given intent
+/// to the first reachable candidate (IPv4 first), bounding each attempt by 5s.
+/// Shared by the join and ping paths.
+pub async fn connect(
+    server: &ServerAddr,
+    intention: ClientIntention,
+) -> Result<HandshakeConnection, ConnectError> {
+    let candidates = resolve_candidates(server)
+        .await
+        .map_err(ConnectError::Resolve)?;
+
+    let mut last_err = std::io::Error::new(std::io::ErrorKind::NotFound, "no addresses resolved");
+    for addr in &candidates {
+        match tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(addr)).await {
+            Ok(Ok(stream)) => {
+                let _ = stream.set_nodelay(true);
+                tracing::info!("Connecting to {} (resolved: {addr})...", server.host);
+                let mut conn = Connection::new_from_stream(stream)
+                    .await
+                    .map_err(ConnectError::Handshake)?;
+                conn.write(ServerboundIntention {
+                    protocol_version: PROTOCOL_VERSION,
+                    hostname: server.host.clone(),
+                    port: server.port,
+                    intention,
+                })
+                .await
+                .map_err(|e| ConnectError::Handshake(e.into()))?;
+                return Ok(conn);
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("Connect to {addr} failed: {e}");
+                last_err = e;
+            }
+            Err(_) => {
+                tracing::warn!("Connect to {addr} timed out");
+                last_err = std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timed out");
+            }
+        }
+    }
+    Err(ConnectError::Unreachable(last_err))
+}

--- a/pomme-client/src/ui/server_list.rs
+++ b/pomme-client/src/ui/server_list.rs
@@ -96,12 +96,10 @@ pub fn ping_all_servers(
 }
 
 async fn ping_server(address: String, results: PingResults) {
-    use azalea_protocol::connect::Connection;
-    use azalea_protocol::packets::handshake::s_intention::ServerboundIntention;
+    use azalea_protocol::packets::ClientIntention;
     use azalea_protocol::packets::status::ClientboundStatusPacket;
     use azalea_protocol::packets::status::s_ping_request::ServerboundPingRequest;
     use azalea_protocol::packets::status::s_status_request::ServerboundStatusRequest;
-    use azalea_protocol::packets::{ClientIntention, PROTOCOL_VERSION};
 
     let result = async {
         use azalea_protocol::address::ServerAddr;
@@ -110,21 +108,9 @@ async fn ping_server(address: String, results: PingResults) {
             .as_str()
             .try_into()
             .map_err(|_| format!("Invalid address: {address}"))?;
-        let addr = azalea_protocol::resolve::resolve_address(&server_addr)
+        let conn = crate::net::resolve::connect(&server_addr, ClientIntention::Status)
             .await
             .map_err(|e| format!("{address}: {e}"))?;
-        let mut conn: Connection<_, _> = Connection::new(&addr)
-            .await
-            .map_err(|e| format!("Connection failed: {e}"))?;
-
-        conn.write(ServerboundIntention {
-            protocol_version: PROTOCOL_VERSION,
-            hostname: server_addr.host.clone(),
-            port: server_addr.port,
-            intention: ClientIntention::Status,
-        })
-        .await
-        .map_err(|e| format!("Handshake failed: {e}"))?;
 
         let mut conn = conn.status();
 

--- a/pomme-launcher/src-tauri/src/client_updater.rs
+++ b/pomme-launcher/src-tauri/src/client_updater.rs
@@ -5,7 +5,7 @@
 //! when no local build is present.
 
 use std::io::Cursor;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -130,8 +130,11 @@ async fn install(
     }
 
     emit(app, 1, 1, "Installing client...");
+    extract_all(&bytes, &dir)?;
     let binary = storage::client_binary(tag);
-    extract_binary(&bytes, &binary)?;
+    if !binary.exists() {
+        return Err("client binary not found in downloaded archive".to_string());
+    }
 
     #[cfg(unix)]
     {
@@ -145,8 +148,9 @@ async fn install(
     Ok(())
 }
 
-/// Extract the single `pomme-client[.exe]` entry from the downloaded zip.
-fn extract_binary(zip_bytes: &[u8], dest: &PathBuf) -> Result<(), String> {
+/// Extract every file in the zip (flat) into `dir`. Releases bundle the binary
+/// plus, on macOS, the Vulkan loader + MoltenVK + ICD next to it.
+fn extract_all(zip_bytes: &[u8], dir: &Path) -> Result<(), String> {
     let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).map_err(|e| e.to_string())?;
     for i in 0..archive.len() {
         let mut entry = archive.by_index(i).map_err(|e| e.to_string())?;
@@ -154,13 +158,13 @@ fn extract_binary(zip_bytes: &[u8], dest: &PathBuf) -> Result<(), String> {
             continue;
         }
         let base = entry.name().rsplit('/').next().unwrap_or_default();
-        if base.starts_with("pomme-client") {
-            let mut out = std::fs::File::create(dest).map_err(|e| e.to_string())?;
-            std::io::copy(&mut entry, &mut out).map_err(|e| e.to_string())?;
-            return Ok(());
+        if base.is_empty() {
+            continue;
         }
+        let mut out = std::fs::File::create(dir.join(base)).map_err(|e| e.to_string())?;
+        std::io::copy(&mut entry, &mut out).map_err(|e| e.to_string())?;
     }
-    Err("client binary not found in downloaded archive".to_string())
+    Ok(())
 }
 
 /// Find the sha256 for `asset_name` in `sha256sum`-format text (`<hash>

--- a/pomme-launcher/src-tauri/src/client_updater.rs
+++ b/pomme-launcher/src-tauri/src/client_updater.rs
@@ -1,0 +1,244 @@
+//! Downloads the correct per-platform `pomme-client` binary from the project's
+//! GitHub releases (vanilla-style), caches it under `.pomme/clients/<tag>/`,
+//! verifies its sha256, and returns the path. The launcher prefers a local dev
+//! build (`commands::find_client_binary`); this is the production path used
+//! when no local build is present.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tauri::AppHandle;
+use tauri_specta::Event;
+
+use crate::downloader::DownloadProgressEvent;
+use crate::storage;
+
+const RELEASES_URL: &str = "https://api.github.com/repos/PommeMC/Client/releases?per_page=30";
+const USER_AGENT: &str = "pomme-launcher";
+const CHECKSUMS_ASSET: &str = "sha256sums.txt";
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<Asset>,
+}
+
+#[derive(Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// The release asset name for the current platform, or `None` if unsupported.
+fn platform_asset() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("windows", "x86_64") => Some("pomme-client-windows-x64.zip"),
+        ("linux", "x86_64") => Some("pomme-client-linux-x64-gnu.zip"),
+        ("macos", "aarch64") => Some("pomme-client-macos-arm64.zip"),
+        _ => None,
+    }
+}
+
+/// Ensure the latest released client is installed and return its binary path.
+/// Returns a cached copy if it's already current; on network failure, falls
+/// back to the newest cached client so the game still launches offline.
+pub async fn ensure_client(app: &AppHandle) -> Result<PathBuf, String> {
+    let asset_name = platform_asset().ok_or_else(|| {
+        format!(
+            "No client build for your platform ({}/{})",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    })?;
+
+    let client = reqwest::Client::new();
+
+    let release = match latest_client_release(&client).await {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!("Couldn't reach GitHub releases ({e}); falling back to cached client");
+            return newest_cached_client()
+                .ok_or_else(|| format!("Couldn't download the client and none is installed: {e}"));
+        }
+    };
+
+    if let Some(binary) = installed_binary(&release.tag_name) {
+        return Ok(binary);
+    }
+
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == asset_name)
+        .ok_or_else(|| format!("Release {} has no asset {asset_name}", release.tag_name))?;
+    let checksums = release.assets.iter().find(|a| a.name == CHECKSUMS_ASSET);
+
+    install(app, &client, &release.tag_name, asset, checksums).await?;
+    Ok(storage::client_binary(&release.tag_name))
+}
+
+/// Newest `client-v*` release (the GitHub API returns releases newest-first).
+async fn latest_client_release(client: &reqwest::Client) -> Result<Release, String> {
+    let releases: Vec<Release> = get(client, RELEASES_URL)
+        .await?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    releases
+        .into_iter()
+        .find(|r| r.tag_name.starts_with("client-v"))
+        .ok_or_else(|| "No client-v* release found".to_string())
+}
+
+async fn install(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    tag: &str,
+    asset: &Asset,
+    checksums: Option<&Asset>,
+) -> Result<(), String> {
+    let dir = storage::client_version_dir(tag);
+    let _ = std::fs::create_dir_all(&dir);
+
+    emit(app, 0, 1, "Downloading client...");
+    let bytes = get(client, &asset.browser_download_url)
+        .await?
+        .bytes()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if let Some(cs) = checksums {
+        let sums = get(client, &cs.browser_download_url)
+            .await?
+            .text()
+            .await
+            .map_err(|e| e.to_string())?;
+        let expected = checksum_for(&sums, &asset.name)
+            .ok_or_else(|| format!("No checksum for {} in {CHECKSUMS_ASSET}", asset.name))?;
+        let actual = hex(&Sha256::digest(&bytes));
+        if !actual.eq_ignore_ascii_case(&expected) {
+            return Err(format!(
+                "Client checksum mismatch for {}: expected {expected}, got {actual}",
+                asset.name
+            ));
+        }
+    } else {
+        log::warn!("Release {tag} has no {CHECKSUMS_ASSET}; skipping client integrity check");
+    }
+
+    emit(app, 1, 1, "Installing client...");
+    let binary = storage::client_binary(tag);
+    extract_binary(&bytes, &binary)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| e.to_string())?;
+    }
+
+    std::fs::write(storage::client_marker(tag), tag).map_err(|e| e.to_string())?;
+    prune_old_clients(tag);
+    Ok(())
+}
+
+/// Extract the single `pomme-client[.exe]` entry from the downloaded zip.
+fn extract_binary(zip_bytes: &[u8], dest: &PathBuf) -> Result<(), String> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).map_err(|e| e.to_string())?;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).map_err(|e| e.to_string())?;
+        if entry.is_dir() {
+            continue;
+        }
+        let base = entry.name().rsplit('/').next().unwrap_or_default();
+        if base.starts_with("pomme-client") {
+            let mut out = std::fs::File::create(dest).map_err(|e| e.to_string())?;
+            std::io::copy(&mut entry, &mut out).map_err(|e| e.to_string())?;
+            return Ok(());
+        }
+    }
+    Err("client binary not found in downloaded archive".to_string())
+}
+
+/// Find the sha256 for `asset_name` in `sha256sum`-format text (`<hash>
+/// <file>`).
+fn checksum_for(sums: &str, asset_name: &str) -> Option<String> {
+    sums.lines().find_map(|line| {
+        let mut it = line.split_whitespace();
+        let hash = it.next()?;
+        let file = it.next()?.trim_start_matches('*');
+        let base = file.rsplit('/').next().unwrap_or(file);
+        (base == asset_name).then(|| hash.to_string())
+    })
+}
+
+/// Newest verified client already on disk (by marker mtime), for offline
+/// launch.
+fn newest_cached_client() -> Option<PathBuf> {
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(storage::clients_dir()).ok()?.flatten() {
+        let name = entry.file_name();
+        let Some(tag) = name.to_str() else { continue };
+        let Some(binary) = installed_binary(tag) else {
+            continue;
+        };
+        if let Ok(mtime) = std::fs::metadata(storage::client_marker(tag)).and_then(|m| m.modified())
+            && best.as_ref().is_none_or(|(t, _)| mtime > *t)
+        {
+            best = Some((mtime, binary));
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+/// Drop every cached client except the one we just installed.
+fn prune_old_clients(keep: &str) {
+    if let Ok(entries) = std::fs::read_dir(storage::clients_dir()) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() && entry.file_name().to_str() != Some(keep) {
+                let _ = std::fs::remove_dir_all(path);
+            }
+        }
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
+/// The cached binary path for `tag` if it's fully installed (binary + marker).
+fn installed_binary(tag: &str) -> Option<PathBuf> {
+    let binary = storage::client_binary(tag);
+    (binary.exists() && storage::client_marker(tag).exists()).then_some(binary)
+}
+
+/// GET `url` with the GitHub-required User-Agent, erroring on a non-2xx status.
+async fn get(client: &reqwest::Client, url: &str) -> Result<reqwest::Response, String> {
+    client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())
+}
+
+fn emit(app: &AppHandle, downloaded: u32, total: u32, status: &str) {
+    let _ = DownloadProgressEvent {
+        downloaded,
+        total,
+        status: status.to_string(),
+    }
+    .emit(app);
+}

--- a/pomme-launcher/src-tauri/src/commands.rs
+++ b/pomme-launcher/src-tauri/src/commands.rs
@@ -370,7 +370,11 @@ pub async fn launch_game(
     override_version: Option<String>,
     debug_enabled: Option<bool>,
 ) -> Result<String, String> {
-    let exe = find_client_binary()?;
+    // Prefer a local dev build (target/); otherwise download the latest release.
+    let exe = match find_client_binary() {
+        Ok(local) => local,
+        Err(_) => crate::client_updater::ensure_client(&app).await?,
+    };
     let account = uuid.as_deref().and_then(crate::auth::try_restore);
     let username = account
         .as_ref()

--- a/pomme-launcher/src-tauri/src/commands.rs
+++ b/pomme-launcher/src-tauri/src/commands.rs
@@ -396,6 +396,17 @@ pub async fn launch_game(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
+    // macOS releases bundle MoltenVK next to the client; point the Vulkan loader
+    // at the bundled ICD. Absent for local dev builds, which use system Vulkan.
+    #[cfg(target_os = "macos")]
+    if let Some(icd) = exe
+        .parent()
+        .map(|d| d.join("MoltenVK_icd.json"))
+        .filter(|p| p.exists())
+    {
+        cmd.env("VK_ICD_FILENAMES", &icd);
+    }
+
     if debug_enabled.unwrap_or(false) {
         cmd.env("RUST_LOG", "debug");
         cmd.env("RUST_BACKTRACE", "full");

--- a/pomme-launcher/src-tauri/src/lib.rs
+++ b/pomme-launcher/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod client_updater;
 mod commands;
 mod downloader;
 mod friends;

--- a/pomme-launcher/src-tauri/src/lib.rs
+++ b/pomme-launcher/src-tauri/src/lib.rs
@@ -21,9 +21,13 @@ pub struct AppState {
 
 /// Maps all supported versions to their protocol version.
 /// Snapshots encode as `(1 << 30) | base_protocol`.
-/// KEEP IN SYNC WITH pomme-client/src-tauri/src/lib.rs
-const VERSION_PROTOCOL_MAP: [(&str, i32); 3] =
-    [("26.1", 775), ("26.1.1-rc-1", 0x40000130), ("26.1.1", 775)];
+/// KEEP IN SYNC WITH pomme-client/src/main.rs
+const VERSION_PROTOCOL_MAP: [(&str, i32); 4] = [
+    ("26.2", 776),
+    ("26.1", 775),
+    ("26.1.1-rc-1", 0x40000130),
+    ("26.1.1", 775),
+];
 
 const TYPED_ERROR_IMPL: &str = r#"export type Result<T, E> =
   | { ok: true;  value: T }

--- a/pomme-launcher/src-tauri/src/storage.rs
+++ b/pomme-launcher/src-tauri/src/storage.rs
@@ -24,6 +24,7 @@ pub fn ensure_dirs() {
     let _ = std::fs::create_dir_all(assets_dir());
     let _ = std::fs::create_dir_all(pomme_assets_dir());
     let _ = std::fs::create_dir_all(versions_dir());
+    let _ = std::fs::create_dir_all(clients_dir());
     let _ = std::fs::create_dir_all(installations_dir());
 
     let _ = std::fs::create_dir_all(indexes_dir());
@@ -70,6 +71,27 @@ pub fn version_extracted_dir(version: &str) -> PathBuf {
 /// `.pomc/versions/{version}/extracted/.extracted`
 pub fn version_extracted_marker(version: &str) -> PathBuf {
     version_extracted_dir(version).join(".extracted")
+}
+
+/// `.pomc/clients/`
+pub fn clients_dir() -> PathBuf {
+    data_dir().join("clients")
+}
+/// `.pomc/clients/{tag}/`
+pub fn client_version_dir(tag: &str) -> PathBuf {
+    clients_dir().join(tag)
+}
+/// `.pomc/clients/{tag}/pomme-client[.exe]`
+pub fn client_binary(tag: &str) -> PathBuf {
+    #[cfg(target_family = "windows")]
+    let name = "pomme-client.exe";
+    #[cfg(not(target_family = "windows"))]
+    let name = "pomme-client";
+    client_version_dir(tag).join(name)
+}
+/// `.pomc/clients/{tag}/.verified`
+pub fn client_marker(tag: &str) -> PathBuf {
+    client_version_dir(tag).join(".verified")
 }
 
 /// `.pomc/installations/`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # Pinned so local and CI build identically. Bump deliberately; nightly is only
 # needed for rustfmt's options.
 channel = "nightly-2026-03-21"
-components = ["rustfmt", "rust-analyzer", "rust-src"]
+components = ["clippy", "rustfmt", "rust-analyzer", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,5 @@
 [toolchain]
-channel = "nightly"
+# Pinned so local and CI build identically. Bump deliberately; nightly is only
+# needed for rustfmt's options.
+channel = "nightly-2026-03-21"
 components = ["rustfmt", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
launcher fetches the per-platform client binary from github releases instead of shipping it.

- launcher: download + verify + extract client from releases
- ci: weekly pre-alpha release from master; libudev/winit deps
- pin nightly toolchain
- bundle moltenvk with the macos client (fixes sigabrt)
- support 26.2 (azalea protocol 776)
- resolve servers ipv4-first for join and ping