### PR TITLE
Fix door/trapdoor/fence rendering (#317)

### DIFF
--- a/pomme-client/src/renderer/context.rs
+++ b/pomme-client/src/renderer/context.rs
@@ -33,7 +33,9 @@ const VK_APP_NAME: &CStr = c"Pomme";
 const VK_APP_VERSION: u32 = vk::make_api_version(0, 0, 1, 0);
 const VK_ENGINE_NAME: &CStr = c"Pomme Engine";
 const VK_ENGINE_VERSION: u32 = vk::make_api_version(0, 0, 1, 0);
-const VK_API_VERSION: u32 = vk::API_VERSION_1_4;
+// 1.2 is the highest feature set used; requesting higher makes injected layers
+// (e.g. VK_LAYER_OBS_HOOK, capped at 1.3) warn about a version mismatch.
+const VK_API_VERSION: u32 = vk::API_VERSION_1_2;
 
 #[cfg(debug_assertions)]
 const VALIDATION_LAYERS: &[&CStr] = &[c"VK_LAYER_KHRONOS_validation"];

--- a/pomme-client/src/world/block/model.rs
+++ b/pomme-client/src/world/block/model.rs
@@ -1164,8 +1164,8 @@ fn rotate_positions(mut positions: [[f32; 3]; 4], rot_x: i32, rot_y: i32) -> [[f
         for pos in &mut positions {
             let dy = pos[1] - center;
             let dz = pos[2] - center;
-            pos[1] = center + cos * dy - sin * dz;
-            pos[2] = center + sin * dy + cos * dz;
+            pos[1] = center + cos * dy + sin * dz;
+            pos[2] = center - sin * dy + cos * dz;
         }
     }
 
@@ -1176,8 +1176,8 @@ fn rotate_positions(mut positions: [[f32; 3]; 4], rot_x: i32, rot_y: i32) -> [[f
         for pos in &mut positions {
             let dx = pos[0] - center;
             let dz = pos[2] - center;
-            pos[0] = center + cos * dx + sin * dz;
-            pos[2] = center - sin * dx + cos * dz;
+            pos[0] = center + cos * dx - sin * dz;
+            pos[2] = center + sin * dx + cos * dz;
         }
     }
 

--- a/pomme-client/src/world/block/registry.rs
+++ b/pomme-client/src/world/block/registry.rs
@@ -157,10 +157,16 @@ impl BlockRegistry {
             return variants.values().next();
         }
 
-        let variant_key = build_variant_key(&*block);
+        // Vanilla variant keys only list the properties that affect the model, so
+        // match by subset rather than exact string equality (an empty key matches
+        // any state, serving as the default variant).
+        let props = block.property_map();
         variants
-            .get(&variant_key)
-            .or_else(|| variants.get(""))
+            .iter()
+            .find(|(key, _)| {
+                constraints_match(&props, key.split(',').filter_map(|p| p.split_once('=')))
+            })
+            .map(|(_, model)| model)
             .or_else(|| variants.values().next())
     }
 
@@ -171,14 +177,8 @@ impl BlockRegistry {
 
         let mut quads = Vec::new();
         for entry in entries {
-            if entry.when.is_empty()
-                || entry.when.iter().all(|(k, v)| {
-                    props
-                        .get(k.as_str())
-                        .map(|pv| v.split('|').any(|opt| opt == *pv))
-                        .unwrap_or(false)
-                })
-            {
+            let when = entry.when.iter().map(|(k, v)| (k.as_str(), v.as_str()));
+            if constraints_match(&props, when) {
                 quads.extend(entry.quads.iter());
             }
         }
@@ -253,18 +253,17 @@ fn build_placeable_blocks() -> HashMap<String, BlockState> {
         .collect()
 }
 
-fn build_variant_key(block: &dyn azalea_block::BlockTrait) -> String {
-    let props = block.property_map();
-    if props.is_empty() {
-        return String::new();
-    }
-    let mut entries: Vec<_> = props.iter().collect();
-    entries.sort_by_key(|(k, _)| *k);
-    entries
-        .iter()
-        .map(|(k, v)| format!("{k}={v}"))
-        .collect::<Vec<_>>()
-        .join(",")
+/// Whether every `key=value` constraint holds for `props`. A value may list
+/// alternatives separated by `|`, as vanilla multipart `when` clauses do.
+fn constraints_match<'a>(
+    props: &HashMap<&str, &str>,
+    mut constraints: impl Iterator<Item = (&'a str, &'a str)>,
+) -> bool {
+    constraints.all(|(k, v)| {
+        props
+            .get(k)
+            .is_some_and(|pv| v.split('|').any(|opt| opt == *pv))
+    })
 }
 
 fn load_cache(path: &Path) -> Option<HashMap<String, FaceTextures>> {


### PR DESCRIPTION
Fixes #317.

- Match block model variants by property subset so doors/trapdoors/stairs render their actual state.
- Rotate model geometry clockwise to match blockstate rotations so fences and directional blocks aren't mirrored.