### PR TITLE
implement leaf litter rendering

### DIFF
--- a/pomme-client/src/net/connection.rs
+++ b/pomme-client/src/net/connection.rs
@@ -384,6 +384,10 @@ fn extract_biome_climate(
                 .and_then(|e| nbt_color_from_compound(e, "foliage_color"))
                 .map(int_to_rgb);
 
+            let dry_foliage_color_override = effects
+                .and_then(|e| nbt_color_from_compound(e, "dry_foliage_color"))
+                .map(int_to_rgb);
+
             let grass_color_modifier = effects
                 .and_then(|e| nbt_string_from_compound(e, "grass_color_modifier"))
                 .map(|s| match s.as_str() {
@@ -401,6 +405,7 @@ fn extract_biome_climate(
                     grass_color_override,
                     grass_color_modifier,
                     foliage_color_override,
+                    dry_foliage_color_override,
                 },
             );
         }

--- a/pomme-client/src/renderer/chunk/mesher.rs
+++ b/pomme-client/src/renderer/chunk/mesher.rs
@@ -143,6 +143,7 @@ pub struct BiomeClimate {
     pub grass_color_override: Option<[f32; 3]>,
     pub grass_color_modifier: GrassColorModifier,
     pub foliage_color_override: Option<[f32; 3]>,
+    pub dry_foliage_color_override: Option<[f32; 3]>,
 }
 
 impl Default for BiomeClimate {
@@ -153,15 +154,17 @@ impl Default for BiomeClimate {
             grass_color_override: None,
             grass_color_modifier: GrassColorModifier::None,
             foliage_color_override: None,
+            dry_foliage_color_override: None,
         }
     }
 }
 
-fn tint_color(tint: Tint, grass: [f32; 3], foliage: [f32; 3]) -> u32 {
+fn tint_color(tint: Tint, grass: [f32; 3], foliage: [f32; 3], dry_foliage: [f32; 3]) -> u32 {
     match tint {
         Tint::None => PACKED_WHITE_SHIFTED,
         Tint::Grass => pack_tint_shifted(grass),
         Tint::Foliage => pack_tint_shifted(foliage),
+        Tint::DryFoliage => pack_tint_shifted(dry_foliage),
     }
 }
 
@@ -393,6 +396,7 @@ pub struct MeshDispatcher {
     uv_map: Arc<AtlasUVMap>,
     grass_colormap: Arc<Colormap>,
     foliage_colormap: Arc<Colormap>,
+    dry_foliage_colormap: Arc<Colormap>,
     biome_climate: Arc<HashMap<u32, BiomeClimate>>,
 }
 
@@ -402,6 +406,7 @@ impl MeshDispatcher {
         uv_map: AtlasUVMap,
         grass_colormap: Colormap,
         foliage_colormap: Colormap,
+        dry_foliage_colormap: Colormap,
         biome_climate: Arc<HashMap<u32, BiomeClimate>>,
     ) -> Self {
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
@@ -435,6 +440,7 @@ impl MeshDispatcher {
             uv_map: Arc::new(uv_map),
             grass_colormap: Arc::new(grass_colormap),
             foliage_colormap: Arc::new(foliage_colormap),
+            dry_foliage_colormap: Arc::new(dry_foliage_colormap),
             biome_climate,
         }
     }
@@ -460,6 +466,7 @@ impl MeshDispatcher {
         let uv_map = Arc::clone(&self.uv_map);
         let grass_colormap = Arc::clone(&self.grass_colormap);
         let foliage_colormap = Arc::clone(&self.foliage_colormap);
+        let dry_foliage_colormap = Arc::clone(&self.dry_foliage_colormap);
         let biome_climate = Arc::clone(&self.biome_climate);
         let tx = if priority {
             self.priority_tx.clone()
@@ -505,6 +512,7 @@ impl MeshDispatcher {
             uv_map,
             grass_colormap,
             foliage_colormap,
+            dry_foliage_colormap,
             biome_climate,
             min_y,
             height,
@@ -554,6 +562,7 @@ struct PendingJob {
     uv_map: Arc<AtlasUVMap>,
     grass_colormap: Arc<Colormap>,
     foliage_colormap: Arc<Colormap>,
+    dry_foliage_colormap: Arc<Colormap>,
     biome_climate: Arc<HashMap<u32, BiomeClimate>>,
     min_y: i32,
     height: u32,
@@ -572,6 +581,7 @@ impl PendingJob {
             light: self.light,
             grass_colormap: self.grass_colormap,
             foliage_colormap: self.foliage_colormap,
+            dry_foliage_colormap: self.dry_foliage_colormap,
             biome_climate: self.biome_climate,
             min_y: self.min_y,
             height: self.height,
@@ -726,6 +736,7 @@ struct ChunkStoreSnapshot {
     light: std::collections::HashMap<(i32, i32), crate::world::chunk::ChunkLightData>,
     grass_colormap: Arc<Colormap>,
     foliage_colormap: Arc<Colormap>,
+    dry_foliage_colormap: Arc<Colormap>,
     biome_climate: Arc<HashMap<u32, BiomeClimate>>,
     min_y: i32,
     height: u32,
@@ -800,12 +811,24 @@ impl ChunkStoreSnapshot {
         })
     }
 
+    fn dry_foliage_color_at(&self, x: i32, y: i32, z: i32) -> [f32; 3] {
+        let climate = self.climate_at(x, y, z);
+        climate.dry_foliage_color_override.unwrap_or_else(|| {
+            self.dry_foliage_colormap
+                .lookup(climate.temperature, climate.downfall)
+        })
+    }
+
     fn grass_tint(&self, x: i32, y: i32, z: i32) -> [f32; 3] {
         self.blend_color(x, y, z, Self::grass_color_at)
     }
 
     fn foliage_tint(&self, x: i32, y: i32, z: i32) -> [f32; 3] {
         self.blend_color(x, y, z, Self::foliage_color_at)
+    }
+
+    fn dry_foliage_tint(&self, x: i32, y: i32, z: i32) -> [f32; 3] {
+        self.blend_color(x, y, z, Self::dry_foliage_color_at)
     }
 
     fn blend_color(
@@ -1000,6 +1023,7 @@ fn greedy_mesh_section(
                 info.textures.tint,
                 snapshot.grass_tint(block_x, section_y, block_z),
                 snapshot.foliage_tint(block_x, section_y, block_z),
+                snapshot.dry_foliage_tint(block_x, section_y, block_z),
             );
 
             let ao = quad.ao_levels();
@@ -1296,6 +1320,7 @@ fn emit_baked_model(
             quad.tint,
             snapshot.grass_tint(bx, by, bz),
             snapshot.foliage_tint(bx, by, bz),
+            snapshot.dry_foliage_tint(bx, by, bz),
         );
         let lights = if let Some(dir) = quad.cullface {
             compute_face_ao(snapshot, registry, bx, by, bz, dir)
@@ -1332,6 +1357,7 @@ fn emit_cube_faces(
         textures.tint,
         snapshot.grass_tint(bx, by, bz),
         snapshot.foliage_tint(bx, by, bz),
+        snapshot.dry_foliage_tint(bx, by, bz),
     );
 
     for (i, dir) in CUBE_FACE_DIRS.iter().enumerate() {
@@ -1443,6 +1469,7 @@ fn block_face_tex_tint(
                     textures.tint,
                     snapshot.grass_tint(bx, by, bz),
                     snapshot.foliage_tint(bx, by, bz),
+                    snapshot.dry_foliage_tint(bx, by, bz),
                 );
                 let tex_name = match dir {
                     Direction::Up => &textures.top,
@@ -1533,6 +1560,7 @@ fn emit_multipart(
             quad.tint,
             snapshot.grass_tint(bx, by, bz),
             snapshot.foliage_tint(bx, by, bz),
+            snapshot.dry_foliage_tint(bx, by, bz),
         );
         emit_face(
             vertices,

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -880,11 +880,18 @@ impl Renderer {
             "minecraft/textures/colormap/foliage.png",
             packs,
         );
+        let dry_foliage_colormap = crate::renderer::chunk::mesher::Colormap::load(
+            &self.jar_assets_dir,
+            &self.asset_index,
+            "minecraft/textures/colormap/dry_foliage.png",
+            packs,
+        );
         MeshDispatcher::new(
             self.registry.clone(),
             self.atlas.uv_map.clone(),
             grass_colormap,
             foliage_colormap,
+            dry_foliage_colormap,
             biome_climate,
         )
     }

--- a/pomme-client/src/world/block/model.rs
+++ b/pomme-client/src/world/block/model.rs
@@ -229,6 +229,8 @@ const FOLIAGE_TINTED: &[&str] = &[
     "vine",
 ];
 
+const DRY_FOLIAGE_TINTED: &[&str] = &["leaf_litter"];
+
 const GRASS_TINTED: &[&str] = &[
     "grass_block",
     "short_grass",
@@ -1264,7 +1266,12 @@ fn build_face_textures(
 fn determine_tint(block_name: &str) -> Tint {
     if GRASS_TINTED.contains(&block_name) {
         Tint::Grass
+    } else if DRY_FOLIAGE_TINTED.contains(&block_name) {
+        Tint::DryFoliage
     } else if FOLIAGE_TINTED.contains(&block_name) || block_name.ends_with("_leaves") {
+        // TODO: spruce_leaves and birch_leaves use fixed constant colors in
+        // vanilla (BlockColors), not biome foliage; the `_leaves` suffix rule
+        // mistints them.
         Tint::Foliage
     } else {
         Tint::None

--- a/pomme-client/src/world/block/registry.rs
+++ b/pomme-client/src/world/block/registry.rs
@@ -15,6 +15,7 @@ pub enum Tint {
     None,
     Grass,
     Foliage,
+    DryFoliage,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -160,10 +161,12 @@ impl BlockRegistry {
         let mut quads = Vec::new();
         for entry in entries {
             if entry.when.is_empty()
-                || entry
-                    .when
-                    .iter()
-                    .all(|(k, v)| props.get(k.as_str()).map(|pv| pv == v).unwrap_or(false))
+                || entry.when.iter().all(|(k, v)| {
+                    props
+                        .get(k.as_str())
+                        .map(|pv| v.split('|').any(|opt| opt == *pv))
+                        .unwrap_or(false)
+                })
             {
                 quads.extend(entry.quads.iter());
             }


### PR DESCRIPTION
renders leaf litter flat on the ground with the dry-foliage biome tint, instead of as a grey full cube.

- fix multipart `when` matching to handle pipe-or values (e.g. `segment_amount=2|3`).
- add `tint::dryfoliage` and route leaf_litter to it.