### PR TITLE
Fix multiplayer player skins

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ops::Add;
 use std::sync::Arc;
 use std::time::Instant;
@@ -35,6 +36,11 @@ pub struct PendingPackDownload {
 }
 
 pub type PackDownloadResult = Result<std::path::PathBuf, crate::resource_pack::PackError>;
+
+struct PlayerSkinResult {
+    uuid: uuid::Uuid,
+    result: Result<(Vec<u8>, u32, u32), String>,
+}
 
 /// Queues `pos` and its already-loaded mesh neighborhood (de-duplicated): when
 /// `pos` changes, every chunk whose mesh samples it must re-mesh too, else
@@ -124,6 +130,9 @@ pub struct AppCore {
     pub audio: crate::audio::AudioEngine,
     pub tick_accumulator: f32,
     pub time_tick_accumulator: f32,
+    player_skin_tx: crossbeam_channel::Sender<PlayerSkinResult>,
+    player_skin_rx: crossbeam_channel::Receiver<PlayerSkinResult>,
+    requested_player_skins: HashSet<uuid::Uuid>,
 }
 
 impl AppCore {
@@ -151,6 +160,7 @@ impl AppCore {
             asset_index.clone(),
             menu.category_volumes(),
         );
+        let (player_skin_tx, player_skin_rx) = crossbeam_channel::unbounded();
 
         Self {
             user,
@@ -167,6 +177,9 @@ impl AppCore {
             audio,
             tick_accumulator: 0.0,
             time_tick_accumulator: 0.0,
+            player_skin_tx,
+            player_skin_rx,
+            requested_player_skins: HashSet::new(),
         }
     }
 
@@ -245,6 +258,36 @@ impl AppCore {
         let _ = connection.chat_tx.try_send(msg);
     }
 
+    fn queue_player_skin(&mut self, uuid: uuid::Uuid, textures: Option<String>) {
+        if !self.requested_player_skins.insert(uuid.clone()) {
+            return;
+        }
+
+        let tx = self.player_skin_tx.clone();
+        self.tokio_rt.spawn(async move {
+            let result = if let Some(textures) = textures {
+                crate::renderer::fetch_skin_texture_from_profile_property(&textures).await
+            } else {
+                let uuid_str = uuid.to_string().replace('-', "");
+                crate::renderer::fetch_skin_texture(&uuid_str).await
+            };
+            let _ = tx.send(PlayerSkinResult { uuid, result });
+        });
+    }
+
+    fn drain_player_skin_results(&mut self, renderer: &mut Renderer) {
+        while let Ok(skin) = self.player_skin_rx.try_recv() {
+            match skin.result {
+                Ok((pixels, width, height)) => {
+                    renderer.update_player_entity_skin(&skin.uuid, &pixels, width, height);
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load entity player skin for {}: {e}", skin.uuid)
+                }
+            }
+        }
+    }
+
     pub fn drain_network_events(
         &mut self,
         connection: &ConnectionHandle,
@@ -261,6 +304,7 @@ impl AppCore {
         let mut priority_remesh: Vec<(azalea_core::position::ChunkPos, i32)> = Vec::new();
         let mut disconnect_reason: Option<String> = None;
         let mut processed = 0u32;
+        self.drain_player_skin_results(renderer);
 
         while let Ok(event) = rx.try_recv() {
             processed += 1;
@@ -625,6 +669,7 @@ impl AppCore {
                 }
                 NetworkEvent::EntitySpawned {
                     id,
+                    uuid,
                     entity_type,
                     position,
                     y_rot_deg,
@@ -639,6 +684,8 @@ impl AppCore {
                             LookDirection::new(head_y_rot_deg, x_rot_deg),
                             y_rot_deg,
                             head_y_rot_deg,
+                            (entity_type == azalea_registry::builtin::EntityKind::Player)
+                                .then_some(uuid),
                         );
                     }
                     if entity_type == azalea_registry::builtin::EntityKind::Item {
@@ -812,8 +859,18 @@ impl AppCore {
                     tracing::warn!("Disconnected: {reason}");
                     disconnect_reason = Some(reason);
                     game.tab_list.clear();
+                    self.requested_player_skins.clear();
                 }
                 NetworkEvent::PlayerInfoUpdate { actions, entries } => {
+                    if actions.add_player {
+                        for entry in &entries {
+                            self.queue_player_skin(entry.uuid, entry.textures.clone());
+                        }
+                    } else {
+                        for entry in entries.iter().filter(|e| e.textures.is_some()) {
+                            self.queue_player_skin(entry.uuid, entry.textures.clone());
+                        }
+                    }
                     game.tab_list.apply_update(&actions, &entries);
                 }
                 NetworkEvent::PlayerInfoRemove { uuids } => {

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -748,6 +748,7 @@ impl AppCore {
                     for id in &ids {
                         if let Some(entity) = game.entity_store.remove_living(*id)
                             && let Some(uuid) = entity.player_uuid
+                            && !game.entity_store.has_player_uuid(&uuid)
                         {
                             self.remove_player_skin(renderer, &uuid);
                         }
@@ -904,7 +905,9 @@ impl AppCore {
                 }
                 NetworkEvent::PlayerInfoRemove { uuids } => {
                     for uuid in &uuids {
-                        self.remove_player_skin(renderer, uuid);
+                        if !game.entity_store.has_player_uuid(uuid) {
+                            self.remove_player_skin(renderer, uuid);
+                        }
                     }
                     game.tab_list.remove(&uuids);
                 }

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::ops::Add;
 use std::sync::Arc;
 use std::time::Instant;
@@ -39,6 +39,7 @@ pub type PackDownloadResult = Result<std::path::PathBuf, crate::resource_pack::P
 
 struct PlayerSkinResult {
     uuid: uuid::Uuid,
+    textures: Option<String>,
     result: Result<(Vec<u8>, u32, u32), String>,
 }
 
@@ -132,7 +133,7 @@ pub struct AppCore {
     pub time_tick_accumulator: f32,
     player_skin_tx: crossbeam_channel::Sender<PlayerSkinResult>,
     player_skin_rx: crossbeam_channel::Receiver<PlayerSkinResult>,
-    requested_player_skins: HashSet<uuid::Uuid>,
+    requested_player_skins: HashMap<uuid::Uuid, Option<String>>,
 }
 
 impl AppCore {
@@ -179,7 +180,7 @@ impl AppCore {
             time_tick_accumulator: 0.0,
             player_skin_tx,
             player_skin_rx,
-            requested_player_skins: HashSet::new(),
+            requested_player_skins: HashMap::new(),
         }
     }
 
@@ -259,11 +260,13 @@ impl AppCore {
     }
 
     fn queue_player_skin(&mut self, uuid: uuid::Uuid, textures: Option<String>) {
-        if !self.requested_player_skins.insert(uuid) {
+        if self.requested_player_skins.get(&uuid) == Some(&textures) {
             return;
         }
+        self.requested_player_skins.insert(uuid, textures.clone());
 
         let tx = self.player_skin_tx.clone();
+        let requested_textures = textures.clone();
         self.tokio_rt.spawn(async move {
             let result = if let Some(textures) = textures {
                 crate::renderer::fetch_skin_texture_from_profile_property(&textures).await
@@ -271,12 +274,19 @@ impl AppCore {
                 let uuid_str = uuid.to_string().replace('-', "");
                 crate::renderer::fetch_skin_texture(&uuid_str).await
             };
-            let _ = tx.send(PlayerSkinResult { uuid, result });
+            let _ = tx.send(PlayerSkinResult {
+                uuid,
+                textures: requested_textures,
+                result,
+            });
         });
     }
 
     fn drain_player_skin_results(&mut self, renderer: &mut Renderer) {
         while let Ok(skin) = self.player_skin_rx.try_recv() {
+            if self.requested_player_skins.get(&skin.uuid) != Some(&skin.textures) {
+                continue;
+            }
             match skin.result {
                 Ok((pixels, width, height)) => {
                     renderer.update_player_entity_skin(&skin.uuid, &pixels, width, height);
@@ -286,6 +296,11 @@ impl AppCore {
                 }
             }
         }
+    }
+
+    fn remove_player_skin(&mut self, renderer: &mut Renderer, uuid: &uuid::Uuid) {
+        self.requested_player_skins.remove(uuid);
+        renderer.remove_player_entity_skin(uuid);
     }
 
     pub fn drain_network_events(
@@ -677,15 +692,25 @@ impl AppCore {
                     head_y_rot_deg,
                 } => {
                     if crate::entity::is_living_mob(&entity_type) {
+                        let player_uuid = (entity_type
+                            == azalea_registry::builtin::EntityKind::Player)
+                            .then_some(uuid);
                         game.entity_store.spawn_living(
                             id,
                             entity_type,
                             position,
                             LookDirection::new(head_y_rot_deg, x_rot_deg),
                             y_rot_deg,
-                            (entity_type == azalea_registry::builtin::EntityKind::Player)
-                                .then_some(uuid),
+                            player_uuid,
                         );
+                        if let Some(uuid) = player_uuid {
+                            let textures = game
+                                .tab_list
+                                .players
+                                .get(&uuid)
+                                .and_then(|p| p.textures.clone());
+                            self.queue_player_skin(uuid, textures);
+                        }
                     }
                     if entity_type == azalea_registry::builtin::EntityKind::Item {
                         game.item_entity_store.spawn_item(id, position);
@@ -721,7 +746,11 @@ impl AppCore {
                 }
                 NetworkEvent::EntitiesRemoved { ids } => {
                     for id in &ids {
-                        game.entity_store.remove_living(*id);
+                        if let Some(entity) = game.entity_store.remove_living(*id)
+                            && let Some(uuid) = entity.player_uuid
+                        {
+                            self.remove_player_skin(renderer, &uuid);
+                        }
                     }
                     game.item_entity_store.remove(&ids);
                 }
@@ -859,6 +888,7 @@ impl AppCore {
                     disconnect_reason = Some(reason);
                     game.tab_list.clear();
                     self.requested_player_skins.clear();
+                    renderer.clear_player_entity_skins();
                 }
                 NetworkEvent::PlayerInfoUpdate { actions, entries } => {
                     if actions.add_player {
@@ -873,6 +903,9 @@ impl AppCore {
                     game.tab_list.apply_update(&actions, &entries);
                 }
                 NetworkEvent::PlayerInfoRemove { uuids } => {
+                    for uuid in &uuids {
+                        self.remove_player_skin(renderer, uuid);
+                    }
                     game.tab_list.remove(&uuids);
                 }
                 NetworkEvent::TabListHeaderFooter { header, footer } => {

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -259,7 +259,7 @@ impl AppCore {
     }
 
     fn queue_player_skin(&mut self, uuid: uuid::Uuid, textures: Option<String>) {
-        if !self.requested_player_skins.insert(uuid.clone()) {
+        if !self.requested_player_skins.insert(uuid) {
             return;
         }
 
@@ -683,7 +683,6 @@ impl AppCore {
                             position,
                             LookDirection::new(head_y_rot_deg, x_rot_deg),
                             y_rot_deg,
-                            head_y_rot_deg,
                             (entity_type == azalea_registry::builtin::EntityKind::Player)
                                 .then_some(uuid),
                         );

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -977,6 +977,7 @@ pub fn update_game(
                     + (e.walk_anim_speed - e.prev_walk_anim_speed) * partial_tick)
                     .min(1.0),
                 entity_kind: e.entity_type,
+                player_uuid: e.player_uuid.clone(),
                 variant_index: extras.variant_index,
                 overlay_tints: extras.overlay_tints,
                 head_y_offset: extras.head_y_offset,
@@ -1014,6 +1015,7 @@ pub fn update_game(
                 + (game.player_walk_speed - game.player_prev_walk_speed) * partial_tick)
                 .min(1.0),
             entity_kind: EntityKind::Player,
+            player_uuid: Some(core.user.uuid.clone()),
             variant_index: 0,
             overlay_tints: [None, None],
             head_y_offset: 0.0,

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -977,7 +977,7 @@ pub fn update_game(
                     + (e.walk_anim_speed - e.prev_walk_anim_speed) * partial_tick)
                     .min(1.0),
                 entity_kind: e.entity_type,
-                player_uuid: e.player_uuid.clone(),
+                player_uuid: e.player_uuid,
                 variant_index: extras.variant_index,
                 overlay_tints: extras.overlay_tints,
                 head_y_offset: extras.head_y_offset,
@@ -1015,7 +1015,7 @@ pub fn update_game(
                 + (game.player_walk_speed - game.player_prev_walk_speed) * partial_tick)
                 .min(1.0),
             entity_kind: EntityKind::Player,
-            player_uuid: Some(core.user.uuid.clone()),
+            player_uuid: Some(core.user.uuid),
             variant_index: 0,
             overlay_tints: [None, None],
             head_y_offset: 0.0,

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -394,7 +394,6 @@ impl EntityStore {
         position: Position,
         look_dir: LookDirection,
         body_y_rot_deg: f32,
-        head_y_rot_deg: f32,
         player_uuid: Option<uuid::Uuid>,
     ) {
         self.living.insert(
@@ -403,7 +402,7 @@ impl EntityStore {
                 entity_type,
                 position,
                 look_dir,
-                head_y_rot_deg,
+                look_dir.y_rot_deg(),
                 body_y_rot_deg,
                 player_uuid,
             ),

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -24,6 +24,7 @@ pub struct LivingEntity {
     pub body_y_rot_deg: f32,
     pub prev_body_y_rot_deg: f32,
     pub entity_type: EntityKind,
+    pub player_uuid: Option<uuid::Uuid>,
     pub walk_anim_pos: f32,
     pub walk_anim_speed: f32,
     pub prev_walk_anim_speed: f32,
@@ -61,6 +62,7 @@ impl LivingEntity {
         look_dir: LookDirection,
         head_y_rot_deg: f32,
         body_y_rot_deg: f32,
+        player_uuid: Option<uuid::Uuid>,
     ) -> Self {
         Self {
             position,
@@ -72,6 +74,7 @@ impl LivingEntity {
             body_y_rot_deg,
             prev_body_y_rot_deg: body_y_rot_deg,
             entity_type,
+            player_uuid,
             walk_anim_pos: 0.0,
             walk_anim_speed: 0.0,
             prev_walk_anim_speed: 0.0,
@@ -392,6 +395,7 @@ impl EntityStore {
         look_dir: LookDirection,
         body_y_rot_deg: f32,
         head_y_rot_deg: f32,
+        player_uuid: Option<uuid::Uuid>,
     ) {
         self.living.insert(
             id,
@@ -401,6 +405,7 @@ impl EntityStore {
                 look_dir,
                 head_y_rot_deg,
                 body_y_rot_deg,
+                player_uuid,
             ),
         );
     }

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -516,6 +516,12 @@ impl EntityStore {
         self.living.remove(&id)
     }
 
+    pub fn has_player_uuid(&self, uuid: &uuid::Uuid) -> bool {
+        self.living
+            .values()
+            .any(|entity| entity.player_uuid == Some(*uuid))
+    }
+
     pub fn tick_living(&mut self) {
         for entity in self.living.values_mut() {
             entity.tick_interpolation();

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -512,8 +512,8 @@ impl EntityStore {
         }
     }
 
-    pub fn remove_living(&mut self, id: i32) {
-        self.living.remove(&id);
+    pub fn remove_living(&mut self, id: i32) -> Option<LivingEntity> {
+        self.living.remove(&id)
     }
 
     pub fn tick_living(&mut self) {

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -275,6 +275,7 @@ pub fn handle_game_packet(
             let head_y_rot_deg = (p.y_head_rot as f32) * 360.0 / 256.0;
             let _ = event_tx.try_send(NetworkEvent::EntitySpawned {
                 id: p.id.0,
+                uuid: p.uuid,
                 entity_type: p.entity_type,
                 position: p.position.into(),
                 y_rot_deg,
@@ -509,6 +510,12 @@ pub fn handle_game_packet(
                 .map(|e| PlayerInfoEntry {
                     uuid: e.profile.uuid,
                     name: e.profile.name.clone(),
+                    textures: e
+                        .profile
+                        .properties
+                        .map
+                        .get("textures")
+                        .map(|p| p.value.clone()),
                     game_mode: e.game_mode.to_id(),
                     listed: e.listed,
                     latency: e.latency,

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -129,6 +129,7 @@ pub enum NetworkEvent {
     },
     EntitySpawned {
         id: i32,
+        uuid: uuid::Uuid,
         entity_type: EntityKind,
         position: Position,
         y_rot_deg: f32,

--- a/pomme-client/src/player/tab_list.rs
+++ b/pomme-client/src/player/tab_list.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 pub struct PlayerInfoEntry {
     pub uuid: Uuid,
     pub name: String,
+    pub textures: Option<String>,
     /// 0 survival, 1 creative, 2 adventure, 3 spectator.
     pub game_mode: u8,
     pub listed: bool,
@@ -29,6 +30,7 @@ pub struct TabListPlayer {
     #[allow(dead_code)]
     pub uuid: Uuid,
     pub name: String,
+    pub textures: Option<String>,
     pub display_name: Option<String>,
     pub game_mode: u8,
     pub latency: i32,
@@ -62,6 +64,7 @@ impl TabList {
                     TabListPlayer {
                         uuid: e.uuid,
                         name: e.name.clone(),
+                        textures: e.textures.clone(),
                         display_name: e.display_name.clone(),
                         game_mode: e.game_mode,
                         latency: e.latency,
@@ -70,6 +73,9 @@ impl TabList {
                     },
                 );
             } else if let Some(p) = self.players.get_mut(&e.uuid) {
+                if let Some(textures) = &e.textures {
+                    p.textures = Some(textures.clone());
+                }
                 if actions.update_game_mode {
                     p.game_mode = e.game_mode;
                 }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1079,6 +1079,16 @@ impl Renderer {
         );
     }
 
+    pub fn remove_player_entity_skin(&mut self, uuid: &uuid::Uuid) {
+        self.entity_renderer
+            .remove_player_skin(&self.ctx.device, &self.ctx.allocator, uuid);
+    }
+
+    pub fn clear_player_entity_skins(&mut self) {
+        self.entity_renderer
+            .clear_player_skins(&self.ctx.device, &self.ctx.allocator);
+    }
+
     pub fn update_favicon_atlas(&mut self, favicons: &[(String, Vec<u8>, u32)]) {
         self.menu_pipeline.update_favicon_atlas(
             &self.ctx.device,

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1777,6 +1777,7 @@ fn skin_url_from_texture_property(value: &str) -> Result<String, String> {
     use base64::Engine;
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(value)
+        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(value))
         .map_err(|e| e.to_string())?;
     let payload: TexturesPayload = serde_json::from_slice(&decoded).map_err(|e| e.to_string())?;
 
@@ -1867,6 +1868,21 @@ mod tests {
 
         assert_eq!(
             skin_url_from_texture_property(&value).unwrap(),
+            "https://textures.minecraft.net/texture/testskin"
+        );
+    }
+
+    #[test]
+    fn decodes_unpadded_skin_url_from_textures_property() {
+        use base64::Engine;
+
+        let payload =
+            r#"{"textures":{"SKIN":{"url":"https://textures.minecraft.net/texture/testskin"}}}"#;
+        let value = base64::engine::general_purpose::STANDARD.encode(payload);
+        let value = value.trim_end_matches('=');
+
+        assert_eq!(
+            skin_url_from_texture_property(value).unwrap(),
             "https://textures.minecraft.net/texture/testskin"
         );
     }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1792,25 +1792,6 @@ async fn fetch_skin_image(skin_url: &str) -> Result<(Vec<u8>, u32, u32), String>
     Ok((rgba.into_raw(), w, h))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn decodes_skin_url_from_textures_property() {
-        use base64::Engine;
-
-        let payload =
-            r#"{"textures":{"SKIN":{"url":"https://textures.minecraft.net/texture/testskin"}}}"#;
-        let value = base64::engine::general_purpose::STANDARD.encode(payload);
-
-        assert_eq!(
-            skin_url_from_texture_property(&value).unwrap(),
-            "https://textures.minecraft.net/texture/testskin"
-        );
-    }
-}
-
 impl Drop for Renderer {
     fn drop(&mut self) {
         let _ = self.ctx.device.wait_idle();
@@ -1859,5 +1840,24 @@ impl Drop for Renderer {
 
         self.swapchain
             .destroy(&self.ctx.device, &self.ctx.allocator);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_skin_url_from_textures_property() {
+        use base64::Engine;
+
+        let payload =
+            r#"{"textures":{"SKIN":{"url":"https://textures.minecraft.net/texture/testskin"}}}"#;
+        let value = base64::engine::general_purpose::STANDARD.encode(payload);
+
+        assert_eq!(
+            skin_url_from_texture_property(&value).unwrap(),
+            "https://textures.minecraft.net/texture/testskin"
+        );
     }
 }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1054,9 +1054,29 @@ impl Renderer {
                     self.hand_pipeline.skin_view(),
                     self.hand_pipeline.skin_sampler(),
                 );
+                self.update_player_entity_skin(uuid, &pixels, w, h);
             }
             Err(e) => tracing::warn!("Failed to load player skin: {e}"),
         }
+    }
+
+    pub fn update_player_entity_skin(
+        &mut self,
+        uuid: &uuid::Uuid,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+    ) {
+        self.entity_renderer.update_player_skin(
+            &self.ctx.device,
+            self.ctx.graphics_queue,
+            self.ctx.command_pool,
+            &self.ctx.allocator,
+            uuid,
+            pixels,
+            width,
+            height,
+        );
     }
 
     pub fn update_favicon_atlas(&mut self, favicons: &[(String, Vec<u8>, u32)]) {
@@ -1699,8 +1719,37 @@ pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32)
     }
     #[derive(serde::Deserialize)]
     struct ProfileProperty {
+        name: Option<String>,
         value: String,
     }
+
+    let url = format!("https://sessionserver.mojang.com/session/minecraft/profile/{uuid}");
+    let profile: SessionProfile = reqwest::get(&url)
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let value = &profile
+        .properties
+        .iter()
+        .find(|p| p.name.as_deref() == Some("textures"))
+        .or_else(|| profile.properties.first())
+        .ok_or("No properties")?
+        .value;
+
+    fetch_skin_texture_from_profile_property(value).await
+}
+
+pub(crate) async fn fetch_skin_texture_from_profile_property(
+    value: &str,
+) -> Result<(Vec<u8>, u32, u32), String> {
+    let skin_url = skin_url_from_texture_property(value)?;
+    fetch_skin_image(&skin_url).await
+}
+
+fn skin_url_from_texture_property(value: &str) -> Result<String, String> {
     #[derive(serde::Deserialize)]
     struct TexturesPayload {
         textures: Textures,
@@ -1715,29 +1764,21 @@ pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32)
         url: String,
     }
 
-    let url = format!("https://sessionserver.mojang.com/session/minecraft/profile/{uuid}");
-    let profile: SessionProfile = reqwest::get(&url)
-        .await
-        .map_err(|e| e.to_string())?
-        .json()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let value = &profile.properties.first().ok_or("No properties")?.value;
-
     use base64::Engine;
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(value)
         .map_err(|e| e.to_string())?;
     let payload: TexturesPayload = serde_json::from_slice(&decoded).map_err(|e| e.to_string())?;
 
-    let skin_url = payload
+    payload
         .textures
         .skin
         .map(|s| s.url)
-        .ok_or("No skin texture")?;
+        .ok_or_else(|| "No skin texture".to_string())
+}
 
-    let skin_bytes = reqwest::get(&skin_url)
+async fn fetch_skin_image(skin_url: &str) -> Result<(Vec<u8>, u32, u32), String> {
+    let skin_bytes = reqwest::get(skin_url)
         .await
         .map_err(|e| e.to_string())?
         .bytes()
@@ -1749,6 +1790,25 @@ pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32)
     let w = rgba.width();
     let h = rgba.height();
     Ok((rgba.into_raw(), w, h))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_skin_url_from_textures_property() {
+        use base64::Engine;
+
+        let payload =
+            r#"{"textures":{"SKIN":{"url":"https://textures.minecraft.net/texture/testskin"}}}"#;
+        let value = base64::engine::general_purpose::STANDARD.encode(payload);
+
+        assert_eq!(
+            skin_url_from_texture_property(&value).unwrap(),
+            "https://textures.minecraft.net/texture/testskin"
+        );
+    }
 }
 
 impl Drop for Renderer {

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -563,8 +563,15 @@ impl EntityRenderer {
             return;
         }
 
-        let (image, view, allocation) =
-            upload_texture_pixels(device, queue, command_pool, allocator, pixels, width, height);
+        let (image, view, allocation) = upload_texture_pixels(
+            device,
+            queue,
+            command_pool,
+            allocator,
+            pixels,
+            width,
+            height,
+        );
         let set = if let Some(old) = self.player_skins.get(uuid) {
             old.set
         } else {
@@ -739,7 +746,11 @@ impl EntityRenderer {
                 };
                 let base = v.entry.base_variant(v.info.is_baby, v.info.variant_index);
                 let texture_set = self.player_texture_set(v.info, base.texture_set);
-                opaque.add(base, texture_set, (vi, WHITE_TINT, overlay_color, [0.0, 0.0]));
+                opaque.add(
+                    base,
+                    texture_set,
+                    (vi, WHITE_TINT, overlay_color, [0.0, 0.0]),
+                );
                 for (slot, overlay) in v.entry.overlays(v.info.is_baby).iter().enumerate() {
                     if overlay.overlay_kind != OverlayKind::Opaque {
                         continue;
@@ -997,15 +1008,16 @@ struct VariantGroups<'a> {
 impl<'a> VariantGroups<'a> {
     fn add(&mut self, variant: &'a MobVariant, texture_set: vk::DescriptorSet, member: Member) {
         let key = variant as *const MobVariant as usize;
-        let gi = match self.groups.iter().position(|(v, set, _)| {
-            *v as *const MobVariant as usize == key && *set == texture_set
-        }) {
-            Some(gi) => gi,
-            None => {
-                self.groups.push((variant, texture_set, Vec::new()));
-                self.groups.len() - 1
-            }
-        };
+        let gi =
+            match self.groups.iter().position(|(v, set, _)| {
+                *v as *const MobVariant as usize == key && *set == texture_set
+            }) {
+                Some(gi) => gi,
+                None => {
+                    self.groups.push((variant, texture_set, Vec::new()));
+                    self.groups.len() - 1
+                }
+            };
         self.groups[gi].2.push(member);
     }
 

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -448,6 +448,7 @@ impl EntityRenderer {
             },
         ];
         let pool_info = vk::DescriptorPoolCreateInfo {
+            flags: vk::DescriptorPoolCreateFlags::FreeDescriptorSet,
             max_sets: MAX_FRAMES_IN_FLIGHT as u32 + tex_count,
             pool_size_count: pool_sizes.len() as u32,
             pool_sizes: pool_sizes.as_ptr(),
@@ -617,7 +618,25 @@ impl EntityRenderer {
             allocator.lock().unwrap().free(old.allocation).ok();
         }
 
-        tracing::info!("Player skin loaded for {uuid}: {width}x{height}");
+        tracing::debug!("Player skin loaded for {uuid}: {width}x{height}");
+    }
+
+    pub fn remove_player_skin(
+        &mut self,
+        device: &vk::Device,
+        allocator: &Arc<Mutex<Allocator>>,
+        uuid: &uuid::Uuid,
+    ) {
+        if let Some(skin) = self.player_skins.remove(uuid) {
+            free_player_skin_texture(device, allocator, self.descriptor_pool, skin);
+        }
+    }
+
+    pub fn clear_player_skins(&mut self, device: &vk::Device, allocator: &Arc<Mutex<Allocator>>) {
+        let descriptor_pool = self.descriptor_pool;
+        for (_, skin) in self.player_skins.drain() {
+            free_player_skin_texture(device, allocator, descriptor_pool, skin);
+        }
     }
 
     fn player_texture_set(
@@ -889,14 +908,8 @@ impl EntityRenderer {
                 device.destroy_image(v.texture_image, None);
             }
         }
-        for skin in self.player_skins.values_mut() {
-            device.destroy_image_view(skin.view, None);
-            alloc
-                .free(std::mem::replace(&mut skin.allocation, unsafe {
-                    std::mem::zeroed()
-                }))
-                .ok();
-            device.destroy_image(skin.image, None);
+        for (_, skin) in self.player_skins.drain() {
+            destroy_player_skin_texture(device, &mut alloc, skin);
         }
 
         drop(alloc);
@@ -1305,6 +1318,29 @@ fn upload_texture_pixels(
     device.destroy_buffer(staging_buf, None);
     allocator.lock().unwrap().free(staging_alloc).ok();
     (image, view, allocation)
+}
+
+fn free_player_skin_texture(
+    device: &vk::Device,
+    allocator: &Arc<Mutex<Allocator>>,
+    descriptor_pool: vk::DescriptorPool,
+    skin: PlayerSkinTexture,
+) {
+    device
+        .free_descriptor_sets(descriptor_pool, &[skin.set])
+        .ok();
+    let mut alloc = allocator.lock().unwrap();
+    destroy_player_skin_texture(device, &mut alloc, skin);
+}
+
+fn destroy_player_skin_texture(
+    device: &vk::Device,
+    allocator: &mut Allocator,
+    skin: PlayerSkinTexture,
+) {
+    device.destroy_image_view(skin.view, None);
+    allocator.free(skin.allocation).ok();
+    device.destroy_image(skin.image, None);
 }
 
 pub(super) fn fallback_texture(size: u32) -> (Vec<u8>, u32, u32) {

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -19,6 +19,7 @@ pub const MAX_OVERLAYS: usize = 2;
 /// Per-frame instance buffer capacity, in (entity, part) draws. Far above any
 /// realistic on-screen entity count; excess is dropped with a warning.
 const MAX_INSTANCES: usize = 16384;
+const MAX_PLAYER_SKINS: usize = 128;
 
 /// Per-instance data for one (entity, part) draw, fed as instance-rate vertex
 /// attributes (binding 1) — the four model-matrix columns, tint, overlay, uv.
@@ -41,6 +42,7 @@ pub struct EntityRenderInfo {
     pub walk_anim_pos: f32,
     pub walk_anim_speed: f32,
     pub entity_kind: EntityKind,
+    pub player_uuid: Option<uuid::Uuid>,
     pub variant_index: u32,
     pub overlay_tints: [Option<[f32; 4]>; MAX_OVERLAYS],
     pub head_y_offset: f32,
@@ -86,6 +88,13 @@ struct MobEntry {
     adult_overlays: Vec<MobVariant>,
     baby_overlays: Vec<MobVariant>,
     anim: AnimationType,
+}
+
+struct PlayerSkinTexture {
+    image: vk::Image,
+    view: vk::ImageView,
+    allocation: Allocation,
+    set: vk::DescriptorSet,
 }
 
 impl MobEntry {
@@ -181,6 +190,7 @@ pub struct EntityRenderer {
     /// REPEAT-wrap sampler for the scrolling swirl overlay.
     texture_sampler_repeat: vk::Sampler,
     mobs: HashMap<EntityKind, MobEntry>,
+    player_skins: HashMap<uuid::Uuid, PlayerSkinTexture>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -425,6 +435,7 @@ impl EntityRenderer {
                 n
             })
             .sum();
+        let tex_count = tex_count + MAX_PLAYER_SKINS as u32;
 
         let pool_sizes = [
             vk::DescriptorPoolSize {
@@ -525,6 +536,7 @@ impl EntityRenderer {
             texture_sampler,
             texture_sampler_repeat,
             mobs,
+            player_skins: HashMap::new(),
         }
     }
 
@@ -532,6 +544,88 @@ impl EntityRenderer {
         let bytes = bytemuck::bytes_of(uniform);
         self.camera_allocations[frame].mapped_slice_mut().unwrap()[..bytes.len()]
             .copy_from_slice(bytes);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_player_skin(
+        &mut self,
+        device: &vk::Device,
+        queue: vk::Queue,
+        command_pool: vk::CommandPool,
+        allocator: &Arc<Mutex<Allocator>>,
+        uuid: &uuid::Uuid,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+    ) {
+        if !self.player_skins.contains_key(uuid) && self.player_skins.len() >= MAX_PLAYER_SKINS {
+            tracing::warn!("Player skin cache full; keeping fallback texture for {uuid}");
+            return;
+        }
+
+        let (image, view, allocation) =
+            upload_texture_pixels(device, queue, command_pool, allocator, pixels, width, height);
+        let set = if let Some(old) = self.player_skins.get(uuid) {
+            old.set
+        } else {
+            let tex_alloc_info = vk::DescriptorSetAllocateInfo {
+                descriptor_pool: self.descriptor_pool,
+                descriptor_set_count: 1,
+                set_layouts: &self.texture_layout,
+                ..Default::default()
+            };
+            let mut texture_set = vk::DescriptorSet::null();
+            device
+                .allocate_descriptor_sets(&tex_alloc_info, slice::from_mut(&mut texture_set))
+                .expect("failed to allocate player skin texture descriptor set");
+            texture_set
+        };
+
+        let image_info = vk::DescriptorImageInfo {
+            sampler: self.texture_sampler,
+            image_view: view,
+            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+        };
+        let tex_write = vk::WriteDescriptorSet {
+            dst_set: set,
+            dst_binding: 0,
+            descriptor_type: vk::DescriptorType::CombinedImageSampler,
+            descriptor_count: 1,
+            image_info: &image_info,
+            ..Default::default()
+        };
+        device.update_descriptor_sets(&[tex_write], &[]);
+
+        if let Some(old) = self.player_skins.insert(
+            uuid.to_owned(),
+            PlayerSkinTexture {
+                image,
+                view,
+                allocation,
+                set,
+            },
+        ) {
+            device.destroy_image_view(old.view, None);
+            device.destroy_image(old.image, None);
+            allocator.lock().unwrap().free(old.allocation).ok();
+        }
+
+        tracing::info!("Player skin loaded for {uuid}: {width}x{height}");
+    }
+
+    fn player_texture_set(
+        &self,
+        info: &EntityRenderInfo,
+        fallback: vk::DescriptorSet,
+    ) -> vk::DescriptorSet {
+        if info.entity_kind == EntityKind::Player
+            && let Some(uuid) = &info.player_uuid
+            && let Some(skin) = self.player_skins.get(uuid)
+        {
+            skin.set
+        } else {
+            fallback
+        }
     }
 
     fn compute_anim(
@@ -644,13 +738,18 @@ impl EntityRenderer {
                     NO_OVERLAY
                 };
                 let base = v.entry.base_variant(v.info.is_baby, v.info.variant_index);
-                opaque.add(base, (vi, WHITE_TINT, overlay_color, [0.0, 0.0]));
+                let texture_set = self.player_texture_set(v.info, base.texture_set);
+                opaque.add(base, texture_set, (vi, WHITE_TINT, overlay_color, [0.0, 0.0]));
                 for (slot, overlay) in v.entry.overlays(v.info.is_baby).iter().enumerate() {
                     if overlay.overlay_kind != OverlayKind::Opaque {
                         continue;
                     }
                     if let Some(tint) = v.info.overlay_tints[slot] {
-                        opaque.add(overlay, (vi, tint, overlay_color, [0.0, 0.0]));
+                        opaque.add(
+                            overlay,
+                            overlay.texture_set,
+                            (vi, tint, overlay_color, [0.0, 0.0]),
+                        );
                     }
                 }
             }
@@ -700,11 +799,12 @@ impl EntityRenderer {
         // gl_InstanceIndex (incl. firstInstance) indexes into it.
         cmd.bind_vertex_buffers(1, &[self.instance_buffers[frame]], &[0]);
         let mut last_vb = vk::Buffer::null();
+        let mut last_texture_set = vk::DescriptorSet::null();
         for r in records {
             if r.first_instance as usize + r.instance_count as usize > count {
                 continue; // dropped by the capacity clamp above
             }
-            if r.vertex_buffer != last_vb {
+            if r.vertex_buffer != last_vb || r.texture_set != last_texture_set {
                 cmd.bind_descriptor_sets(
                     vk::PipelineBindPoint::Graphics,
                     self.pipeline_layout,
@@ -714,6 +814,7 @@ impl EntityRenderer {
                 );
                 cmd.bind_vertex_buffers(0, &[r.vertex_buffer], &[0]);
                 last_vb = r.vertex_buffer;
+                last_texture_set = r.texture_set;
             }
             cmd.draw(
                 r.part_count,
@@ -776,6 +877,15 @@ impl EntityRenderer {
                     .ok();
                 device.destroy_image(v.texture_image, None);
             }
+        }
+        for skin in self.player_skins.values_mut() {
+            device.destroy_image_view(skin.view, None);
+            alloc
+                .free(std::mem::replace(&mut skin.allocation, unsafe {
+                    std::mem::zeroed()
+                }))
+                .ok();
+            device.destroy_image(skin.image, None);
         }
 
         drop(alloc);
@@ -881,28 +991,27 @@ type Member = (usize, [f32; 4], [f32; 4], [f32; 2]);
 /// one instanced draw covering all its entities.
 #[derive(Default)]
 struct VariantGroups<'a> {
-    groups: Vec<(&'a MobVariant, Vec<Member>)>,
-    index: HashMap<usize, usize>,
+    groups: Vec<(&'a MobVariant, vk::DescriptorSet, Vec<Member>)>,
 }
 
 impl<'a> VariantGroups<'a> {
-    fn add(&mut self, variant: &'a MobVariant, member: Member) {
+    fn add(&mut self, variant: &'a MobVariant, texture_set: vk::DescriptorSet, member: Member) {
         let key = variant as *const MobVariant as usize;
-        let gi = match self.index.get(&key) {
-            Some(&gi) => gi,
+        let gi = match self.groups.iter().position(|(v, set, _)| {
+            *v as *const MobVariant as usize == key && *set == texture_set
+        }) {
+            Some(gi) => gi,
             None => {
-                let gi = self.groups.len();
-                self.groups.push((variant, Vec::new()));
-                self.index.insert(key, gi);
-                gi
+                self.groups.push((variant, texture_set, Vec::new()));
+                self.groups.len() - 1
             }
         };
-        self.groups[gi].1.push(member);
+        self.groups[gi].2.push(member);
     }
 
     fn emit(&self, vis: &[VisEntity], instances: &mut Vec<EntityInstance>) -> Vec<DrawRecord> {
         let mut records = Vec::new();
-        for (variant, members) in &self.groups {
+        for (variant, texture_set, members) in &self.groups {
             // Part transforms differ per entity (animation), so compute per member.
             let pts: Vec<Vec<glam::Mat4>> = members
                 .iter()
@@ -923,7 +1032,7 @@ impl<'a> VariantGroups<'a> {
                     });
                 }
                 records.push(DrawRecord {
-                    texture_set: variant.texture_set,
+                    texture_set: *texture_set,
                     vertex_buffer: variant.vertex_buffer,
                     part_start: *start,
                     part_count: *part_count,
@@ -952,7 +1061,7 @@ fn collect_emissive<'a>(vis: &[VisEntity<'a>], kind: OverlayKind) -> VariantGrou
                 continue;
             }
             if let Some(tint) = v.info.overlay_tints[slot] {
-                groups.add(overlay, (vi, tint, NO_OVERLAY, uv));
+                groups.add(overlay, overlay.texture_set, (vi, tint, NO_OVERLAY, uv));
             }
         }
     }
@@ -1145,6 +1254,33 @@ fn load_entity_texture(
         util::create_gpu_image(device, allocator, width, height, "entity_texture");
     let (staging_buf, staging_alloc) =
         util::create_staging_buffer(device, allocator, &pixels, "entity_texture_staging");
+    util::upload_image(
+        device,
+        queue,
+        command_pool,
+        staging_buf,
+        image,
+        width,
+        height,
+    );
+    device.destroy_buffer(staging_buf, None);
+    allocator.lock().unwrap().free(staging_alloc).ok();
+    (image, view, allocation)
+}
+
+fn upload_texture_pixels(
+    device: &vk::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    allocator: &Arc<Mutex<Allocator>>,
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+) -> (vk::Image, vk::ImageView, Allocation) {
+    let (image, view, allocation) =
+        util::create_gpu_image(device, allocator, width, height, "player_skin_texture");
+    let (staging_buf, staging_alloc) =
+        util::create_staging_buffer(device, allocator, pixels, "player_skin_texture_staging");
     util::upload_image(
         device,
         queue,


### PR DESCRIPTION
Carry player UUIDs and Mojang `textures` profile data from multiplayer player-info/entity packets into the entity render path. Decode the profile texture payload, download skin PNGs asynchronously, upload them into a bounded Vulkan player-skin cache keyed by UUID, and render player entities with their cached skin texture when available.

Closes #299 