### PR TITLE
Ping servers lazily as their rows draw instead of at boot

### DIFF
--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -405,8 +405,8 @@ impl MainMenu {
         access_token: Option<String>,
     ) -> Self {
         let server_list = ServerList::load(game_dir);
+        // Servers ping lazily as their rows draw (build_server_list), not at boot.
         let ping_results: PingResults = Default::default();
-        ping_all_servers(&rt, &server_list.servers, &ping_results);
         let settings = load_settings(game_dir);
         Self {
             username,
@@ -741,6 +741,7 @@ impl MainMenu {
     }
 
     fn refresh_servers(&self) {
-        ping_all_servers(&self.rt, &self.server_list.servers, &self.ping_results);
+        // Reset to INITIAL; visible rows re-ping on the next draw.
+        self.ping_results.write().clear();
     }
 }

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -164,7 +164,8 @@ use super::common;
 use super::common::WHITE;
 use super::friends::{self, ActionError, FaceCache, FriendsData};
 use super::server_list::{
-    PingResults, PingState, ServerEntry, ServerList, is_valid_address, ping_all_servers,
+    PingGeneration, PingResults, PingState, ServerEntry, ServerList, is_valid_address,
+    ping_all_servers,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -325,6 +326,7 @@ pub struct MainMenu {
     edit_address: String,
     last_mp_ip: String,
     ping_results: PingResults,
+    ping_generation: PingGeneration,
     access_token: Option<String>,
     friends_data: FriendsData,
     face_cache: FaceCache,
@@ -417,6 +419,7 @@ impl MainMenu {
             edit_address: String::new(),
             last_mp_ip: String::new(),
             ping_results,
+            ping_generation: Default::default(),
             access_token,
             friends_data: Default::default(),
             face_cache: Default::default(),
@@ -741,7 +744,10 @@ impl MainMenu {
     }
 
     fn refresh_servers(&self) {
-        // Reset to INITIAL; visible rows re-ping on the next draw.
+        // Bump first so pings still in flight discard their stale results, then
+        // clear so visible rows re-ping on the next draw (matches vanilla refresh).
+        self.ping_generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         self.ping_results.write().clear();
     }
 }

--- a/pomme-client/src/ui/menu/servers.rs
+++ b/pomme-client/src/ui/menu/servers.rs
@@ -250,7 +250,12 @@ impl MainMenu {
         }
 
         if !to_ping.is_empty() {
-            ping_all_servers(&self.rt, &to_ping, &self.ping_results);
+            ping_all_servers(
+                &self.rt,
+                &to_ping,
+                &self.ping_results,
+                &self.ping_generation,
+            );
         }
 
         if let Some((a, b)) = pending_swap {

--- a/pomme-client/src/ui/menu/servers.rs
+++ b/pomme-client/src/ui/menu/servers.rs
@@ -95,10 +95,16 @@ impl MainMenu {
         });
 
         let mut pending_swap: Option<(usize, usize)> = None;
+        // Ping each entry the first frame its row is visible (absent = INITIAL),
+        // deferred past the loop to keep the `servers` borrow off `self.rt`.
+        let mut to_ping: Vec<ServerEntry> = Vec::new();
         for (i, server) in self.server_list.servers.iter().enumerate() {
             let ey = list_top + list_pad + i as f32 * entry_h - self.scroll_offset;
             if ey + entry_h < list_top || ey > list_bottom {
                 continue;
+            }
+            if !ping_results.contains_key(&server.address) {
+                to_ping.push(server.clone());
             }
 
             let selected = self.selected_server == Some(i);
@@ -241,6 +247,10 @@ impl MainMenu {
                     }
                 }
             }
+        }
+
+        if !to_ping.is_empty() {
+            ping_all_servers(&self.rt, &to_ping, &self.ping_results);
         }
 
         if let Some((a, b)) = pending_swap {
@@ -795,24 +805,16 @@ impl MainMenu {
             } else {
                 self.edit_name.clone()
             };
-            let addr = self.edit_address.clone();
             let entry = ServerEntry {
                 name,
-                address: addr.clone(),
+                address: self.edit_address.clone(),
             };
             if let Screen::EditServer(idx) = self.screen {
                 self.server_list.update(idx, entry);
             } else {
                 self.server_list.add(entry);
             }
-            ping_all_servers(
-                &self.rt,
-                &[ServerEntry {
-                    name: String::new(),
-                    address: addr,
-                }],
-                &self.ping_results,
-            );
+            // Absent from the results map, so it pings on draw back on the list.
             self.set_screen(Screen::ServerList);
         }
         y += btn_h + gap;

--- a/pomme-client/src/ui/server_list.rs
+++ b/pomme-client/src/ui/server_list.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use parking_lot::RwLock;
@@ -36,6 +37,10 @@ pub struct ServerList {
 }
 
 pub type PingResults = Arc<RwLock<HashMap<String, PingState>>>;
+
+/// Monotonic refresh counter. A ping discards its result if this advanced while
+/// it was in flight (mirrors vanilla's `pinger.removeAll()` on refresh).
+pub type PingGeneration = Arc<AtomicU64>;
 
 impl ServerList {
     pub fn load(game_dir: &Path) -> Self {
@@ -86,16 +91,27 @@ pub fn ping_all_servers(
     rt: &tokio::runtime::Runtime,
     servers: &[ServerEntry],
     results: &PingResults,
+    generation: &PingGeneration,
 ) {
+    let spawned_gen = generation.load(Ordering::Acquire);
     for server in servers {
         let address = server.address.clone();
         results.write().insert(address.clone(), PingState::Pinging);
-        let results = Arc::clone(results);
-        rt.spawn(ping_server(address, results));
+        rt.spawn(ping_server(
+            address,
+            Arc::clone(results),
+            Arc::clone(generation),
+            spawned_gen,
+        ));
     }
 }
 
-async fn ping_server(address: String, results: PingResults) {
+async fn ping_server(
+    address: String,
+    results: PingResults,
+    generation: PingGeneration,
+    spawned_gen: u64,
+) {
     use azalea_protocol::packets::ClientIntention;
     use azalea_protocol::packets::status::ClientboundStatusPacket;
     use azalea_protocol::packets::status::s_ping_request::ServerboundPingRequest;
@@ -167,7 +183,9 @@ async fn ping_server(address: String, results: PingResults) {
         Ok(s) => s,
         Err(e) => PingState::Failed(e),
     };
-    results.write().insert(address, state);
+    if generation.load(Ordering::Acquire) == spawned_gen {
+        results.write().insert(address, state);
+    }
 }
 
 fn decode_favicon(data: &str) -> Option<Vec<u8>> {


### PR DESCRIPTION
Pings now fire per entry the first frame its row is visible on the multiplayer screen, instead of pinging every saved server at startup.