### PR TITLE
Port standing sign model to 26.2

### DIFF
--- a/pomme-client/src/renderer/block_entity_model.rs
+++ b/pomme-client/src/renderer/block_entity_model.rs
@@ -88,7 +88,8 @@ pub fn bake_sign_model() -> BakedEntityModel {
             name: name.into(),
             offset: Vec3::new(0.0, 24.0, 0.0),
             default_rotation: Vec3::ZERO,
-            cubes: vec![cube],
+            // Vertices were emitted above with explicit UVs, so no cubes to bake.
+            cubes: Vec::new(),
             parent: None,
         });
     }

--- a/pomme-client/src/renderer/block_entity_model.rs
+++ b/pomme-client/src/renderer/block_entity_model.rs
@@ -1,6 +1,8 @@
 use glam::Vec3;
 
-use super::entity_model::{BakedEntityModel, EntityPart, ModelCube, bake_model};
+use super::entity_model::{
+    BakedEntityModel, EntityPart, ModelCube, bake_model, generate_cube_vertices_faces,
+};
 
 /// Shulker box, closed state. Matches vanilla `ShulkerModel`: a 16x12x16 lid
 /// stacked on a 16x8x16 base, with the lid's bottom flush against the base's
@@ -35,37 +37,62 @@ pub fn bake_shulker_box_model() -> BakedEntityModel {
     bake_model(vec![lid, base], 64, 64)
 }
 
-/// Standing sign, matching vanilla `SignRenderer`/`SignModel`: 24x12x2 board
-/// raised above ground, with a 2x14x2 post hanging from its center.
-/// Texture is 64x32 `entity/signs/<wood>.png`.
+/// Standing sign, matching vanilla `block/template_sign_rot_0`: a 16x8x1.33
+/// board (one block wide, centered) raised on a 1.33x9.33x1.33 post. Geometry
+/// and UVs are in block-model units (16 = one block); UVs are in 0-16 space so
+/// the model bakes against a 16x16 reference even though the texture
+/// (`block/<wood>_sign.png`) is 32x32. Face order: -Z, +Z, +Y, -Y, -X, +X.
 pub fn bake_sign_model() -> BakedEntityModel {
-    let board = EntityPart {
-        name: "sign".into(),
-        offset: Vec3::new(0.0, 24.0, 0.0),
-        default_rotation: Vec3::ZERO,
-        cubes: vec![ModelCube {
-            origin: Vec3::new(-12.0, -14.0, -1.0),
-            size: Vec3::new(24.0, 12.0, 2.0),
-            tex_offset: (0, 0),
-            deformation: 0.0,
-            mirror: false,
-        }],
-        parent: None,
+    const BOARD_UVS: [[f32; 4]; 6] = [
+        [0.0, 8.0, 12.0, 14.0],  // -Z (back)
+        [0.0, 1.0, 12.0, 7.0],   // +Z (front)
+        [0.0, 0.0, 12.0, 1.0],   // +Y (top)
+        [0.0, 14.0, 12.0, 15.0], // -Y (bottom)
+        [12.0, 8.0, 13.0, 14.0], // -X
+        [12.0, 1.0, 13.0, 7.0],  // +X
+    ];
+    // The post's top is hidden under the board, so its +Y face reuses the
+    // bottom rect rather than claiming texture vanilla never assigns it.
+    const POST_UVS: [[f32; 4]; 6] = [
+        [14.0, 8.0, 15.0, 15.0],  // -Z
+        [14.0, 0.0, 15.0, 7.0],   // +Z
+        [14.0, 15.0, 15.0, 16.0], // +Y (hidden)
+        [14.0, 15.0, 15.0, 16.0], // -Y
+        [15.0, 8.0, 16.0, 15.0],  // -X
+        [15.0, 0.0, 16.0, 7.0],   // +X
+    ];
+
+    let board = ModelCube {
+        origin: Vec3::new(-8.0, -52.0 / 3.0, -2.0 / 3.0),
+        size: Vec3::new(16.0, 8.0, 4.0 / 3.0),
+        tex_offset: (0, 0),
+        deformation: 0.0,
+        mirror: false,
     };
-    let stick = EntityPart {
-        name: "stick".into(),
-        offset: Vec3::new(0.0, 24.0, 0.0),
-        default_rotation: Vec3::ZERO,
-        cubes: vec![ModelCube {
-            origin: Vec3::new(-1.0, -2.0, -1.0),
-            size: Vec3::new(2.0, 14.0, 2.0),
-            tex_offset: (0, 14),
-            deformation: 0.0,
-            mirror: false,
-        }],
-        parent: None,
+    let post = ModelCube {
+        origin: Vec3::new(-2.0 / 3.0, -28.0 / 3.0, -2.0 / 3.0),
+        size: Vec3::new(4.0 / 3.0, 28.0 / 3.0, 4.0 / 3.0),
+        tex_offset: (0, 0),
+        deformation: 0.0,
+        mirror: false,
     };
-    bake_model(vec![board, stick], 64, 32)
+
+    let mut vertices = Vec::new();
+    let mut part_ranges = Vec::new();
+    let mut parts = Vec::new();
+    for (name, cube, uvs) in [("sign", board, &BOARD_UVS), ("stick", post, &POST_UVS)] {
+        let start = vertices.len() as u32;
+        generate_cube_vertices_faces(&cube, uvs, 16, 16, &mut vertices);
+        part_ranges.push((start, vertices.len() as u32 - start));
+        parts.push(EntityPart {
+            name: name.into(),
+            offset: Vec3::new(0.0, 24.0, 0.0),
+            default_rotation: Vec3::ZERO,
+            cubes: vec![cube],
+            parent: None,
+        });
+    }
+    BakedEntityModel::new(parts, vertices, part_ranges)
 }
 
 /// Single-chest model, matching vanilla `ChestRenderer` geometry.

--- a/pomme-client/src/renderer/context.rs
+++ b/pomme-client/src/renderer/context.rs
@@ -33,7 +33,9 @@ const VK_APP_NAME: &CStr = c"Pomme";
 const VK_APP_VERSION: u32 = vk::make_api_version(0, 0, 1, 0);
 const VK_ENGINE_NAME: &CStr = c"Pomme Engine";
 const VK_ENGINE_VERSION: u32 = vk::make_api_version(0, 0, 1, 0);
-const VK_API_VERSION: u32 = vk::API_VERSION_1_4;
+// 1.2 is the highest feature set used; requesting higher makes injected layers
+// (e.g. VK_LAYER_OBS_HOOK, capped at 1.3) warn about a version mismatch.
+const VK_API_VERSION: u32 = vk::API_VERSION_1_2;
 
 #[cfg(debug_assertions)]
 const VALIDATION_LAYERS: &[&CStr] = &[c"VK_LAYER_KHRONOS_validation"];

--- a/pomme-client/src/renderer/entity_model.rs
+++ b/pomme-client/src/renderer/entity_model.rs
@@ -66,6 +66,21 @@ pub struct PartAnim {
 }
 
 impl BakedEntityModel {
+    /// Assemble baked parts, defaulting every part's scale to 1.0.
+    pub(crate) fn new(
+        parts: Vec<EntityPart>,
+        vertices: Vec<ChunkVertex>,
+        part_ranges: Vec<(u32, u32)>,
+    ) -> Self {
+        let part_scales = vec![1.0; parts.len()];
+        Self {
+            parts,
+            vertices,
+            part_ranges,
+            part_scales,
+        }
+    }
+
     pub fn compute_part_transforms(&self, anim: &PartAnim) -> Vec<Mat4> {
         let mut transforms = Vec::with_capacity(self.parts.len());
 
@@ -139,13 +154,7 @@ pub fn bake_model(parts: Vec<EntityPart>, tex_w: u32, tex_h: u32) -> BakedEntity
         part_ranges.push((start, count));
     }
 
-    let part_scales = vec![1.0; parts.len()];
-    BakedEntityModel {
-        parts,
-        vertices,
-        part_ranges,
-        part_scales,
-    }
+    BakedEntityModel::new(parts, vertices, part_ranges)
 }
 
 pub fn bake_pig_model() -> BakedEntityModel {
@@ -1358,16 +1367,9 @@ pub fn compute_spider_anim(
     anim
 }
 
-fn generate_cube_vertices(
-    cube: &ModelCube,
-    tex_w: u32,
-    tex_h: u32,
-    vertices: &mut Vec<ChunkVertex>,
-) {
-    let tw = tex_w as f32;
-    let th = tex_h as f32;
-    let u0 = cube.tex_offset.0 as f32;
-    let v0 = cube.tex_offset.1 as f32;
+/// The four corner positions of each cube face, in render space (Y already
+/// flipped). Face order: 0 -Z, 1 +Z, 2 +Y, 3 -Y, 4 -X, 5 +X.
+fn cube_face_positions(cube: &ModelCube) -> [[[f32; 3]; 4]; 6] {
     let w = cube.size.x;
     let h = cube.size.y;
     let d = cube.size.z;
@@ -1383,71 +1385,111 @@ fn generate_cube_vertices(
     let yb = -y1;
     let yt = -y0;
 
-    struct Face {
-        positions: [[f32; 3]; 4],
-        uv: [f32; 4],
-    }
+    [
+        [[x1, yb, z0], [x0, yb, z0], [x0, yt, z0], [x1, yt, z0]],
+        [[x0, yb, z1], [x1, yb, z1], [x1, yt, z1], [x0, yt, z1]],
+        [[x0, yt, z0], [x0, yt, z1], [x1, yt, z1], [x1, yt, z0]],
+        [[x0, yb, z1], [x0, yb, z0], [x1, yb, z0], [x1, yb, z1]],
+        [[x0, yb, z1], [x0, yb, z0], [x0, yt, z0], [x0, yt, z1]],
+        [[x1, yb, z0], [x1, yb, z1], [x1, yt, z1], [x1, yt, z0]],
+    ]
+}
 
-    let faces = [
-        Face {
-            positions: [[x1, yb, z0], [x0, yb, z0], [x0, yt, z0], [x1, yt, z0]],
-            uv: [u0 + d, v0 + d, u0 + d + w, v0 + d + h],
-        },
-        Face {
-            positions: [[x0, yb, z1], [x1, yb, z1], [x1, yt, z1], [x0, yt, z1]],
-            uv: [u0 + d + w + d, v0 + d, u0 + d + w + d + w, v0 + d + h],
-        },
-        Face {
-            positions: [[x0, yt, z0], [x0, yt, z1], [x1, yt, z1], [x1, yt, z0]],
-            uv: [u0 + d, v0, u0 + d + w, v0 + d],
-        },
-        Face {
-            positions: [[x0, yb, z1], [x0, yb, z0], [x1, yb, z0], [x1, yb, z1]],
-            uv: [u0 + d + w, v0, u0 + d + w + w, v0 + d],
-        },
-        Face {
-            positions: [[x0, yb, z1], [x0, yb, z0], [x0, yt, z0], [x0, yt, z1]],
-            uv: [u0, v0 + d, u0 + d, v0 + d + h],
-        },
-        Face {
-            positions: [[x1, yb, z0], [x1, yb, z1], [x1, yt, z1], [x1, yt, z0]],
-            uv: [u0 + d + w, v0 + d, u0 + d + w + d, v0 + d + h],
-        },
+/// Emit two triangles for one quad face, mapping the normalized UV rect onto
+/// its corners (`u_min`/`v_min` is the texture's top-left).
+fn push_face(
+    positions: &[[f32; 3]; 4],
+    u_min: f32,
+    u_max: f32,
+    v_min: f32,
+    v_max: f32,
+    vertices: &mut Vec<ChunkVertex>,
+) {
+    let uvs = [
+        [u_min, v_max],
+        [u_max, v_max],
+        [u_max, v_min],
+        [u_min, v_min],
     ];
+    for &i in &[0usize, 1, 2, 0, 2, 3] {
+        vertices.push(ChunkVertex {
+            position: positions[i],
+            tex_coords: crate::renderer::chunk::mesher::pack_uv(uvs[i][0], uvs[i][1]),
+            light_tint: crate::renderer::chunk::mesher::pack_light_tint(
+                1.0,
+                crate::renderer::chunk::mesher::PACKED_WHITE_SHIFTED,
+            ),
+        });
+    }
+}
+
+fn generate_cube_vertices(
+    cube: &ModelCube,
+    tex_w: u32,
+    tex_h: u32,
+    vertices: &mut Vec<ChunkVertex>,
+) {
+    let tw = tex_w as f32;
+    let th = tex_h as f32;
+    let u0 = cube.tex_offset.0 as f32;
+    let v0 = cube.tex_offset.1 as f32;
+    let w = cube.size.x;
+    let h = cube.size.y;
+    let d = cube.size.z;
+
+    // Entity box-unwrap UV rects, face order matching `cube_face_positions`.
+    let face_uv = [
+        [u0 + d, v0 + d, u0 + d + w, v0 + d + h],
+        [u0 + d + w + d, v0 + d, u0 + d + w + d + w, v0 + d + h],
+        [u0 + d, v0, u0 + d + w, v0 + d],
+        [u0 + d + w, v0, u0 + d + w + w, v0 + d],
+        [u0, v0 + d, u0 + d, v0 + d + h],
+        [u0 + d + w, v0 + d, u0 + d + w + d, v0 + d + h],
+    ];
+
+    let positions = cube_face_positions(cube);
 
     // Indices 4 (-X) and 5 (+X) are the side faces. When mirror is set, vanilla's
     // minX/maxX swap effectively exchanges their UV regions; every face also has
     // its U flipped.
-    for (idx, face) in faces.iter().enumerate() {
-        let uv_source = match (cube.mirror, idx) {
-            (true, 4) => &faces[5].uv,
-            (true, 5) => &faces[4].uv,
-            _ => &face.uv,
+    for (idx, pos) in positions.iter().enumerate() {
+        let src = match (cube.mirror, idx) {
+            (true, 4) => &face_uv[5],
+            (true, 5) => &face_uv[4],
+            _ => &face_uv[idx],
         };
-        let v_min = uv_source[1] / th;
-        let v_max = uv_source[3] / th;
+        let v_min = src[1] / th;
+        let v_max = src[3] / th;
         let (u_min, u_max) = if cube.mirror {
-            (uv_source[2] / tw, uv_source[0] / tw)
+            (src[2] / tw, src[0] / tw)
         } else {
-            (uv_source[0] / tw, uv_source[2] / tw)
+            (src[0] / tw, src[2] / tw)
         };
+        push_face(pos, u_min, u_max, v_min, v_max, vertices);
+    }
+}
 
-        let uvs = [
-            [u_min, v_max],
-            [u_max, v_max],
-            [u_max, v_min],
-            [u_min, v_min],
-        ];
-
-        for &i in &[0usize, 1, 2, 0, 2, 3] {
-            vertices.push(ChunkVertex {
-                position: face.positions[i],
-                tex_coords: crate::renderer::chunk::mesher::pack_uv(uvs[i][0], uvs[i][1]),
-                light_tint: crate::renderer::chunk::mesher::pack_light_tint(
-                    1.0,
-                    crate::renderer::chunk::mesher::PACKED_WHITE_SHIFTED,
-                ),
-            });
-        }
+/// Like [`generate_cube_vertices`] but with explicit per-face UV rects (face
+/// order -Z, +Z, +Y, -Y, -X, +X) instead of the entity box-unwrap, for block
+/// models whose texture layout isn't a box-unwrap (e.g. signs).
+pub fn generate_cube_vertices_faces(
+    cube: &ModelCube,
+    face_uvs: &[[f32; 4]; 6],
+    tex_w: u32,
+    tex_h: u32,
+    vertices: &mut Vec<ChunkVertex>,
+) {
+    let tw = tex_w as f32;
+    let th = tex_h as f32;
+    let positions = cube_face_positions(cube);
+    for (pos, uv) in positions.iter().zip(face_uvs) {
+        push_face(
+            pos,
+            uv[0] / tw,
+            uv[2] / tw,
+            uv[1] / th,
+            uv[3] / th,
+            vertices,
+        );
     }
 }

--- a/pomme-client/src/renderer/entity_model.rs
+++ b/pomme-client/src/renderer/entity_model.rs
@@ -1472,7 +1472,7 @@ fn generate_cube_vertices(
 /// Like [`generate_cube_vertices`] but with explicit per-face UV rects (face
 /// order -Z, +Z, +Y, -Y, -X, +X) instead of the entity box-unwrap, for block
 /// models whose texture layout isn't a box-unwrap (e.g. signs).
-pub fn generate_cube_vertices_faces(
+pub(crate) fn generate_cube_vertices_faces(
     cube: &ModelCube,
     face_uvs: &[[f32; 4]; 6],
     tex_w: u32,

--- a/pomme-client/src/renderer/pipelines/block_entity.rs
+++ b/pomme-client/src/renderer/pipelines/block_entity.rs
@@ -77,18 +77,18 @@ const SIGN_WOOD_NAMES: [&str; 12] = [
 ];
 
 const SIGN_TEXTURES: &[&[&str]] = &[
-    &["minecraft/textures/entity/signs/oak.png"],
-    &["minecraft/textures/entity/signs/spruce.png"],
-    &["minecraft/textures/entity/signs/birch.png"],
-    &["minecraft/textures/entity/signs/jungle.png"],
-    &["minecraft/textures/entity/signs/acacia.png"],
-    &["minecraft/textures/entity/signs/dark_oak.png"],
-    &["minecraft/textures/entity/signs/mangrove.png"],
-    &["minecraft/textures/entity/signs/cherry.png"],
-    &["minecraft/textures/entity/signs/pale_oak.png"],
-    &["minecraft/textures/entity/signs/bamboo.png"],
-    &["minecraft/textures/entity/signs/crimson.png"],
-    &["minecraft/textures/entity/signs/warped.png"],
+    &["minecraft/textures/block/oak_sign.png"],
+    &["minecraft/textures/block/spruce_sign.png"],
+    &["minecraft/textures/block/birch_sign.png"],
+    &["minecraft/textures/block/jungle_sign.png"],
+    &["minecraft/textures/block/acacia_sign.png"],
+    &["minecraft/textures/block/dark_oak_sign.png"],
+    &["minecraft/textures/block/mangrove_sign.png"],
+    &["minecraft/textures/block/cherry_sign.png"],
+    &["minecraft/textures/block/pale_oak_sign.png"],
+    &["minecraft/textures/block/bamboo_sign.png"],
+    &["minecraft/textures/block/crimson_sign.png"],
+    &["minecraft/textures/block/warped_sign.png"],
 ];
 
 const SHULKER_TEXTURES: &[&[&str]] = &[
@@ -172,6 +172,9 @@ pub fn yaw_for_block(kind: BlockEntityKind, props: &HashMap<&str, &str>) -> f32 
             Some("east") => 270.0,
             _ => 0.0,
         },
+        // TODO: wall signs have no `rotation` (they use `facing`) and vanilla
+        // renders them with a postless model offset against the wall; they
+        // currently fall back to the standing model facing south.
         BlockEntityKind::Sign => props
             .get("rotation")
             .and_then(|s| s.parse::<f32>().ok())
@@ -199,7 +202,7 @@ fn kind_definitions() -> Vec<KindDef> {
             kind: BlockEntityKind::Sign,
             model: block_entity_model::bake_sign_model(),
             tex_variants: SIGN_TEXTURES,
-            tex_size: 64,
+            tex_size: 32,
         },
     ]
 }


### PR DESCRIPTION
Rebakes the standing sign to the 26.2 block model geometry and 32x32 block/<wood>_sign textures, fixing the missing entity/signs texture warnings.