### PR TITLE
Settings menu and F3 fixes

### DIFF
--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -338,7 +338,10 @@ impl ApplicationHandler for App {
                                 {
                                     game.advanced_item_tooltips = !game.advanced_item_tooltips;
                                 } else if game.options_from_game {
-                                    self.core.input.on_menu_key_event(&event);
+                                    let f3_held = self.core.input.key_pressed(KeyCode::F3);
+                                    if !game.handle_debug_key(code, f3_held) {
+                                        self.core.input.on_menu_key_event(&event);
+                                    }
                                 } else if game.chat.is_open() {
                                     match code {
                                         KeyCode::Escape => {
@@ -378,28 +381,10 @@ impl ApplicationHandler for App {
                                             game.death_confirm = false;
                                             self.core.send_respawn(&connection, &mut game);
                                         }
-                                        KeyCode::F3 => {
-                                            game.show_debug = !game.show_debug;
+                                        _ => {
+                                            let f3_held = self.core.input.key_pressed(KeyCode::F3);
+                                            game.handle_debug_key(code, f3_held);
                                         }
-                                        KeyCode::KeyG
-                                            if self.core.input.key_pressed(KeyCode::F3) =>
-                                        {
-                                            game.show_chunk_borders = !game.show_chunk_borders;
-                                        }
-                                        KeyCode::KeyO
-                                            if self.core.input.key_pressed(KeyCode::F3) =>
-                                        {
-                                            game.chunk_occlusion_enabled =
-                                                !game.chunk_occlusion_enabled;
-                                            // Force the throttled recompute to run
-                                            // next frame so the toggle takes effect.
-                                            game.vis_valid = false;
-                                            tracing::info!(
-                                                "Chunk occlusion: {}",
-                                                game.chunk_occlusion_enabled
-                                            );
-                                        }
-                                        _ => {}
                                     }
                                 }
                             }
@@ -429,7 +414,7 @@ impl ApplicationHandler for App {
                         self.core.input.on_menu_scroll(scroll);
                     }
                     // TODO: open chat should capture scroll (chat history scrolling)
-                    AppPhase::InGame { game, .. } if !game.gui_open() && !game.paused => {
+                    AppPhase::InGame { game, .. } if game.input_live() => {
                         self.core.input.on_scroll(scroll)
                     }
                     _ => {}

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -352,8 +352,12 @@ impl ApplicationHandler for App {
                                             self.core
                                                 .apply_cursor_grab(&gfx.window, Some(&mut game));
                                         }
-                                        KeyCode::F3 => game.show_debug = !game.show_debug,
-                                        _ => self.core.input.on_menu_key_event(&event),
+                                        _ => {
+                                            let f3_held = self.core.input.key_pressed(KeyCode::F3);
+                                            if !game.handle_debug_key(code, f3_held) {
+                                                self.core.input.on_menu_key_event(&event);
+                                            }
+                                        }
                                     }
                                 } else if game.creative_inventory_open {
                                     match code {
@@ -365,8 +369,12 @@ impl ApplicationHandler for App {
                                             self.core
                                                 .apply_cursor_grab(&gfx.window, Some(&mut game));
                                         }
-                                        KeyCode::F3 => game.show_debug = !game.show_debug,
-                                        _ => self.core.input.on_menu_key_event(&event),
+                                        _ => {
+                                            let f3_held = self.core.input.key_pressed(KeyCode::F3);
+                                            if !game.handle_debug_key(code, f3_held) {
+                                                self.core.input.on_menu_key_event(&event);
+                                            }
+                                        }
                                     }
                                 } else {
                                     match code {

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -337,6 +337,8 @@ impl ApplicationHandler for App {
                                 if code == KeyCode::KeyH && self.core.input.key_pressed(KeyCode::F3)
                                 {
                                     game.advanced_item_tooltips = !game.advanced_item_tooltips;
+                                } else if game.options_from_game {
+                                    self.core.input.on_menu_key_event(&event);
                                 } else if game.chat.is_open() {
                                     match code {
                                         KeyCode::Escape => {
@@ -421,11 +423,14 @@ impl ApplicationHandler for App {
                     AppPhase::InMenu { .. } | AppPhase::Connecting { .. } => {
                         self.core.input.on_menu_scroll(scroll);
                     }
-                    AppPhase::InGame { game, .. } if !game.gui_open() => {
-                        self.core.input.on_scroll(scroll)
-                    }
-                    AppPhase::InGame { game, .. } if game.creative_inventory_open => {
+                    AppPhase::InGame { game, .. }
+                        if game.options_from_game || game.creative_inventory_open =>
+                    {
                         self.core.input.on_menu_scroll(scroll);
+                    }
+                    // TODO: open chat should capture scroll (chat history scrolling)
+                    AppPhase::InGame { game, .. } if !game.gui_open() && !game.paused => {
+                        self.core.input.on_scroll(scroll)
                     }
                     _ => {}
                 }

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1017,6 +1017,7 @@ pub fn update_game(
             gfx.renderer.is_first_person(),
             debug.as_ref(),
             core.menu.gui_scale_setting,
+            &|t, s| gfx.renderer.menu_text_width(t, s),
         );
     }
 

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -266,6 +266,29 @@ impl GameState {
             && self.chunk_load_result.is_none()
     }
 
+    /// F3-family debug toggles; these fire even while a menu is open,
+    /// matching vanilla KeyboardHandler. Returns true if handled.
+    pub fn handle_debug_key(&mut self, code: winit::keyboard::KeyCode, f3_held: bool) -> bool {
+        use winit::keyboard::KeyCode;
+        match code {
+            KeyCode::F3 => {
+                self.show_debug = !self.show_debug;
+            }
+            KeyCode::KeyG if f3_held => {
+                self.show_chunk_borders = !self.show_chunk_borders;
+            }
+            KeyCode::KeyO if f3_held => {
+                self.chunk_occlusion_enabled = !self.chunk_occlusion_enabled;
+                // Force the throttled recompute to run next frame so the
+                // toggle takes effect.
+                self.vis_valid = false;
+                tracing::info!("Chunk occlusion: {}", self.chunk_occlusion_enabled);
+            }
+            _ => return false,
+        }
+        true
+    }
+
     pub fn sync_render_distance(&mut self, connection: &ConnectionHandle, render_distance: u32) {
         self.last_render_distance = render_distance;
         tracing::info!("Render distance changed to {render_distance}");

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -644,7 +644,6 @@ impl MenuOverlayPipeline {
         let mut deferred_tooltips: Vec<&MenuElement> = Vec::new();
         let mut draw_ops: Vec<DrawOp> = Vec::new();
         let mut scissor_stack: Vec<[f32; 4]> = Vec::new();
-        let mut current_scissor: Option<[f32; 4]> = None;
         let mut cmd_start: u32 = 0;
 
         for elem in elements {
@@ -664,7 +663,7 @@ impl MenuOverlayPipeline {
                     draw_ops.push(DrawOp {
                         start: cmd_start,
                         count,
-                        scissor: current_scissor,
+                        scissor: scissor_stack.last().copied(),
                     });
                 }
                 cmd_start = vertices.len() as u32;
@@ -684,7 +683,6 @@ impl MenuOverlayPipeline {
                 } else {
                     scissor_stack.pop();
                 }
-                current_scissor = scissor_stack.last().copied();
                 continue;
             }
             match elem {
@@ -1096,7 +1094,7 @@ impl MenuOverlayPipeline {
             draw_ops.push(DrawOp {
                 start: cmd_start,
                 count: final_count,
-                scissor: current_scissor,
+                scissor: scissor_stack.last().copied(),
             });
         }
 

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -643,6 +643,7 @@ impl MenuOverlayPipeline {
         let mut vertices: Vec<Vertex> = Vec::with_capacity(elements.len() * 24);
         let mut deferred_tooltips: Vec<&MenuElement> = Vec::new();
         let mut draw_ops: Vec<DrawOp> = Vec::new();
+        let mut scissor_stack: Vec<[f32; 4]> = Vec::new();
         let mut current_scissor: Option<[f32; 4]> = None;
         let mut cmd_start: u32 = 0;
 
@@ -667,11 +668,23 @@ impl MenuOverlayPipeline {
                     });
                 }
                 cmd_start = vertices.len() as u32;
-                current_scissor = if let MenuElement::ScissorPush { x, y, w, h } = elem {
-                    Some([*x, *y, *w, *h])
+                if let MenuElement::ScissorPush { x, y, w, h } = elem {
+                    // Nested regions clip to the intersection with the enclosing one.
+                    let rect = match scissor_stack.last() {
+                        Some(outer) => {
+                            let x0 = x.max(outer[0]);
+                            let y0 = y.max(outer[1]);
+                            let x1 = (x + w).min(outer[0] + outer[2]);
+                            let y1 = (y + h).min(outer[1] + outer[3]);
+                            [x0, y0, (x1 - x0).max(0.0), (y1 - y0).max(0.0)]
+                        }
+                        None => [*x, *y, *w, *h],
+                    };
+                    scissor_stack.push(rect);
                 } else {
-                    None
-                };
+                    scissor_stack.pop();
+                }
+                current_scissor = scissor_stack.last().copied();
                 continue;
             }
             match elem {

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -273,6 +273,70 @@ pub fn push_item_icon(
     }
 }
 
+/// Inputs for the vanilla scrolling-label treatment: labels wider than the
+/// widget are clipped to it and slide back and forth over time.
+pub struct LabelScroll<'a> {
+    pub text_width_fn: &'a dyn Fn(&str, f32) -> f32,
+    pub time_secs: f64,
+}
+
+/// Widget label: centered when it fits, otherwise (with `scroll`) clipped and
+/// oscillated like vanilla's ActiveTextCollector.defaultScrollingHelper.
+#[allow(clippy::too_many_arguments)]
+fn push_widget_label(
+    elements: &mut Vec<MenuElement>,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    gs: f32,
+    fs: f32,
+    label: &str,
+    color: [f32; 4],
+    scroll: Option<&LabelScroll<'_>>,
+) {
+    let ty = y + (h - fs) / 2.0 + 1.0;
+    if let Some(s) = scroll {
+        let margin = 2.0 * gs;
+        let avail = w - 2.0 * margin;
+        let lw = (s.text_width_fn)(label, fs);
+        if lw > avail {
+            let max_pos = lw - avail;
+            let period = ((max_pos / gs) as f64 * 0.5).max(3.0);
+            let alpha = (std::f64::consts::FRAC_PI_2
+                * (std::f64::consts::TAU * s.time_secs / period).cos())
+            .sin()
+                / 2.0
+                + 0.5;
+            let pos = alpha as f32 * max_pos;
+            elements.push(MenuElement::ScissorPush {
+                x: x + margin,
+                y,
+                w: avail,
+                h,
+            });
+            elements.push(MenuElement::Text {
+                x: x + margin - pos,
+                y: ty,
+                text: label.into(),
+                scale: fs,
+                color,
+                centered: false,
+            });
+            elements.push(MenuElement::ScissorPop);
+            return;
+        }
+    }
+    elements.push(MenuElement::Text {
+        x: x + w / 2.0,
+        y: ty,
+        text: label.into(),
+        scale: fs,
+        color,
+        centered: true,
+    });
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn push_button(
     elements: &mut Vec<MenuElement>,
@@ -285,6 +349,52 @@ pub fn push_button(
     fs: f32,
     label: &str,
     enabled: bool,
+) -> bool {
+    push_button_inner(elements, cursor, x, y, w, h, gs, fs, label, enabled, None)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn push_button_scrolling(
+    elements: &mut Vec<MenuElement>,
+    cursor: (f32, f32),
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    gs: f32,
+    fs: f32,
+    label: &str,
+    enabled: bool,
+    scroll: &LabelScroll<'_>,
+) -> bool {
+    push_button_inner(
+        elements,
+        cursor,
+        x,
+        y,
+        w,
+        h,
+        gs,
+        fs,
+        label,
+        enabled,
+        Some(scroll),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_button_inner(
+    elements: &mut Vec<MenuElement>,
+    cursor: (f32, f32),
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    gs: f32,
+    fs: f32,
+    label: &str,
+    enabled: bool,
+    scroll: Option<&LabelScroll<'_>>,
 ) -> bool {
     let hovered = enabled && hit_test(cursor, [x, y, w, h]);
 
@@ -307,14 +417,7 @@ pub fn push_button(
         tint: WHITE,
     });
 
-    elements.push(MenuElement::Text {
-        x: x + w / 2.0,
-        y: y + (h - fs) / 2.0 + 1.0,
-        text: label.into(),
-        scale: fs,
-        color: text_col,
-        centered: true,
-    });
+    push_widget_label(elements, x, y, w, h, gs, fs, label, text_col, scroll);
 
     hovered
 }
@@ -333,6 +436,7 @@ pub fn push_slider(
     label: &str,
     value: f32,
     dragging: bool,
+    scroll: &LabelScroll<'_>,
 ) -> SliderResult {
     let hovered = hit_test(cursor, [x, y, w, h]);
     let handle_w = 8.0 * gs;
@@ -374,14 +478,7 @@ pub fn push_slider(
         tint: WHITE,
     });
 
-    elements.push(MenuElement::Text {
-        x: x + w / 2.0,
-        y: y + (h - fs) / 2.0 + 1.0,
-        text: label.into(),
-        scale: fs,
-        color: WHITE,
-        centered: true,
-    });
+    push_widget_label(elements, x, y, w, h, gs, fs, label, WHITE, Some(scroll));
 
     SliderResult {
         hovered,

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -273,10 +273,13 @@ pub fn push_item_icon(
     }
 }
 
+/// Measures rendered text width in framebuffer px at the given font size.
+pub type TextWidthFn<'a> = &'a dyn Fn(&str, f32) -> f32;
+
 /// Inputs for the vanilla scrolling-label treatment: labels wider than the
 /// widget are clipped to it and slide back and forth over time.
 pub struct LabelScroll<'a> {
-    pub text_width_fn: &'a dyn Fn(&str, f32) -> f32,
+    pub text_width_fn: TextWidthFn<'a>,
     pub time_secs: f64,
 }
 

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -83,6 +83,7 @@ pub fn build_hud(
     first_person: bool,
     debug: Option<&DebugInfo<'_>>,
     gui_scale_setting: u32,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
 ) {
     let gs = gui_scale(screen_w, screen_h, gui_scale_setting);
     let cx = screen_w / 2.0;
@@ -93,7 +94,7 @@ pub fn build_hud(
     }
 
     if let Some(info) = debug {
-        build_debug_overlay(elements, info, gs);
+        build_debug_overlay(elements, info, gs, text_width_fn);
     }
 
     let hotbar_w = HOTBAR_W * gs;
@@ -365,7 +366,12 @@ fn build_status_bar(
     }
 }
 
-fn build_debug_overlay(elements: &mut Vec<MenuElement>, info: &DebugInfo<'_>, gs: f32) {
+fn build_debug_overlay(
+    elements: &mut Vec<MenuElement>,
+    info: &DebugInfo<'_>,
+    gs: f32,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
+) {
     let fs = super::common::FONT_SIZE * gs;
     let pad = 4.0 * gs;
 
@@ -417,7 +423,7 @@ fn build_debug_overlay(elements: &mut Vec<MenuElement>, info: &DebugInfo<'_>, gs
         left_lines.push(format!("Face: {:?}", face));
     }
 
-    push_debug_lines(elements, &left_lines, pad, pad, fs, true);
+    push_debug_lines(elements, &left_lines, pad, pad, fs, true, text_width_fn);
 
     let mut right_lines: Vec<String> = vec![
         info.vulkan_version.to_string(),
@@ -435,7 +441,15 @@ fn build_debug_overlay(elements: &mut Vec<MenuElement>, info: &DebugInfo<'_>, gs
         right_lines.push(format!("  Present: {:.2}ms", t.present_ms));
     }
     let right_x = info.screen_w as f32 - pad;
-    push_debug_lines(elements, &right_lines, right_x, pad, fs, false);
+    push_debug_lines(
+        elements,
+        &right_lines,
+        right_x,
+        pad,
+        fs,
+        false,
+        text_width_fn,
+    );
 }
 
 fn push_debug_lines(
@@ -445,6 +459,7 @@ fn push_debug_lines(
     start_y: f32,
     fs: f32,
     left_align: bool,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
 ) {
     let line_h = fs * 1.25;
     for (i, line) in lines.iter().enumerate() {
@@ -455,7 +470,7 @@ fn push_debug_lines(
         let tx = if left_align {
             x
         } else {
-            x - line.len() as f32 * fs * 0.6
+            x - text_width_fn(line, fs)
         };
         elements.push(MenuElement::Text {
             x: tx,

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -2,7 +2,7 @@ use azalea_core::position::BlockPos;
 use azalea_inventory::ItemStack;
 use glam::DVec3;
 
-use super::common::{FONT_SIZE, WHITE, push_item_count};
+use super::common::{FONT_SIZE, TextWidthFn, WHITE, push_item_count};
 use crate::player::inventory::item_resource_name;
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
 
@@ -83,7 +83,7 @@ pub fn build_hud(
     first_person: bool,
     debug: Option<&DebugInfo<'_>>,
     gui_scale_setting: u32,
-    text_width_fn: &dyn Fn(&str, f32) -> f32,
+    text_width_fn: TextWidthFn,
 ) {
     let gs = gui_scale(screen_w, screen_h, gui_scale_setting);
     let cx = screen_w / 2.0;
@@ -370,7 +370,7 @@ fn build_debug_overlay(
     elements: &mut Vec<MenuElement>,
     info: &DebugInfo<'_>,
     gs: f32,
-    text_width_fn: &dyn Fn(&str, f32) -> f32,
+    text_width_fn: TextWidthFn,
 ) {
     let fs = super::common::FONT_SIZE * gs;
     let pad = 4.0 * gs;
@@ -459,7 +459,7 @@ fn push_debug_lines(
     start_y: f32,
     fs: f32,
     left_align: bool,
-    text_width_fn: &dyn Fn(&str, f32) -> f32,
+    text_width_fn: TextWidthFn,
 ) {
     let line_h = fs * 1.25;
     for (i, line) in lines.iter().enumerate() {

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -352,6 +352,8 @@ pub struct MainMenu {
     field_undo_stack: Vec<(u8, String)>,
     cursor_blink: Instant,
     last_click_time: Instant,
+    /// Steady clock for label scroll animation.
+    created: Instant,
     last_click_index: Option<usize>,
     pub gui_scale_setting: u32,
     pub render_distance: u32,
@@ -443,6 +445,7 @@ impl MainMenu {
             field_undo_stack: Vec::new(),
             cursor_blink: Instant::now(),
             last_click_time: Instant::now(),
+            created: Instant::now(),
             last_click_index: None,
             gui_scale_setting: settings.gui_scale,
             render_distance: settings.render_distance,
@@ -702,12 +705,22 @@ impl MainMenu {
             Screen::Disconnected(_) => {
                 self.build_disconnected(screen_w, screen_h, input, &text_width_fn)
             }
-            Screen::Options => self.build_options(screen_w, screen_h, input),
-            Screen::OptionsOnline => self.build_options_online(screen_w, screen_h, input),
-            Screen::OptionsVideo => self.build_options_video(screen_w, screen_h, input),
-            Screen::OptionsSkinCustomization => self.build_options_skin(screen_w, screen_h, input),
-            Screen::OptionsMusicSounds => self.build_options_music(screen_w, screen_h, input),
-            Screen::OptionsControls => self.build_options_controls(screen_w, screen_h, input),
+            Screen::Options => self.build_options(screen_w, screen_h, input, &text_width_fn),
+            Screen::OptionsOnline => {
+                self.build_options_online(screen_w, screen_h, input, &text_width_fn)
+            }
+            Screen::OptionsVideo => {
+                self.build_options_video(screen_w, screen_h, input, &text_width_fn)
+            }
+            Screen::OptionsSkinCustomization => {
+                self.build_options_skin(screen_w, screen_h, input, &text_width_fn)
+            }
+            Screen::OptionsMusicSounds => {
+                self.build_options_music(screen_w, screen_h, input, &text_width_fn)
+            }
+            Screen::OptionsControls => {
+                self.build_options_controls(screen_w, screen_h, input, &text_width_fn)
+            }
             Screen::OptionsKeybinds => self.build_options_stub(
                 screen_w,
                 screen_h,
@@ -719,12 +732,14 @@ impl MainMenu {
                 let back = self.settings_back.clone_screen();
                 self.build_options_stub(screen_w, screen_h, input, "Language", back)
             }
-            Screen::OptionsChatSettings => self.build_options_chat(screen_w, screen_h, input),
+            Screen::OptionsChatSettings => {
+                self.build_options_chat(screen_w, screen_h, input, &text_width_fn)
+            }
             Screen::OptionsResourcePacks => {
                 self.build_options_resource_packs(screen_w, screen_h, input, &text_width_fn)
             }
             Screen::OptionsAccessibility => {
-                self.build_options_accessibility(screen_w, screen_h, input)
+                self.build_options_accessibility(screen_w, screen_h, input, &text_width_fn)
             }
             Screen::OptionsTelemetry => self.build_options_stub(
                 screen_w,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -24,7 +24,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         // Sub-screens reached from here (Language/Accessibility) return to Options.
         self.settings_back = Screen::Options;
@@ -90,7 +90,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let fullscreen_label = match self.display_mode {
             DisplayMode::Windowed => "Fullscreen: Windowed",
@@ -166,7 +166,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let rows: Vec<OptRow> = vec![
             OptRow::Pair("Sensitivity: 100%", "Invert Mouse: OFF"),
@@ -195,7 +195,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let rows: Vec<OptRow> = vec![
             OptRow::Pair("Chat: Shown", "Chat Colors: ON"),
@@ -228,7 +228,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let fov_effect_label = if self.fov_effect_scale <= 0.0 {
             "FOV Effects: OFF".to_string()
@@ -274,7 +274,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let pct = |v: f32| -> String {
             let p = (v * 100.0).round() as u32;
@@ -339,7 +339,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let cape = if self.skin_cape {
             "Cape: ON"
@@ -403,7 +403,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         let online_status_label = if self.show_online_status {
             "Show Online Status: ON"
@@ -465,7 +465,7 @@ impl MainMenu {
         sliders: &[(&'static str, f32)],
         header_footer: bool,
         tooltips: &[(&str, &str)],
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         if input.escape {
             self.set_screen(back.clone_screen());
@@ -783,7 +783,9 @@ impl MainMenu {
             self.save_settings();
         }
 
-        elements.push(MenuElement::ScissorPop);
+        if header_footer {
+            elements.push(MenuElement::ScissorPop);
+        }
 
         if scrollable {
             let max_scroll = (grid_h + content_pad - content_h).max(0.001);
@@ -846,7 +848,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
-        text_width_fn: &dyn Fn(&str, f32) -> f32,
+        text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
         use crate::resource_pack::PackSource;
 

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -19,7 +19,13 @@ fn compat_label(compat: PackCompat) -> (&'static str, [f32; 4]) {
 }
 
 impl MainMenu {
-    pub(super) fn build_options(&mut self, sw: f32, sh: f32, input: &MenuInput) -> MainMenuResult {
+    pub(super) fn build_options(
+        &mut self,
+        sw: f32,
+        sh: f32,
+        input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
+    ) -> MainMenuResult {
         // Sub-screens reached from here (Language/Accessibility) return to Options.
         self.settings_back = Screen::Options;
         let fov_label = if self.fov == 70 {
@@ -67,6 +73,7 @@ impl MainMenu {
             sliders,
             false,
             &[],
+            text_width_fn,
         )
     }
 
@@ -83,6 +90,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let fullscreen_label = match self.display_mode {
             DisplayMode::Windowed => "Fullscreen: Windowed",
@@ -149,6 +157,7 @@ impl MainMenu {
             sliders,
             true,
             &[],
+            text_width_fn,
         )
     }
 
@@ -157,6 +166,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let rows: Vec<OptRow> = vec![
             OptRow::Pair("Sensitivity: 100%", "Invert Mouse: OFF"),
@@ -176,6 +186,7 @@ impl MainMenu {
             &[],
             true,
             &[],
+            text_width_fn,
         )
     }
 
@@ -184,6 +195,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let rows: Vec<OptRow> = vec![
             OptRow::Pair("Chat: Shown", "Chat Colors: ON"),
@@ -207,6 +219,7 @@ impl MainMenu {
             &[],
             true,
             &[],
+            text_width_fn,
         )
     }
 
@@ -215,6 +228,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let fov_effect_label = if self.fov_effect_scale <= 0.0 {
             "FOV Effects: OFF".to_string()
@@ -251,6 +265,7 @@ impl MainMenu {
             sliders,
             true,
             &[],
+            text_width_fn,
         )
     }
 
@@ -259,6 +274,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let pct = |v: f32| -> String {
             let p = (v * 100.0).round() as u32;
@@ -314,6 +330,7 @@ impl MainMenu {
             sliders,
             true,
             &[],
+            text_width_fn,
         )
     }
 
@@ -322,6 +339,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let cape = if self.skin_cape {
             "Cape: ON"
@@ -376,6 +394,7 @@ impl MainMenu {
             &[],
             true,
             &[],
+            text_width_fn,
         )
     }
 
@@ -384,6 +403,7 @@ impl MainMenu {
         sw: f32,
         sh: f32,
         input: &MenuInput,
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let online_status_label = if self.show_online_status {
             "Show Online Status: ON"
@@ -428,6 +448,7 @@ impl MainMenu {
             &[],
             true,
             tooltips,
+            text_width_fn,
         )
     }
 
@@ -444,6 +465,7 @@ impl MainMenu {
         sliders: &[(&'static str, f32)],
         header_footer: bool,
         tooltips: &[(&str, &str)],
+        text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         if input.escape {
             self.set_screen(back.clone_screen());
@@ -572,6 +594,10 @@ impl MainMenu {
             content_top + (content_h - grid_h) / 2.0
         };
         let mut slider_results: Vec<(&str, f32)> = Vec::new();
+        let label_scroll = common::LabelScroll {
+            text_width_fn,
+            time_secs: self.created.elapsed().as_secs_f64(),
+        };
 
         if header_footer {
             elements.push(MenuElement::ScissorPush {
@@ -621,6 +647,7 @@ impl MainMenu {
                         label,
                         *value,
                         is_active,
+                        &label_scroll,
                     );
                     any_hovered |= result.hovered;
                     if result.dragging {
@@ -635,7 +662,7 @@ impl MainMenu {
                     continue;
                 }
 
-                let h = common::push_button(
+                let h = common::push_button_scrolling(
                     &mut elements,
                     cursor,
                     bx,
@@ -646,6 +673,7 @@ impl MainMenu {
                     fs,
                     label,
                     true,
+                    &label_scroll,
                 );
                 any_hovered |= h;
                 if h && let Some((_, tip)) = tooltips.iter().find(|(p, _)| label.starts_with(p)) {
@@ -785,7 +813,7 @@ impl MainMenu {
         }
 
         let done_w = 200.0 * gs;
-        let h = common::push_button(
+        let h = common::push_button_scrolling(
             &mut elements,
             cursor,
             cx - done_w / 2.0,
@@ -796,6 +824,7 @@ impl MainMenu {
             fs,
             "Done",
             true,
+            &label_scroll,
         );
         any_hovered |= h;
         if clicked && h {


### PR DESCRIPTION
Fixes esc/scroll routing in the in-game settings menu, F3 right column alignment, and long option labels overflowing their buttons.