### PR TITLE
Silence rodio DeviceSink drop warning

### DIFF
--- a/pomme-client/src/audio/mod.rs
+++ b/pomme-client/src/audio/mod.rs
@@ -109,7 +109,11 @@ pub struct AudioEngine {
 impl AudioEngine {
     pub fn new(jar_assets_dir: &Path, asset_index: Option<AssetIndex>, volumes: [f32; 10]) -> Self {
         let output = match DeviceSinkBuilder::open_default_sink() {
-            Ok(sink) => Some(Output { sink }),
+            Ok(mut sink) => {
+                // Only dropped at shutdown, so silence rodio's stderr drop warning.
+                sink.log_on_drop(false);
+                Some(Output { sink })
+            }
             Err(e) => {
                 tracing::warn!("audio disabled: no output device ({e})");
                 None

--- a/pomme-client/src/renderer/context.rs
+++ b/pomme-client/src/renderer/context.rs
@@ -33,7 +33,9 @@ const VK_APP_NAME: &CStr = c"Pomme";
 const VK_APP_VERSION: u32 = vk::make_api_version(0, 0, 1, 0);
 const VK_ENGINE_NAME: &CStr = c"Pomme Engine";
 const VK_ENGINE_VERSION: u32 = vk::make_api_version(0, 0, 1, 0);
-const VK_API_VERSION: u32 = vk::API_VERSION_1_4;
+// 1.2 is the highest feature set used; requesting higher makes injected layers
+// (e.g. VK_LAYER_OBS_HOOK, capped at 1.3) warn about a version mismatch.
+const VK_API_VERSION: u32 = vk::API_VERSION_1_2;
 
 #[cfg(debug_assertions)]
 const VALIDATION_LAYERS: &[&CStr] = &[c"VK_LAYER_KHRONOS_validation"];


### PR DESCRIPTION
The audio sink is only dropped at shutdown, so disable its drop warning.