### PR TITLE
Air bubble position and pop sound

### DIFF
--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1132,9 +1132,11 @@ pub fn update_game(
     // the measured frame times honest.
     let benchmark_running = game.chunk_load_bench.is_some();
     if !benchmark_running {
-        if let Some(bubbles) = hud::air_bubbles(game.player.air_supply, game.player.eyes_in_water)
-            .filter(|_| crate::player::is_survival(game.player.game_mode))
-        {
+        let air_bubbles = hud::air_bubbles(game.player.air_supply, game.player.eyes_in_water)
+            .filter(|_| crate::player::is_survival(game.player.game_mode));
+        // TODO: gate the pop sound on HUD visibility if a hide-HUD toggle (F1) is
+        // added.
+        if let Some(bubbles) = &air_bubbles {
             if !game.player.eyes_in_water {
                 game.last_bubble_pop_sound_played = 0;
             } else if bubbles.is_popping && game.last_bubble_pop_sound_played != bubbles.popping_pos
@@ -1160,8 +1162,9 @@ pub fn update_game(
             game.player.health,
             game.player.food,
             game.player.armor,
-            game.player.air_supply,
+            air_bubbles,
             game.player.eyes_in_water,
+            game.sky_state.game_time,
             game.player.experience_level,
             game.player.experience_progress,
             game.player.game_mode,

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -10,6 +10,7 @@ use glam::FloatExt as _;
 use crate::app::core::{AppCore, PlayerInputState};
 use crate::app::phases::Gfx;
 use crate::app::{DEFAULT_RENDER_DISTANCE, TICK_RATE, input};
+use crate::audio::{CATEGORY_PLAYERS, SoundRef};
 use crate::benchmark::{
     Benchmark, BenchmarkResult, ChunkLoadBench, ChunkLoadResult, ChunkLoadStep, UploadHandle,
     UploadStatus, upload_result,
@@ -58,6 +59,8 @@ pub struct GameState {
     pub position_set: bool,
     pub player_loaded_sent: bool,
     pub player: LocalPlayer,
+    /// Bubble index the pop sound last played for, so each pop fires once.
+    pub last_bubble_pop_sound_played: i32,
     pub biome_climate: Arc<HashMap<u32, BiomeClimate>>,
     pub player_walk_pos: f32,
     pub player_walk_speed: f32,
@@ -208,6 +211,7 @@ impl GameState {
             },
             block_entity_anim: BlockEntityAnimStore::default(),
             player: LocalPlayer::new(),
+            last_bubble_pop_sound_played: 0,
             biome_climate: Arc::new(HashMap::new()),
             player_walk_pos: 0.0,
             player_walk_speed: 0.0,
@@ -1128,6 +1132,26 @@ pub fn update_game(
     // the measured frame times honest.
     let benchmark_running = game.chunk_load_bench.is_some();
     if !benchmark_running {
+        if let Some(bubbles) = hud::air_bubbles(game.player.air_supply, game.player.eyes_in_water)
+            .filter(|_| crate::player::is_survival(game.player.game_mode))
+        {
+            if !game.player.eyes_in_water {
+                game.last_bubble_pop_sound_played = 0;
+            } else if bubbles.is_popping && game.last_bubble_pop_sound_played != bubbles.popping_pos
+            {
+                let volume = 0.5 + 0.1 * (bubbles.empty - 3 + 1).max(0) as f32;
+                let pitch = 1.0 + 0.1 * (bubbles.empty - 5 + 1).max(0) as f32;
+                core.audio.play_world_sound(
+                    &SoundRef::Event("ui.hud.bubble_pop".into()),
+                    CATEGORY_PLAYERS,
+                    game.player.position,
+                    volume,
+                    pitch,
+                    fastrand::u64(..),
+                );
+                game.last_bubble_pop_sound_played = bubbles.popping_pos;
+            }
+        }
         hud::build_hud(
             &mut elements,
             sw,

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -74,8 +74,10 @@ pub fn build_hud(
     health: f32,
     food: u32,
     armor: u32,
-    air_supply: i32,
+    // Gated to survival by the caller.
+    air_bubbles: Option<AirBubbles>,
     eyes_in_water: bool,
+    tick: u64,
     experience_level: i32,
     experience_progress: f32,
     game_mode: u8,
@@ -254,11 +256,13 @@ pub fn build_hud(
         }
     }
 
-    if let Some(bubbles) = air_bubbles(air_supply, eyes_in_water).filter(|_| is_survival) {
+    if let Some(bubbles) = air_bubbles {
         let bubble_y = (status_bar_y - (ICON_SIZE * 2.0 + 1.0) * gs).round();
-        let stride = ICON_STRIDE * gs;
         let icon_size = ICON_SIZE * gs;
+        let mut rng = crate::util::JavaRandom::new((tick as i64).wrapping_mul(312871));
+        let wobbling = bubbles.empty == 10 && tick.is_multiple_of(2);
         for b in 1..=10i32 {
+            let mut y = bubble_y;
             let sprite = if b <= bubbles.full {
                 SpriteId::AirFull
             } else if bubbles.is_popping && b == bubbles.popping_pos && eyes_in_water {
@@ -266,12 +270,15 @@ pub fn build_hud(
             } else if b <= 10 - bubbles.empty {
                 continue;
             } else {
+                if wobbling {
+                    y += rng.next_int(2) as f32 * gs;
+                }
                 SpriteId::AirEmpty
             };
-            let x = (hotbar_x + hotbar_w - (b - 1) as f32 * stride - icon_size).round();
+            let x = icon_row_x_rtl(hotbar_x + hotbar_w, b - 1, gs);
             elements.push(MenuElement::Image {
                 x,
-                y: bubble_y,
+                y,
                 w: icon_size,
                 h: icon_size,
                 sprite,
@@ -279,6 +286,11 @@ pub fn build_hud(
             });
         }
     }
+}
+
+/// Right-aligned status icon x, matching vanilla `xRight - i * 8 - 9`.
+fn icon_row_x_rtl(x_right: f32, i: i32, gs: f32) -> f32 {
+    (x_right - i as f32 * ICON_STRIDE * gs - ICON_SIZE * gs).round()
 }
 
 pub struct AirBubbles {
@@ -348,7 +360,7 @@ fn build_status_bar(
 
     for i in 0..10u8 {
         let x = if right_to_left {
-            (x_start - i as f32 * stride - icon_size).round()
+            icon_row_x_rtl(x_start, i as i32, gs)
         } else {
             (x_start + i as f32 * stride).round()
         };

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -254,26 +254,16 @@ pub fn build_hud(
         }
     }
 
-    let max_air = crate::player::MAX_AIR_SUPPLY;
-    if is_survival && (eyes_in_water || air_supply < max_air) {
-        let air = air_supply.clamp(0, max_air);
-        let bubble_count =
-            |offset: i32| -> i32 { (((air + offset) * 10 + max_air - 1) / max_air).clamp(0, 10) };
-        let full_bubbles = bubble_count(-2);
-        let popping_pos = bubble_count(0);
-        let empty_delay = if air == 0 || !eyes_in_water { 0 } else { 1 };
-        let empty_bubbles = 10 - bubble_count(empty_delay);
-        let is_popping = full_bubbles != popping_pos;
-
-        let bubble_y = (status_bar_y - ICON_SIZE * gs - 1.0 * gs).round();
+    if let Some(bubbles) = air_bubbles(air_supply, eyes_in_water).filter(|_| is_survival) {
+        let bubble_y = (status_bar_y - (ICON_SIZE * 2.0 + 1.0) * gs).round();
         let stride = ICON_STRIDE * gs;
         let icon_size = ICON_SIZE * gs;
         for b in 1..=10i32 {
-            let sprite = if b <= full_bubbles {
+            let sprite = if b <= bubbles.full {
                 SpriteId::AirFull
-            } else if is_popping && b == popping_pos && eyes_in_water {
+            } else if bubbles.is_popping && b == bubbles.popping_pos && eyes_in_water {
                 SpriteId::AirBursting
-            } else if b <= 10 - empty_bubbles {
+            } else if b <= 10 - bubbles.empty {
                 continue;
             } else {
                 SpriteId::AirEmpty
@@ -289,6 +279,33 @@ pub fn build_hud(
             });
         }
     }
+}
+
+pub struct AirBubbles {
+    pub full: i32,
+    pub popping_pos: i32,
+    pub empty: i32,
+    pub is_popping: bool,
+}
+
+/// None when the air row is hidden (full air and not underwater).
+pub fn air_bubbles(air_supply: i32, eyes_in_water: bool) -> Option<AirBubbles> {
+    let max_air = crate::player::MAX_AIR_SUPPLY;
+    if !eyes_in_water && air_supply >= max_air {
+        return None;
+    }
+    let air = air_supply.clamp(0, max_air);
+    let bubble_count =
+        |offset: i32| -> i32 { (((air + offset) * 10 + max_air - 1) / max_air).clamp(0, 10) };
+    let full = bubble_count(-2);
+    let popping_pos = bubble_count(0);
+    let empty_delay = if air == 0 || !eyes_in_water { 0 } else { 1 };
+    Some(AirBubbles {
+        full,
+        popping_pos,
+        empty: 10 - bubble_count(empty_delay),
+        is_popping: full != popping_pos,
+    })
 }
 
 fn build_crosshair(elements: &mut Vec<MenuElement>, cx: f32, cy: f32) {
@@ -331,7 +348,7 @@ fn build_status_bar(
 
     for i in 0..10u8 {
         let x = if right_to_left {
-            (x_start - (i as f32 + 1.0) * stride).round()
+            (x_start - i as f32 * stride - icon_size).round()
         } else {
             (x_start + i as f32 * stride).round()
         };

--- a/pomme-client/src/util.rs
+++ b/pomme-client/src/util.rs
@@ -38,4 +38,20 @@ impl JavaRandom {
     pub fn next_float(&mut self) -> f32 {
         self.next(24) as f32 / (1u32 << 24) as f32
     }
+
+    /// Matches `Random.nextInt(int)`, in `[0, bound)`.
+    pub fn next_int(&mut self, bound: i32) -> i32 {
+        assert!(bound > 0);
+        if bound & (bound - 1) == 0 {
+            return ((bound as i64).wrapping_mul(self.next(31) as i64) >> 31) as i32;
+        }
+        loop {
+            let bits = self.next(31);
+            let val = bits % bound;
+            // Java relies on int overflow here to reject biased samples.
+            if bits.wrapping_sub(val).wrapping_add(bound - 1) >= 0 {
+                return val;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Moves the air bubble row a full icon row above the hunger bar instead of overlapping it, aligns the right side status icons flush with the hotbar edge, and plays ui.hud.bubble_pop once per popped bubble with volume and pitch rising as air runs out.