### PR TITLE
Fix see-through leaves

### DIFF
--- a/pomme-client/src/renderer/chunk/mesher.rs
+++ b/pomme-client/src/renderer/chunk/mesher.rs
@@ -1310,7 +1310,7 @@ fn emit_baked_model(
         if let Some(cullface) = quad.cullface {
             let offset = cullface.offset();
             let neighbor = snapshot.get_block_state(bx + offset[0], by + offset[1], bz + offset[2]);
-            if registry.is_opaque_full_cube(neighbor) {
+            if registry.occludes_neighbor(neighbor) {
                 continue;
             }
         }
@@ -1363,7 +1363,7 @@ fn emit_cube_faces(
     for (i, dir) in CUBE_FACE_DIRS.iter().enumerate() {
         let offset = dir.offset();
         let neighbor = snapshot.get_block_state(bx + offset[0], by + offset[1], bz + offset[2]);
-        if registry.is_opaque_full_cube(neighbor) {
+        if registry.occludes_neighbor(neighbor) {
             continue;
         }
 
@@ -1508,7 +1508,7 @@ fn emit_fluid(
         let neighbor = snapshot.get_block_state(bx + offset[0], by + offset[1], bz + offset[2]);
 
         if matches!(classify_block(neighbor), BlockKind::Water | BlockKind::Lava)
-            || registry.is_opaque_full_cube(neighbor)
+            || registry.occludes_neighbor(neighbor)
         {
             continue;
         }
@@ -1550,7 +1550,7 @@ fn emit_multipart(
         if let Some(cullface) = quad.cullface {
             let offset = cullface.offset();
             let neighbor = snapshot.get_block_state(bx + offset[0], by + offset[1], bz + offset[2]);
-            if registry.is_opaque_full_cube(neighbor) {
+            if registry.occludes_neighbor(neighbor) {
                 continue;
             }
         }
@@ -1608,7 +1608,7 @@ fn emit_lod_cube(
         let ny = by + offset[1] * step;
         let nz = bz + offset[2] * step;
         let neighbor = snapshot.get_block_state(nx, ny, nz);
-        if registry.is_opaque_full_cube(neighbor) {
+        if registry.occludes_neighbor(neighbor) {
             continue;
         }
         if is_fluid && matches!(classify_block(neighbor), BlockKind::Water | BlockKind::Lava) {
@@ -1656,7 +1656,7 @@ fn emit_missing_cube(
     for dir in &CUBE_FACE_DIRS {
         let offset = dir.offset();
         let neighbor = snapshot.get_block_state(bx + offset[0], by + offset[1], bz + offset[2]);
-        if registry.is_opaque_full_cube(neighbor) {
+        if registry.occludes_neighbor(neighbor) {
             continue;
         }
 

--- a/pomme-client/src/renderer/chunk/mesher.rs
+++ b/pomme-client/src/renderer/chunk/mesher.rs
@@ -1724,6 +1724,8 @@ fn emit_face(
 }
 
 fn shade_brightness(state: azalea_block::BlockState, registry: &BlockRegistry) -> f32 {
+    // TODO: non-occluding full cubes (leaves, glass, ice) still darken adjacent
+    // faces here. Vanilla's are `isViewBlocking=never` and don't contribute AO.
     if registry.is_opaque_full_cube(state) {
         0.2
     } else {

--- a/pomme-client/src/world/block/model.rs
+++ b/pomme-client/src/world/block/model.rs
@@ -1271,10 +1271,12 @@ fn build_face_textures(
     None
 }
 
-/// Leaves bake as a full cube but mustn't cull adjacent faces, or the cutout
-/// texture lets you see through them (vanilla `noOcclusion`).
+/// Full-cube blocks that mustn't cull adjacent faces (vanilla `noOcclusion`).
+/// Solid `packed_ice`/`blue_ice` still occlude, so `ice` is matched exactly.
 fn is_non_occluding(block_name: &str) -> bool {
     block_name.ends_with("_leaves")
+        || block_name.ends_with("_stained_glass")
+        || matches!(block_name, "glass" | "tinted_glass" | "ice" | "frosted_ice")
 }
 
 fn determine_tint(block_name: &str) -> Tint {

--- a/pomme-client/src/world/block/model.rs
+++ b/pomme-client/src/world/block/model.rs
@@ -212,6 +212,9 @@ pub struct BakedQuad {
 pub struct BakedModel {
     pub quads: Vec<BakedQuad>,
     pub is_full_cube: bool,
+    /// Vanilla `canOcclude`: full cubes occlude, but cutout blocks like leaves
+    /// don't, so neighbor faces against them still render.
+    pub occludes: bool,
 }
 
 #[derive(Clone)]
@@ -305,9 +308,12 @@ pub fn bake_all_models(
                         &mut model_cache,
                         packs,
                     );
-                    if let Some(baked) =
+                    if let Some(mut baked) =
                         bake_resolved_model(&resolved, model_ref.x, model_ref.y, block_tint)
                     {
+                        if is_non_occluding(block_name) {
+                            baked.occludes = false;
+                        }
                         variants_map.insert(variant_key.clone(), baked);
                     }
                 }
@@ -500,6 +506,7 @@ pub fn bake_chest_item_model() -> BakedModel {
     BakedModel {
         quads,
         is_full_cube: false,
+        occludes: false,
     }
 }
 
@@ -1001,6 +1008,7 @@ fn bake_resolved_model(
     Some(BakedModel {
         quads,
         is_full_cube,
+        occludes: is_full_cube,
     })
 }
 
@@ -1261,6 +1269,12 @@ fn build_face_textures(
     }
 
     None
+}
+
+/// Leaves bake as a full cube but mustn't cull adjacent faces, or the cutout
+/// texture lets you see through them (vanilla `noOcclusion`).
+fn is_non_occluding(block_name: &str) -> bool {
+    block_name.ends_with("_leaves")
 }
 
 fn determine_tint(block_name: &str) -> Tint {

--- a/pomme-client/src/world/block/registry.rs
+++ b/pomme-client/src/world/block/registry.rs
@@ -186,13 +186,22 @@ impl BlockRegistry {
         if quads.is_empty() { None } else { Some(quads) }
     }
 
-    pub fn is_opaque_full_cube(&self, state: BlockState) -> bool {
+    fn baked_model_flag(&self, state: BlockState, f: impl Fn(&BakedModel) -> bool) -> bool {
         if state.is_air() {
             return false;
         }
-        self.get_baked_model(state)
-            .map(|m| m.is_full_cube)
-            .unwrap_or(false)
+        self.get_baked_model(state).map(f).unwrap_or(false)
+    }
+
+    pub fn is_opaque_full_cube(&self, state: BlockState) -> bool {
+        self.baked_model_flag(state, |m| m.is_full_cube)
+    }
+
+    /// Whether `state` culls a neighbor's adjacent face. Unlike
+    /// [`Self::is_opaque_full_cube`], non-occluding blocks like leaves return
+    /// false even though they bake as full cubes.
+    pub fn occludes_neighbor(&self, state: BlockState) -> bool {
+        self.baked_model_flag(state, |m| m.occludes)
     }
 
     pub fn texture_names(&self) -> impl Iterator<Item = &str> + '_ {


### PR DESCRIPTION
Mark leaves non-occluding so neighbor faces against them stop getting culled.