### PR TITLE
Furnace, chest, and anvil screens

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -554,6 +554,18 @@ impl AppCore {
                         game.set_container_state_id(state_id);
                     }
                 }
+                NetworkEvent::ContainerData {
+                    container_id,
+                    id,
+                    value,
+                } => {
+                    if let Some(c) = &mut game.open_container
+                        && c.id == container_id
+                        && let Some(d) = c.data.get_mut(id as usize)
+                    {
+                        *d = value;
+                    }
+                }
                 NetworkEvent::OpenScreen {
                     container_id,
                     menu_type,
@@ -561,7 +573,21 @@ impl AppCore {
                 } => {
                     use azalea_inventory::ItemStack;
                     use azalea_registry::builtin::MenuKind;
-                    if menu_type == MenuKind::Crafting {
+
+                    use crate::app::phases::in_game::ContainerScreen;
+                    use crate::ui::furnace::FurnaceVariant;
+                    let screen = match menu_type {
+                        MenuKind::Crafting => Some(ContainerScreen::CraftingTable),
+                        MenuKind::Furnace => {
+                            Some(ContainerScreen::Furnace(FurnaceVariant::Furnace))
+                        }
+                        MenuKind::BlastFurnace => {
+                            Some(ContainerScreen::Furnace(FurnaceVariant::BlastFurnace))
+                        }
+                        MenuKind::Smoker => Some(ContainerScreen::Furnace(FurnaceVariant::Smoker)),
+                        _ => None,
+                    };
+                    if let Some(screen) = screen {
                         // Vanilla setScreen replaces whatever screen is up,
                         // including the pause menu.
                         game.paused = false;
@@ -572,7 +598,9 @@ impl AppCore {
                         game.open_container = Some(crate::app::phases::in_game::OpenContainer {
                             id: container_id,
                             title,
-                            slots: vec![ItemStack::Empty; crate::ui::crafting_table::SLOT_COUNT],
+                            screen,
+                            slots: vec![ItemStack::Empty; screen.click_kind().slot_count()],
+                            data: [0; 4],
                             state_id: 0,
                         });
                         game.sync_container_from_inventory();
@@ -583,8 +611,9 @@ impl AppCore {
                         self.apply_cursor_grab(window, Some(game));
                     } else {
                         // TODO: render the remaining menu screens (chest,
-                        // furnace, ...). Until then tell the server we closed
-                        // the menu so its container state stays consistent.
+                        // brewing stand, ...). Until then tell the server we
+                        // closed the menu so its container state stays
+                        // consistent.
                         use azalea_protocol::packets::game::s_container_close::ServerboundContainerClose;
                         connection
                             .packet_tx

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -1249,7 +1249,7 @@ impl AppCore {
             game.player.look_dir,
             &game.chunk_store,
             &game.entity_store,
-            game.player.game_mode == 1,
+            crate::player::is_creative(game.player.game_mode),
         );
 
         let held_stack = match game
@@ -1276,7 +1276,7 @@ impl AppCore {
             game.player.eye_pos().into(),
             game.player.look_dir,
             game.player.on_ground,
-            game.player.game_mode == 1,
+            crate::player::is_creative(game.player.game_mode),
             game.player.food,
             input.selected_slot(),
             held_stack,

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -592,6 +592,7 @@ impl AppCore {
                         MenuKind::Generic9x5 => Some(ContainerScreen::Chest { rows: 5 }),
                         MenuKind::Generic9x6 => Some(ContainerScreen::Chest { rows: 6 }),
                         MenuKind::ShulkerBox => Some(ContainerScreen::ShulkerBox),
+                        MenuKind::Anvil => Some(ContainerScreen::Anvil),
                         _ => None,
                     };
                     if let Some(screen) = screen {
@@ -608,6 +609,8 @@ impl AppCore {
                             screen,
                             slots: vec![ItemStack::Empty; screen.click_kind().slot_count()],
                             data: [0; 4],
+                            anvil: (screen == ContainerScreen::Anvil)
+                                .then(crate::ui::anvil::AnvilState::new),
                             state_id: 0,
                         });
                         game.sync_container_from_inventory();

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -585,6 +585,13 @@ impl AppCore {
                             Some(ContainerScreen::Furnace(FurnaceVariant::BlastFurnace))
                         }
                         MenuKind::Smoker => Some(ContainerScreen::Furnace(FurnaceVariant::Smoker)),
+                        MenuKind::Generic9x1 => Some(ContainerScreen::Chest { rows: 1 }),
+                        MenuKind::Generic9x2 => Some(ContainerScreen::Chest { rows: 2 }),
+                        MenuKind::Generic9x3 => Some(ContainerScreen::Chest { rows: 3 }),
+                        MenuKind::Generic9x4 => Some(ContainerScreen::Chest { rows: 4 }),
+                        MenuKind::Generic9x5 => Some(ContainerScreen::Chest { rows: 5 }),
+                        MenuKind::Generic9x6 => Some(ContainerScreen::Chest { rows: 6 }),
+                        MenuKind::ShulkerBox => Some(ContainerScreen::ShulkerBox),
                         _ => None,
                     };
                     if let Some(screen) = screen {

--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -45,6 +45,9 @@ pub struct InputState {
     cursor_moved: bool,
     typed_chars: Vec<char>,
     menu_scroll: f32,
+    /// A focused text field (anvil rename, creative search) is capturing
+    /// keyboard input this frame: letter/digit hotkeys must type, not act.
+    pub text_capture: bool,
     backspace_pressed: bool,
     enter_pressed: bool,
     escape_pressed: bool,
@@ -121,6 +124,7 @@ impl InputState {
             cursor_moved: false,
             typed_chars: Vec::new(),
             menu_scroll: 0.0,
+            text_capture: false,
             backspace_pressed: false,
             enter_pressed: false,
             escape_pressed: false,
@@ -438,11 +442,13 @@ impl InputState {
             match event.state {
                 ElementState::Pressed => {
                     self.pressed.insert(code);
-                    if let Some(slot) = hotbar_slot(code) {
+                    if !self.text_capture
+                        && let Some(slot) = hotbar_slot(code)
+                    {
                         self.selected_slot = slot;
                     }
                     match code {
-                        KeyCode::KeyE => {
+                        KeyCode::KeyE if !self.text_capture => {
                             self.recent_actions.insert(Action::ToggleInventory, true);
                         }
                         KeyCode::Escape => {

--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -172,7 +172,7 @@ impl InputState {
                         && game.player.game_mode != 3
                         && !game.chat.is_open()
                     {
-                        if game.player.game_mode == 1 {
+                        if crate::player::is_creative(game.player.game_mode) {
                             game.creative_inventory_open = true;
                         } else {
                             game.inventory_open = !game.inventory_open;

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -376,6 +376,14 @@ impl ApplicationHandler for App {
                                             }
                                         }
                                     }
+                                } else if game.wants_text_input() {
+                                    // A container text field (anvil rename) has
+                                    // focus; keys type into it. Escape still
+                                    // closes via the OpenMenu action.
+                                    let f3_held = self.core.input.key_pressed(KeyCode::F3);
+                                    if !game.handle_debug_key(code, f3_held) {
+                                        self.core.input.on_menu_key_event(&event);
+                                    }
                                 } else {
                                     match code {
                                         KeyCode::Escape

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1567,7 +1567,7 @@ pub fn update_game(
                     &container.title,
                     container.anvil.as_ref().expect("anvil screen has state"),
                     game.player.experience_level,
-                    game.player.game_mode == 1,
+                    crate::player::is_creative(game.player.game_mode),
                     &game.cursor_item,
                     &mut game.inv_drag,
                     &mut game.inv_last_click,
@@ -1626,7 +1626,7 @@ pub fn update_game(
         );
         use azalea_protocol::packets::game::s_set_creative_mode_slot::ServerboundSetCreativeModeSlot;
         let mut set_creative_slot = |slot_num: u16, item: azalea_inventory::ItemStack| {
-            if game.player.game_mode == 1 {
+            if crate::player::is_creative(game.player.game_mode) {
                 connection
                     .packet_tx
                     .send(ServerboundGamePacket::SetCreativeModeSlot(

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -43,6 +43,7 @@ pub enum ContainerScreen {
     Furnace(crate::ui::furnace::FurnaceVariant),
     Chest { rows: u8 },
     ShulkerBox,
+    Anvil,
 }
 
 impl ContainerScreen {
@@ -53,6 +54,7 @@ impl ContainerScreen {
             Self::Furnace(_) => ContainerKind::Furnace,
             Self::Chest { rows } => ContainerKind::Chest { rows },
             Self::ShulkerBox => ContainerKind::ShulkerBox,
+            Self::Anvil => ContainerKind::Anvil,
         }
     }
 }
@@ -66,8 +68,10 @@ pub struct OpenContainer {
     /// by the player inventory.
     pub slots: Vec<azalea_inventory::ItemStack>,
     /// The menu's data values (`ClientboundContainerSetData`), e.g. furnace
-    /// lit/cook progress.
+    /// lit/cook progress or the anvil repair cost.
     pub data: [u16; 4],
+    /// The anvil rename field's state; Some only for the anvil screen.
+    pub anvil: Option<crate::ui::anvil::AnvilState>,
     /// This menu's latest server state id, echoed in container clicks.
     pub state_id: u32,
 }
@@ -375,6 +379,21 @@ impl GameState {
         self.cursor_item = azalea_inventory::ItemStack::Empty;
         self.inv_drag = None;
         self.inv_last_click = None;
+    }
+
+    /// A focused text field (anvil rename, creative search) is capturing
+    /// keyboard input: letter/digit keys must type instead of acting as
+    /// hotkeys. The anvil field is editable only while its input slot is
+    /// filled, matching vanilla.
+    pub fn wants_text_input(&self) -> bool {
+        if self.creative_inventory_open {
+            return self.creative_state.tab.captures_typing();
+        }
+        matches!(
+            &self.open_container,
+            Some(c) if c.screen == ContainerScreen::Anvil
+                && c.slots.first().is_some_and(|s| s.is_present())
+        )
     }
 
     /// No menu (pause, inventory, chat) is capturing input.
@@ -1047,6 +1066,8 @@ pub fn update_game(
         core.apply_cursor_grab(&gfx.window, Some(game));
     }
 
+    core.input.text_capture = game.wants_text_input();
+
     let mut close_inventory = false;
     let mut pause_action = PauseAction::None;
     let mut death_action = DeathAction::None;
@@ -1464,6 +1485,19 @@ pub fn update_game(
             right_held: core.input.right_held(),
             shift: core.input.shift_held(),
         };
+        // The anvil rename field consumes this frame's typing; a changed
+        // accepted name goes to the server (vanilla `onNameChanged`).
+        if let Some(c) = &mut game.open_container
+            && let Some(state) = &mut c.anvil
+            && let Some(name) = crate::ui::anvil::update_rename(state, &c.slots, &typed, backspace)
+        {
+            use azalea_protocol::packets::game::s_rename_item::ServerboundRenameItem;
+            connection
+                .packet_tx
+                .send(ServerboundGamePacket::RenameItem(ServerboundRenameItem {
+                    name,
+                }));
+        }
         let (clicked_outside, ops) = if let Some(container) = &game.open_container {
             let result = match container.screen {
                 ContainerScreen::CraftingTable => crate::ui::crafting_table::build_crafting_table(
@@ -1522,6 +1556,24 @@ pub fn update_game(
                     &mut game.inv_last_click,
                     gs,
                 ),
+                ContainerScreen::Anvil => crate::ui::anvil::build_anvil(
+                    &mut elements,
+                    sw,
+                    sh,
+                    core.input.cursor_pos(),
+                    &input,
+                    &container.slots,
+                    container.data,
+                    &container.title,
+                    container.anvil.as_ref().expect("anvil screen has state"),
+                    game.player.experience_level,
+                    game.player.game_mode == 1,
+                    &game.cursor_item,
+                    &mut game.inv_drag,
+                    &mut game.inv_last_click,
+                    gs,
+                    &|t, s| gfx.renderer.menu_text_width(t, s),
+                ),
             };
             (result.clicked_outside, result.ops)
         } else {
@@ -1551,8 +1603,8 @@ pub fn update_game(
         let middle_clicked = core.input.middle_just_pressed();
         let right_clicked = core.input.right_just_pressed();
         let scroll_delta = core.input.consume_menu_scroll();
-        let typed = core.input.drain_typed_chars();
-        let backspace = core.input.backspace_pressed();
+        // `typed`/`backspace` come from the frame's single drain up top; a
+        // second drain here would always read empty.
         let action = crate::ui::creative_inventory::build_creative_inventory(
             &mut elements,
             &mut game.creative_state,

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -19,6 +19,7 @@ use crate::entity::{EntityStore, ItemEntityStore, lerp_angle};
 use crate::net::connection::ConnectionHandle;
 use crate::player::LocalPlayer;
 use crate::player::interaction::{HitResult, InteractionState};
+use crate::player::menu_click::ContainerKind;
 use crate::player::tab_list::TabList;
 use crate::renderer::chunk::mesher::{BiomeClimate, ChunkMeshData, MeshDispatcher};
 use crate::renderer::chunk::occlusion_graph::{self, VisibilitySet};
@@ -35,21 +36,44 @@ use crate::ui::{common, hud};
 use crate::world::block_entity_anim::BlockEntityAnimStore;
 use crate::world::chunk::ChunkStore;
 
-/// A server-opened container screen (currently only the crafting table).
+/// Which screen a server-opened container renders as.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ContainerScreen {
+    CraftingTable,
+    Furnace(crate::ui::furnace::FurnaceVariant),
+}
+
+impl ContainerScreen {
+    /// The click-prediction menu kind backing this screen.
+    pub fn click_kind(self) -> ContainerKind {
+        match self {
+            Self::CraftingTable => ContainerKind::CraftingTable,
+            Self::Furnace(_) => ContainerKind::Furnace,
+        }
+    }
+}
+
+/// A server-opened container screen.
 pub struct OpenContainer {
     pub id: i32,
     pub title: String,
-    /// Menu slots in container indices: result 0, grid 1..9, then the
-    /// inventory-backed slots 10..45 (player slot + 1).
+    pub screen: ContainerScreen,
+    /// Menu slots in container indices; slots from `inv_start()` on are backed
+    /// by the player inventory.
     pub slots: Vec<azalea_inventory::ItemStack>,
+    /// The menu's data values (`ClientboundContainerSetData`), e.g. furnace
+    /// lit/cook progress.
+    pub data: [u16; 4],
     /// This menu's latest server state id, echoed in container clicks.
     pub state_id: u32,
 }
 
 impl OpenContainer {
     /// First container slot backed by the player inventory; container slot `i`
-    /// maps to player inventory slot `i - 1` from here on.
-    pub const INV_START: usize = 10;
+    /// maps to player inventory slot `i - inv_start() + 9` from here on.
+    fn inv_start(&self) -> usize {
+        self.screen.click_kind().inv_start()
+    }
 }
 
 pub struct GameState {
@@ -295,7 +319,7 @@ impl GameState {
     }
 
     /// Set a slot of the currently open menu. Container slots backing the
-    /// player inventory (10..) mirror into it, so the hotbar and a reopened
+    /// player inventory mirror into it, so the hotbar and a reopened
     /// inventory stay in sync.
     pub fn set_menu_slot(&mut self, index: usize, item: azalea_inventory::ItemStack) {
         match &mut self.open_container {
@@ -304,8 +328,9 @@ impl GameState {
                     return;
                 };
                 *s = item.clone();
-                if index >= OpenContainer::INV_START {
-                    self.player.inventory.set_slot(index - 1, item);
+                let inv_start = c.inv_start();
+                if index >= inv_start {
+                    self.player.inventory.set_slot(index - inv_start + 9, item);
                 }
             }
             None => self.player.inventory.set_slot(index, item),
@@ -318,13 +343,9 @@ impl GameState {
         let Some(c) = &mut self.open_container else {
             return;
         };
-        for (i, slot) in c
-            .slots
-            .iter_mut()
-            .enumerate()
-            .skip(OpenContainer::INV_START)
-        {
-            *slot = self.player.inventory.slot(i - 1).clone();
+        let inv_start = c.inv_start();
+        for (i, slot) in c.slots.iter_mut().enumerate().skip(inv_start) {
+            *slot = self.player.inventory.slot(i - inv_start + 9).clone();
         }
     }
 
@@ -824,10 +845,10 @@ fn send_container_clicks(
         HashedStack, ServerboundContainerClick,
     };
 
-    use crate::player::menu_click::{self, ContainerKind};
+    use crate::player::menu_click;
 
     let (container_id, kind, state_id) = match &game.open_container {
-        Some(c) => (c.id, ContainerKind::CraftingTable, c.state_id),
+        Some(c) => (c.id, c.screen.click_kind(), c.state_id),
         None => (0, ContainerKind::Player, game.inventory_state_id),
     };
 
@@ -1440,19 +1461,37 @@ pub fn update_game(
             shift: core.input.shift_held(),
         };
         let (clicked_outside, ops) = if let Some(container) = &game.open_container {
-            let result = crate::ui::crafting_table::build_crafting_table(
-                &mut elements,
-                sw,
-                sh,
-                core.input.cursor_pos(),
-                &input,
-                &container.slots,
-                &container.title,
-                &game.cursor_item,
-                &mut game.inv_drag,
-                &mut game.inv_last_click,
-                gs,
-            );
+            let result = match container.screen {
+                ContainerScreen::CraftingTable => crate::ui::crafting_table::build_crafting_table(
+                    &mut elements,
+                    sw,
+                    sh,
+                    core.input.cursor_pos(),
+                    &input,
+                    &container.slots,
+                    &container.title,
+                    &game.cursor_item,
+                    &mut game.inv_drag,
+                    &mut game.inv_last_click,
+                    gs,
+                ),
+                ContainerScreen::Furnace(variant) => crate::ui::furnace::build_furnace(
+                    &mut elements,
+                    sw,
+                    sh,
+                    core.input.cursor_pos(),
+                    &input,
+                    variant,
+                    &container.slots,
+                    container.data,
+                    &container.title,
+                    &game.cursor_item,
+                    &mut game.inv_drag,
+                    &mut game.inv_last_click,
+                    gs,
+                    &|t, s| gfx.renderer.menu_text_width(t, s),
+                ),
+            };
             (result.clicked_outside, result.ops)
         } else {
             let result = crate::ui::inventory::build_inventory(

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -41,6 +41,8 @@ use crate::world::chunk::ChunkStore;
 pub enum ContainerScreen {
     CraftingTable,
     Furnace(crate::ui::furnace::FurnaceVariant),
+    Chest { rows: u8 },
+    ShulkerBox,
 }
 
 impl ContainerScreen {
@@ -49,6 +51,8 @@ impl ContainerScreen {
         match self {
             Self::CraftingTable => ContainerKind::CraftingTable,
             Self::Furnace(_) => ContainerKind::Furnace,
+            Self::Chest { rows } => ContainerKind::Chest { rows },
+            Self::ShulkerBox => ContainerKind::ShulkerBox,
         }
     }
 }
@@ -1490,6 +1494,33 @@ pub fn update_game(
                     &mut game.inv_last_click,
                     gs,
                     &|t, s| gfx.renderer.menu_text_width(t, s),
+                ),
+                ContainerScreen::Chest { rows } => crate::ui::chest::build_chest(
+                    &mut elements,
+                    sw,
+                    sh,
+                    core.input.cursor_pos(),
+                    &input,
+                    rows,
+                    &container.slots,
+                    &container.title,
+                    &game.cursor_item,
+                    &mut game.inv_drag,
+                    &mut game.inv_last_click,
+                    gs,
+                ),
+                ContainerScreen::ShulkerBox => crate::ui::chest::build_shulker_box(
+                    &mut elements,
+                    sw,
+                    sh,
+                    core.input.cursor_pos(),
+                    &input,
+                    &container.slots,
+                    &container.title,
+                    &game.cursor_item,
+                    &mut game.inv_drag,
+                    &mut game.inv_last_click,
+                    gs,
                 ),
             };
             (result.clicked_outside, result.ops)

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -163,6 +163,13 @@ pub fn handle_game_packet(
                 state_id: p.state_id,
             });
         }
+        ClientboundGamePacket::ContainerSetData(p) => {
+            let _ = event_tx.try_send(NetworkEvent::ContainerData {
+                container_id: p.container_id,
+                id: p.id,
+                value: p.value,
+            });
+        }
         ClientboundGamePacket::OpenScreen(p) => {
             let _ = event_tx.try_send(NetworkEvent::OpenScreen {
                 container_id: p.container_id,

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -71,6 +71,12 @@ pub enum NetworkEvent {
         item: ItemStack,
         state_id: u32,
     },
+    /// A menu data value (furnace lit/cook progress, etc.).
+    ContainerData {
+        container_id: i32,
+        id: u16,
+        value: u16,
+    },
     OpenScreen {
         container_id: i32,
         menu_type: azalea_registry::builtin::MenuKind,

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1015,10 +1015,18 @@ impl InteractionState {
 /// Whether right-clicking this block opens a menu we render (so the use
 /// click is consumed: no block placement, no item use).
 fn opens_menu(state: BlockState) -> bool {
+    let id = crate::world::block::block_id(state);
     matches!(
-        crate::world::block::block_id(state),
-        "crafting_table" | "furnace" | "blast_furnace" | "smoker"
-    )
+        id,
+        "crafting_table"
+            | "furnace"
+            | "blast_furnace"
+            | "smoker"
+            | "chest"
+            | "trapped_chest"
+            | "ender_chest"
+            | "barrel"
+    ) || id.ends_with("shulker_box")
 }
 
 fn destroy_progress(state: BlockState, on_ground: bool, creative: bool) -> f32 {

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1015,7 +1015,10 @@ impl InteractionState {
 /// Whether right-clicking this block opens a menu we render (so the use
 /// click is consumed: no block placement, no item use).
 fn opens_menu(state: BlockState) -> bool {
-    crate::world::block::block_id(state) == "crafting_table"
+    matches!(
+        crate::world::block::block_id(state),
+        "crafting_table" | "furnace" | "blast_furnace" | "smoker"
+    )
 }
 
 fn destroy_progress(state: BlockState, on_ground: bool, creative: bool) -> f32 {

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -588,8 +588,8 @@ impl InteractionState {
             }));
             // A menu-opening block consumes the click (vanilla `useWithoutItem`)
             // unless sneaking with something in hand.
-            // TODO: other interactive blocks (chests etc.) should consume the
-            // click here too once their menus render.
+            // TODO: other interactive blocks (brewing stand, dispenser, ...)
+            // should consume the click here too once their menus render.
             if !suppress_block_use {
                 let target =
                     chunks.get_block_state(hit.block_pos.x, hit.block_pos.y, hit.block_pos.z);

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1027,6 +1027,7 @@ fn opens_menu(state: BlockState) -> bool {
             | "ender_chest"
             | "barrel"
     ) || id.ends_with("shulker_box")
+        || id.ends_with("anvil")
 }
 
 fn destroy_progress(state: BlockState, on_ground: bool, creative: bool) -> f32 {

--- a/pomme-client/src/player/menu_click.rs
+++ b/pomme-client/src/player/menu_click.rs
@@ -19,13 +19,14 @@ pub enum ContainerKind {
     Furnace,
     Chest { rows: u8 },
     ShulkerBox,
+    Anvil,
 }
 
 impl ContainerKind {
     pub fn slot_count(self) -> usize {
         match self {
             Self::Player | Self::CraftingTable => 46,
-            Self::Furnace => 39,
+            Self::Furnace | Self::Anvil => 39,
             Self::Chest { rows } => rows as usize * 9 + 36,
             Self::ShulkerBox => 63,
         }
@@ -36,19 +37,21 @@ impl ContainerKind {
     pub fn inv_start(self) -> usize {
         match self {
             Self::Player | Self::CraftingTable => 10,
-            Self::Furnace => 3,
+            Self::Furnace | Self::Anvil => 3,
             Self::Chest { rows } => rows as usize * 9,
             Self::ShulkerBox => 27,
         }
     }
 
-    /// The crafting-result slot, if this menu has one. Its clicks need recipe
-    /// logic we can't predict, and vanilla excludes it from double-click
+    /// The result slot whose clicks we can't predict, if this menu has one:
+    /// crafting results need recipe logic, the anvil result costs XP and
+    /// materials. Vanilla also excludes the crafting result from double-click
     /// gathering (`canTakeItemForPickAll`). The furnace result slot is neither:
     /// taking from it is a plain pickup.
     fn crafting_result_slot(self) -> Option<usize> {
         match self {
             Self::Player | Self::CraftingTable => Some(0),
+            Self::Anvil => Some(2),
             Self::Furnace | Self::Chest { .. } | Self::ShulkerBox => None,
         }
     }
@@ -95,6 +98,12 @@ impl ContainerKind {
                 contents: SlotList::default(),
                 player: SlotList::default(),
             },
+            Self::Anvil => Menu::Anvil {
+                first: ItemStack::Empty,
+                second: ItemStack::Empty,
+                result: ItemStack::Empty,
+                player: SlotList::default(),
+            },
         };
         for (i, item) in slots.iter().enumerate() {
             if let Some(s) = menu.slot_mut(i) {
@@ -112,7 +121,7 @@ impl ContainerKind {
     fn may_place(self, s: usize, item: &ItemStackData) -> bool {
         match (self, s) {
             (Self::Player | Self::CraftingTable, 0) => false,
-            (Self::Furnace, 2) => false,
+            (Self::Furnace | Self::Anvil, 2) => false,
             (Self::Player, 5..=8) => {
                 let want = match s {
                     5 => EquipmentSlot::Head,
@@ -330,8 +339,9 @@ fn safe_insert(slot: &mut ItemStack, carried: &mut ItemStack, amount: i32) {
 /// Shift-click, repeating until it stops making progress (vanilla loops too).
 /// Chest menus move between the contents and player regions exactly like
 /// vanilla `ChestMenu.quickMoveStack` (contents-bound forward, player-bound
-/// reversed); the other menus use azalea's `quick_move_stack`, whose routing
-/// matches vanilla closely enough for them.
+/// reversed); the anvil ports `ItemCombinerMenu.quickMoveStack` (inputs first,
+/// then a main/hotbar toggle); the other menus use azalea's
+/// `quick_move_stack`, whose routing matches vanilla closely enough for them.
 fn quick_move(kind: ContainerKind, menu: &mut Menu, s: usize) {
     for _ in 0..menu.len() {
         let before = menu.slot(s).map(ItemStack::count).unwrap_or(0);
@@ -345,6 +355,17 @@ fn quick_move(kind: ContainerKind, menu: &mut Menu, s: usize) {
                     move_item_stack_to(kind, menu, s, split..menu.len(), true);
                 } else {
                     move_item_stack_to(kind, menu, s, 0..split, false);
+                }
+            }
+            ContainerKind::Anvil => {
+                if s < 3 {
+                    move_item_stack_to(kind, menu, s, 3..menu.len(), false);
+                } else {
+                    move_item_stack_to(kind, menu, s, 0..2, false);
+                    if menu.slot(s).map(ItemStack::count).unwrap_or(0) == before {
+                        let to = if s < 30 { 30..39 } else { 3..30 };
+                        move_item_stack_to(kind, menu, s, to, false);
+                    }
                 }
             }
             _ => {

--- a/pomme-client/src/player/menu_click.rs
+++ b/pomme-client/src/player/menu_click.rs
@@ -45,9 +45,10 @@ impl ContainerKind {
 
     /// The result slot whose clicks we can't predict, if this menu has one:
     /// crafting results need recipe logic, the anvil result costs XP and
-    /// materials. Vanilla also excludes the crafting result from double-click
-    /// gathering (`canTakeItemForPickAll`). The furnace result slot is neither:
-    /// taking from it is a plain pickup.
+    /// materials. Vanilla excludes the crafting result from double-click
+    /// gathering (`canTakeItemForPickAll`) but not the anvil result; we skip
+    /// that one too since its take costs aren't modeled here. The furnace
+    /// result slot is neither: taking from it is a plain pickup.
     fn crafting_result_slot(self) -> Option<usize> {
         match self {
             Self::Player | Self::CraftingTable => Some(0),
@@ -155,9 +156,9 @@ pub fn apply_click(
     {
         return Vec::new();
     }
-    // Azalea's furnace quick-move lacks vanilla's smeltable/fuel routing, so a
-    // shift-click out of the player slots would predict the wrong destination;
-    // leave those to the server too.
+    // Vanilla routes a player-slot shift-click by whether the item is
+    // smeltable or fuel; recipes and fuel values live server-side, so leave
+    // those to the server too.
     if kind == ContainerKind::Furnace
         && matches!(op, ClickOperation::QuickMove(_))
         && op
@@ -337,11 +338,13 @@ fn safe_insert(slot: &mut ItemStack, carried: &mut ItemStack, amount: i32) {
 }
 
 /// Shift-click, repeating until it stops making progress (vanilla loops too).
-/// Chest menus move between the contents and player regions exactly like
-/// vanilla `ChestMenu.quickMoveStack` (contents-bound forward, player-bound
-/// reversed); the anvil ports `ItemCombinerMenu.quickMoveStack` (inputs first,
-/// then a main/hotbar toggle); the other menus use azalea's
-/// `quick_move_stack`, whose routing matches vanilla closely enough for them.
+/// Chests move between the contents and player regions like `ChestMenu`
+/// (player-bound reversed); the anvil only ever tries the input slots
+/// (`canMoveIntoInputSlots` is true, making `ItemCombinerMenu`'s main/hotbar
+/// branches dead code); the furnace moves its own slots to the player region
+/// like `AbstractFurnaceMenu` (result reversed; player-slot clicks never get
+/// predicted). The player and crafting menus use azalea's `quick_move_stack`,
+/// whose routing matches vanilla closely enough for them.
 fn quick_move(kind: ContainerKind, menu: &mut Menu, s: usize) {
     for _ in 0..menu.len() {
         let before = menu.slot(s).map(ItemStack::count).unwrap_or(0);
@@ -362,11 +365,10 @@ fn quick_move(kind: ContainerKind, menu: &mut Menu, s: usize) {
                     move_item_stack_to(kind, menu, s, 3..menu.len(), false);
                 } else {
                     move_item_stack_to(kind, menu, s, 0..2, false);
-                    if menu.slot(s).map(ItemStack::count).unwrap_or(0) == before {
-                        let to = if s < 30 { 30..39 } else { 3..30 };
-                        move_item_stack_to(kind, menu, s, to, false);
-                    }
                 }
+            }
+            ContainerKind::Furnace => {
+                move_item_stack_to(kind, menu, s, 3..menu.len(), s == 2);
             }
             _ => {
                 menu.quick_move_stack(s);

--- a/pomme-client/src/player/menu_click.rs
+++ b/pomme-client/src/player/menu_click.rs
@@ -1,28 +1,63 @@
 //! Client-side prediction of survival container clicks: a port of vanilla
 //! `AbstractContainerMenu.doClick` for the menus we open (player inventory,
-//! crafting table). The server stays authoritative and reconciles, so a wrong
-//! prediction only causes a self-correcting glitch, never item dup/loss.
+//! crafting table, furnace). The server stays authoritative and reconciles,
+//! so a wrong prediction only causes a self-correcting glitch, never item
+//! dup/loss.
 
 use azalea_inventory::components::{EquipmentSlot, Equippable};
 use azalea_inventory::item::MaxStackSizeExt;
 use azalea_inventory::operations::{ClickOperation, PickupClick, QuickCraftKind, QuickMoveClick};
 use azalea_inventory::{ItemStack, ItemStackData, Menu, Player, SlotList};
 
-/// Which container menu a click applies to. Both menus have 46 slots with the
-/// result/output at index 0.
+/// Which container menu a click applies to. `Furnace` covers the furnace,
+/// blast furnace, and smoker menus, which share the same slot structure.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ContainerKind {
     Player,
     CraftingTable,
+    Furnace,
 }
 
 impl ContainerKind {
+    pub fn slot_count(self) -> usize {
+        match self {
+            Self::Player | Self::CraftingTable => 46,
+            Self::Furnace => 39,
+        }
+    }
+
+    /// First menu slot backed by the player inventory; menu slot `i` maps to
+    /// player inventory slot `i - inv_start() + 9` from here on.
+    pub fn inv_start(self) -> usize {
+        match self {
+            Self::Player | Self::CraftingTable => 10,
+            Self::Furnace => 3,
+        }
+    }
+
+    /// The crafting-result slot, if this menu has one. Its clicks need recipe
+    /// logic we can't predict, and vanilla excludes it from double-click
+    /// gathering (`canTakeItemForPickAll`). The furnace result slot is neither:
+    /// taking from it is a plain pickup.
+    fn crafting_result_slot(self) -> Option<usize> {
+        match self {
+            Self::Player | Self::CraftingTable => Some(0),
+            Self::Furnace => None,
+        }
+    }
+
     fn build_menu(self, slots: &[ItemStack]) -> Menu {
         let mut menu = match self {
             Self::Player => Menu::Player(Player::default()),
             Self::CraftingTable => Menu::Crafting {
                 result: ItemStack::Empty,
                 grid: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::Furnace => Menu::Furnace {
+                ingredient: ItemStack::Empty,
+                fuel: ItemStack::Empty,
+                result: ItemStack::Empty,
                 player: SlotList::default(),
             },
         };
@@ -34,12 +69,14 @@ impl ContainerKind {
         menu
     }
 
-    /// Whether `item` may be placed into slot `s`: the result slot never,
+    /// Whether `item` may be placed into slot `s`: result/output slots never,
     /// player armor slots only their matching equipment, everything else yes.
-    /// Mirrors vanilla `mayPlace`.
+    /// Mirrors vanilla `mayPlace`. The furnace fuel slot accepts anything here:
+    /// fuel values live server-side, so the server reconciles bad placements.
     fn may_place(self, s: usize, item: &ItemStackData) -> bool {
         match (self, s) {
-            (_, 0) => false,
+            (Self::Player | Self::CraftingTable, 0) => false,
+            (Self::Furnace, 2) => false,
             (Self::Player, 5..=8) => {
                 let want = match s {
                     5 => EquipmentSlot::Head,
@@ -64,7 +101,21 @@ pub fn apply_click(
     op: &ClickOperation,
 ) -> Vec<(u16, ItemStack)> {
     // Crafting-result clicks need recipe logic; leave them to the server.
-    if op.slot_num() == Some(0) {
+    if op
+        .slot_num()
+        .is_some_and(|s| Some(s as usize) == kind.crafting_result_slot())
+    {
+        return Vec::new();
+    }
+    // Azalea's furnace quick-move lacks vanilla's smeltable/fuel routing, so a
+    // shift-click out of the player slots would predict the wrong destination;
+    // leave those to the server too.
+    if kind == ContainerKind::Furnace
+        && matches!(op, ClickOperation::QuickMove(_))
+        && op
+            .slot_num()
+            .is_some_and(|s| s as usize >= kind.inv_start())
+    {
         return Vec::new();
     }
     let mut menu = kind.build_menu(slots);
@@ -162,7 +213,7 @@ fn apply_op(kind: ContainerKind, menu: &mut Menu, cursor: &mut ItemStack, op: &C
             };
             quick_move(menu, s);
         }
-        ClickOperation::PickupAll(_) => pickup_all(menu, cursor),
+        ClickOperation::PickupAll(_) => pickup_all(kind, menu, cursor),
         // Drag is handled at the send site; the rest have no UI path yet.
         ClickOperation::Swap(_)
         | ClickOperation::Throw(_)
@@ -252,16 +303,19 @@ fn quick_move(menu: &mut Menu, s: usize) {
     }
 }
 
-/// Double-click: gather matching items from every slot but the result slot
-/// onto the cursor up to a full stack, partial stacks first (vanilla
+/// Double-click: gather matching items from every slot but the crafting-result
+/// slot onto the cursor up to a full stack, partial stacks first (vanilla
 /// `PICKUP_ALL` + `canTakeItemForPickAll`).
-fn pickup_all(menu: &mut Menu, cursor: &mut ItemStack) {
+fn pickup_all(kind: ContainerKind, menu: &mut Menu, cursor: &mut ItemStack) {
     let ItemStack::Present(carried) = cursor else {
         return;
     };
     let max = carried.kind.max_stack_size();
     for pass in 0..2 {
-        for s in 1..menu.len() {
+        for s in 0..menu.len() {
+            if Some(s) == kind.crafting_result_slot() {
+                continue;
+            }
             if cursor.count() >= max {
                 break;
             }

--- a/pomme-client/src/player/menu_click.rs
+++ b/pomme-client/src/player/menu_click.rs
@@ -1,8 +1,8 @@
 //! Client-side prediction of survival container clicks: a port of vanilla
 //! `AbstractContainerMenu.doClick` for the menus we open (player inventory,
-//! crafting table, furnace). The server stays authoritative and reconciles,
-//! so a wrong prediction only causes a self-correcting glitch, never item
-//! dup/loss.
+//! crafting table, furnace, chests). The server stays authoritative and
+//! reconciles, so a wrong prediction only causes a self-correcting glitch,
+//! never item dup/loss.
 
 use azalea_inventory::components::{EquipmentSlot, Equippable};
 use azalea_inventory::item::MaxStackSizeExt;
@@ -10,12 +10,15 @@ use azalea_inventory::operations::{ClickOperation, PickupClick, QuickCraftKind, 
 use azalea_inventory::{ItemStack, ItemStackData, Menu, Player, SlotList};
 
 /// Which container menu a click applies to. `Furnace` covers the furnace,
-/// blast furnace, and smoker menus, which share the same slot structure.
+/// blast furnace, and smoker menus, which share the same slot structure;
+/// `Chest` covers every generic 9xN menu (chests, ender chests, barrels, ...).
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ContainerKind {
     Player,
     CraftingTable,
     Furnace,
+    Chest { rows: u8 },
+    ShulkerBox,
 }
 
 impl ContainerKind {
@@ -23,6 +26,8 @@ impl ContainerKind {
         match self {
             Self::Player | Self::CraftingTable => 46,
             Self::Furnace => 39,
+            Self::Chest { rows } => rows as usize * 9 + 36,
+            Self::ShulkerBox => 63,
         }
     }
 
@@ -32,6 +37,8 @@ impl ContainerKind {
         match self {
             Self::Player | Self::CraftingTable => 10,
             Self::Furnace => 3,
+            Self::Chest { rows } => rows as usize * 9,
+            Self::ShulkerBox => 27,
         }
     }
 
@@ -42,7 +49,7 @@ impl ContainerKind {
     fn crafting_result_slot(self) -> Option<usize> {
         match self {
             Self::Player | Self::CraftingTable => Some(0),
-            Self::Furnace => None,
+            Self::Furnace | Self::Chest { .. } | Self::ShulkerBox => None,
         }
     }
 
@@ -60,6 +67,34 @@ impl ContainerKind {
                 result: ItemStack::Empty,
                 player: SlotList::default(),
             },
+            Self::Chest { rows: 1 } => Menu::Generic9x1 {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::Chest { rows: 2 } => Menu::Generic9x2 {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::Chest { rows: 3 } => Menu::Generic9x3 {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::Chest { rows: 4 } => Menu::Generic9x4 {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::Chest { rows: 5 } => Menu::Generic9x5 {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::Chest { .. } => Menu::Generic9x6 {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
+            Self::ShulkerBox => Menu::ShulkerBox {
+                contents: SlotList::default(),
+                player: SlotList::default(),
+            },
         };
         for (i, item) in slots.iter().enumerate() {
             if let Some(s) = menu.slot_mut(i) {
@@ -70,9 +105,10 @@ impl ContainerKind {
     }
 
     /// Whether `item` may be placed into slot `s`: result/output slots never,
-    /// player armor slots only their matching equipment, everything else yes.
-    /// Mirrors vanilla `mayPlace`. The furnace fuel slot accepts anything here:
-    /// fuel values live server-side, so the server reconciles bad placements.
+    /// player armor slots only their matching equipment, shulker contents no
+    /// shulker boxes, everything else yes. Mirrors vanilla `mayPlace`. The
+    /// furnace fuel slot accepts anything here: fuel values live server-side,
+    /// so the server reconciles bad placements.
     fn may_place(self, s: usize, item: &ItemStackData) -> bool {
         match (self, s) {
             (Self::Player | Self::CraftingTable, 0) => false,
@@ -85,6 +121,9 @@ impl ContainerKind {
                     _ => EquipmentSlot::Feet,
                 };
                 item.get_component::<Equippable>().map(|c| c.slot) == Some(want)
+            }
+            (Self::ShulkerBox, 0..=26) => {
+                !crate::player::inventory::item_resource_name(item.kind).ends_with("shulker_box")
             }
             _ => true,
         }
@@ -211,7 +250,7 @@ fn apply_op(kind: ContainerKind, menu: &mut Menu, cursor: &mut ItemStack, op: &C
             let s = match q {
                 QuickMoveClick::Left { slot } | QuickMoveClick::Right { slot } => *slot as usize,
             };
-            quick_move(menu, s);
+            quick_move(kind, menu, s);
         }
         ClickOperation::PickupAll(_) => pickup_all(kind, menu, cursor),
         // Drag is handled at the send site; the rest have no UI path yet.
@@ -288,19 +327,84 @@ fn safe_insert(slot: &mut ItemStack, carried: &mut ItemStack, amount: i32) {
     shrink(carried, take);
 }
 
-/// Shift-click: let azalea's `quick_move_stack` move the stack to its
-/// destination, repeating until it stops making progress (vanilla loops too).
-fn quick_move(menu: &mut Menu, s: usize) {
+/// Shift-click, repeating until it stops making progress (vanilla loops too).
+/// Chest menus move between the contents and player regions exactly like
+/// vanilla `ChestMenu.quickMoveStack` (contents-bound forward, player-bound
+/// reversed); the other menus use azalea's `quick_move_stack`, whose routing
+/// matches vanilla closely enough for them.
+fn quick_move(kind: ContainerKind, menu: &mut Menu, s: usize) {
     for _ in 0..menu.len() {
         let before = menu.slot(s).map(ItemStack::count).unwrap_or(0);
         if before == 0 {
             break;
         }
-        menu.quick_move_stack(s);
+        match kind {
+            ContainerKind::Chest { .. } | ContainerKind::ShulkerBox => {
+                let split = kind.inv_start();
+                if s < split {
+                    move_item_stack_to(kind, menu, s, split..menu.len(), true);
+                } else {
+                    move_item_stack_to(kind, menu, s, 0..split, false);
+                }
+            }
+            _ => {
+                menu.quick_move_stack(s);
+            }
+        }
         if menu.slot(s).map(ItemStack::count).unwrap_or(0) == before {
             break;
         }
     }
+}
+
+/// Vanilla `AbstractContainerMenu.moveItemStackTo`: first merge into matching
+/// stacks across `range` (back to front when `reverse`), then place the
+/// remainder into the first empty slot that accepts it.
+fn move_item_stack_to(
+    kind: ContainerKind,
+    menu: &mut Menu,
+    src: usize,
+    range: std::ops::Range<usize>,
+    reverse: bool,
+) {
+    let mut moving = take_slot(menu, src);
+    let indices: Vec<usize> = if reverse {
+        range.rev().collect()
+    } else {
+        range.collect()
+    };
+
+    if moving
+        .as_present()
+        .is_some_and(|d| d.kind.max_stack_size() > 1)
+    {
+        for &i in &indices {
+            if moving.is_empty() {
+                break;
+            }
+            if let Some(slot) = menu.slot_mut(i)
+                && same_item(slot, &moving)
+            {
+                merge_into(slot, &mut moving);
+            }
+        }
+    }
+
+    if let ItemStack::Present(data) = &moving {
+        for &i in &indices {
+            if !kind.may_place(i, data) {
+                continue;
+            }
+            if let Some(slot) = menu.slot_mut(i)
+                && slot.is_empty()
+            {
+                *slot = std::mem::take(&mut moving);
+                break;
+            }
+        }
+    }
+
+    put_slot(menu, src, moving);
 }
 
 /// Double-click: gather matching items from every slot but the crafting-result

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -25,6 +25,11 @@ pub fn is_survival(game_mode: u8) -> bool {
     game_mode == 0 || game_mode == 2
 }
 
+/// Matches vanilla GameType.isCreative(): Creative (1).
+pub fn is_creative(game_mode: u8) -> bool {
+    game_mode == 1
+}
+
 fn is_water_block(state: azalea_block::BlockState) -> bool {
     if state.is_air() {
         return false;

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1549,6 +1549,10 @@ pub enum SpriteId {
     Generic54Top,
     Generic54Bottom,
     ShulkerBoxBackground,
+    AnvilBackground,
+    AnvilTextField,
+    AnvilTextFieldDisabled,
+    AnvilError,
     FurnaceLitProgress,
     FurnaceBurnProgress,
     BlastFurnaceLitProgress,
@@ -1833,6 +1837,21 @@ fn build_sprite_atlas(
         (
             SpriteId::SlotHighlightFront,
             "minecraft/textures/gui/sprites/container/slot_highlight_front.png",
+            0.0,
+        ),
+        (
+            SpriteId::AnvilTextField,
+            "minecraft/textures/gui/sprites/container/anvil/text_field.png",
+            0.0,
+        ),
+        (
+            SpriteId::AnvilTextFieldDisabled,
+            "minecraft/textures/gui/sprites/container/anvil/text_field_disabled.png",
+            0.0,
+        ),
+        (
+            SpriteId::AnvilError,
+            "minecraft/textures/gui/sprites/container/anvil/error.png",
             0.0,
         ),
         (
@@ -2205,6 +2224,13 @@ fn build_sprite_atlas(
             0,
             INV_TEX_W,
             167,
+        ),
+        (
+            SpriteId::AnvilBackground,
+            "minecraft/textures/gui/container/anvil.png",
+            0,
+            INV_TEX_W,
+            INV_TEX_H,
         ),
         (
             SpriteId::CreativeItemsBackground,

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1546,6 +1546,9 @@ pub enum SpriteId {
     FurnaceBackground,
     BlastFurnaceBackground,
     SmokerBackground,
+    Generic54Top,
+    Generic54Bottom,
+    ShulkerBoxBackground,
     FurnaceLitProgress,
     FurnaceBurnProgress,
     BlastFurnaceLitProgress,
@@ -2144,53 +2147,83 @@ fn build_sprite_atlas(
         }
     }
 
-    // Container backgrounds live in a 256x256 atlas; crop out the used region.
-    for (id, path, max_w, max_h) in [
+    // Container backgrounds live in a 256x256 atlas; crop out the used region
+    // starting at texture row `src_y`.
+    for (id, path, src_y, max_w, max_h) in [
         (
             SpriteId::InventoryBackground,
             "minecraft/textures/gui/container/inventory.png",
+            0,
             INV_TEX_W,
             INV_TEX_H,
         ),
         (
             SpriteId::CraftingTableBackground,
             "minecraft/textures/gui/container/crafting_table.png",
+            0,
             INV_TEX_W,
             INV_TEX_H,
         ),
         (
             SpriteId::FurnaceBackground,
             "minecraft/textures/gui/container/furnace.png",
+            0,
             INV_TEX_W,
             INV_TEX_H,
         ),
         (
             SpriteId::BlastFurnaceBackground,
             "minecraft/textures/gui/container/blast_furnace.png",
+            0,
             INV_TEX_W,
             INV_TEX_H,
         ),
         (
             SpriteId::SmokerBackground,
             "minecraft/textures/gui/container/smoker.png",
+            0,
             INV_TEX_W,
             INV_TEX_H,
         ),
         (
+            SpriteId::Generic54Top,
+            "minecraft/textures/gui/container/generic_54.png",
+            0,
+            INV_TEX_W,
+            125,
+        ),
+        (
+            SpriteId::Generic54Bottom,
+            "minecraft/textures/gui/container/generic_54.png",
+            126,
+            INV_TEX_W,
+            96,
+        ),
+        (
+            SpriteId::ShulkerBoxBackground,
+            "minecraft/textures/gui/container/shulker_box.png",
+            0,
+            INV_TEX_W,
+            167,
+        ),
+        (
             SpriteId::CreativeItemsBackground,
             "minecraft/textures/gui/container/creative_inventory/tab_items.png",
+            0,
             195,
             136,
         ),
         (
             SpriteId::CreativeSearchBackground,
             "minecraft/textures/gui/container/creative_inventory/tab_item_search.png",
+            0,
             195,
             136,
         ),
         (
             SpriteId::CreativeInventoryBackground,
             "minecraft/textures/gui/container/creative_inventory/tab_inventory.png",
+            0,
             195,
             136,
         ),
@@ -2201,10 +2234,10 @@ fn build_sprite_atlas(
                 let rgba = img.to_rgba8();
                 let full_w = rgba.width();
                 let crop_w = max_w.min(full_w);
-                let crop_h = max_h.min(rgba.height());
+                let crop_h = max_h.min(rgba.height().saturating_sub(src_y));
                 let mut cropped = vec![0u8; (crop_w * crop_h * 4) as usize];
                 for y in 0..crop_h {
-                    let src_off = (y * full_w * 4) as usize;
+                    let src_off = ((src_y + y) * full_w * 4) as usize;
                     let dst_off = (y * crop_w * 4) as usize;
                     let row_bytes = (crop_w * 4) as usize;
                     cropped[dst_off..dst_off + row_bytes]

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1543,6 +1543,15 @@ pub enum SpriteId {
     ExperienceBarProgress,
     InventoryBackground,
     CraftingTableBackground,
+    FurnaceBackground,
+    BlastFurnaceBackground,
+    SmokerBackground,
+    FurnaceLitProgress,
+    FurnaceBurnProgress,
+    BlastFurnaceLitProgress,
+    BlastFurnaceBurnProgress,
+    SmokerLitProgress,
+    SmokerBurnProgress,
     CreativeItemsBackground,
     CreativeSearchBackground,
     CreativeInventoryBackground,
@@ -1821,6 +1830,36 @@ fn build_sprite_atlas(
         (
             SpriteId::SlotHighlightFront,
             "minecraft/textures/gui/sprites/container/slot_highlight_front.png",
+            0.0,
+        ),
+        (
+            SpriteId::FurnaceLitProgress,
+            "minecraft/textures/gui/sprites/container/furnace/lit_progress.png",
+            0.0,
+        ),
+        (
+            SpriteId::FurnaceBurnProgress,
+            "minecraft/textures/gui/sprites/container/furnace/burn_progress.png",
+            0.0,
+        ),
+        (
+            SpriteId::BlastFurnaceLitProgress,
+            "minecraft/textures/gui/sprites/container/blast_furnace/lit_progress.png",
+            0.0,
+        ),
+        (
+            SpriteId::BlastFurnaceBurnProgress,
+            "minecraft/textures/gui/sprites/container/blast_furnace/burn_progress.png",
+            0.0,
+        ),
+        (
+            SpriteId::SmokerLitProgress,
+            "minecraft/textures/gui/sprites/container/smoker/lit_progress.png",
+            0.0,
+        ),
+        (
+            SpriteId::SmokerBurnProgress,
+            "minecraft/textures/gui/sprites/container/smoker/burn_progress.png",
             0.0,
         ),
         (
@@ -2116,6 +2155,24 @@ fn build_sprite_atlas(
         (
             SpriteId::CraftingTableBackground,
             "minecraft/textures/gui/container/crafting_table.png",
+            INV_TEX_W,
+            INV_TEX_H,
+        ),
+        (
+            SpriteId::FurnaceBackground,
+            "minecraft/textures/gui/container/furnace.png",
+            INV_TEX_W,
+            INV_TEX_H,
+        ),
+        (
+            SpriteId::BlastFurnaceBackground,
+            "minecraft/textures/gui/container/blast_furnace.png",
+            INV_TEX_W,
+            INV_TEX_H,
+        ),
+        (
+            SpriteId::SmokerBackground,
+            "minecraft/textures/gui/container/smoker.png",
             INV_TEX_W,
             INV_TEX_H,
         ),

--- a/pomme-client/src/ui/anvil.rs
+++ b/pomme-client/src/ui/anvil.rs
@@ -1,0 +1,281 @@
+//! The anvil screen (vanilla `AnvilScreen` + `AnvilMenu`): input slots 0-1,
+//! result 2, player inventory 3..29, hotbar 30..38, plus the rename text
+//! field. The repair cost arrives as menu data value 0.
+
+use std::time::Instant;
+
+use azalea_inventory::components::{CustomName, ItemName};
+use azalea_inventory::{ItemStack, ItemStackData};
+
+use super::common::{FONT_SIZE, WHITE};
+use super::container::{
+    ContainerInput, ContainerResult, DragState, Panel, SlotCtx, push_cursor_stack, push_panel,
+    resolve_gesture,
+};
+use crate::player::menu_click::ContainerKind;
+use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
+
+const MAX_NAME_LENGTH: usize = 50;
+const COST_GREEN: [f32; 4] = [0.502, 1.0, 0.125, 1.0];
+const COST_RED: [f32; 4] = [1.0, 0.376, 0.376, 1.0];
+
+/// The rename field's client state (vanilla `AnvilScreen.name` +
+/// `AnvilMenu.itemName`), kept on the open container.
+pub struct AnvilState {
+    pub text: String,
+    /// The last name accepted and sent to the server.
+    sent: String,
+    /// Input slot 0 as last seen, to detect changes (vanilla `slotChanged`
+    /// resets the field text whenever the slot is set).
+    last_input: ItemStack,
+    blink: Instant,
+}
+
+impl AnvilState {
+    pub fn new() -> Self {
+        Self {
+            text: String::new(),
+            sent: String::new(),
+            last_input: ItemStack::Empty,
+            blink: Instant::now(),
+        }
+    }
+}
+
+/// The item's hover name: custom name, else item-name component, else the
+/// translated kind name.
+fn hover_name(data: &ItemStackData) -> String {
+    if let Some(c) = data.get_component::<CustomName>() {
+        return c.name.to_string();
+    }
+    if let Some(c) = data.get_component::<ItemName>() {
+        return c.name.to_string();
+    }
+    crate::lang::item_display_name(data.kind)
+}
+
+/// Applies this frame's typing to the rename field, mirroring vanilla
+/// `AnvilScreen.slotChanged` + `onNameChanged`: reset the text when input
+/// slot 0 changes, edit it while the slot is filled, normalize an unchanged
+/// default name to "", and return the name to send when it differs from the
+/// last one sent.
+pub fn update_rename(
+    state: &mut AnvilState,
+    slots: &[ItemStack],
+    typed: &[char],
+    backspace: bool,
+) -> Option<String> {
+    let input = slots.first().cloned().unwrap_or(ItemStack::Empty);
+    if input != state.last_input {
+        state.text = input.as_present().map(hover_name).unwrap_or_default();
+        state.last_input = input.clone();
+        state.blink = Instant::now();
+    }
+    let ItemStack::Present(data) = &input else {
+        return None;
+    };
+
+    if backspace && state.text.pop().is_some() {
+        state.blink = Instant::now();
+    }
+    for &ch in typed {
+        // Vanilla's allowed-chat-character filter plus the 50-char cap.
+        if state.text.chars().count() < MAX_NAME_LENGTH && ch >= ' ' && ch != '\x7f' && ch != '§' {
+            state.text.push(ch);
+            state.blink = Instant::now();
+        }
+    }
+
+    let mut name = state.text.clone();
+    if data.get_component::<CustomName>().is_none() && name == hover_name(data) {
+        name = String::new();
+    }
+    if name != state.sent {
+        state.sent = name.clone();
+        Some(name)
+    } else {
+        None
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_anvil(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    cursor: (f32, f32),
+    input: &ContainerInput,
+    slots: &[ItemStack],
+    data: [u16; 4],
+    title: &str,
+    state: &AnvilState,
+    experience_level: i32,
+    creative: bool,
+    cursor_item: &ItemStack,
+    drag: &mut Option<DragState>,
+    last_click: &mut Option<(u16, Instant)>,
+    gs: f32,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
+) -> ContainerResult {
+    let panel = push_panel(
+        elements,
+        screen_w,
+        screen_h,
+        gs,
+        166.0,
+        SpriteId::AnvilBackground,
+    );
+    panel.label(elements, 60.0, 6.0, title);
+    panel.label(elements, 8.0, 72.0, "Inventory");
+
+    let item = |num: u16| slots.get(num as usize).unwrap_or(&ItemStack::Empty);
+    let editable = item(0).is_present();
+
+    let field_sprite = if editable {
+        SpriteId::AnvilTextField
+    } else {
+        SpriteId::AnvilTextFieldDisabled
+    };
+    panel.image(elements, field_sprite, 59.0, 20.0, 110.0, 16.0);
+    push_name_text(elements, &panel, state, editable, text_width_fn);
+
+    if (item(0).is_present() || item(1).is_present()) && item(2).is_empty() {
+        panel.image(elements, SpriteId::AnvilError, 99.0, 45.0, 28.0, 21.0);
+    }
+
+    push_cost_label(
+        elements,
+        &panel,
+        data[0],
+        item(2).is_present(),
+        experience_level,
+        creative,
+        text_width_fn,
+    );
+
+    let mut ctx = SlotCtx::new(
+        elements,
+        &panel,
+        cursor,
+        ContainerKind::Anvil,
+        slots,
+        cursor_item,
+        drag,
+    );
+    ctx.player_rows(slots, 3, 30, 84.0);
+    ctx.slot(27.0, 47.0, item(0), None, 0);
+    ctx.slot(76.0, 47.0, item(1), None, 1);
+    ctx.slot(134.0, 47.0, item(2), None, 2);
+    let (hovered, shown_cursor) = ctx.finish(cursor_item);
+
+    push_cursor_stack(elements, cursor, panel.scale, &shown_cursor);
+
+    let (ops, clicked_outside) = resolve_gesture(
+        input,
+        hovered,
+        &panel,
+        cursor,
+        ContainerKind::Anvil,
+        slots,
+        cursor_item,
+        drag,
+        last_click,
+    );
+
+    ContainerResult {
+        clicked_outside,
+        ops,
+    }
+}
+
+/// The rename text at (62,24): white shadowed, right-shifted inside its
+/// 103-wide clip when overflowing (vanilla's EditBox keeps the end-of-text
+/// cursor in view), with a blinking append caret while editable.
+fn push_name_text(
+    elements: &mut Vec<MenuElement>,
+    panel: &Panel,
+    state: &AnvilState,
+    editable: bool,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
+) {
+    let s = panel.scale;
+    let fs = FONT_SIZE * s;
+    let field_x = panel.ox + 62.0 * s;
+    let field_w = 103.0 * s;
+    let text_y = panel.oy + 24.0 * s;
+    let tw = text_width_fn(&state.text, fs);
+    let caret_w = text_width_fn("_", fs);
+    let shift = (field_w - tw - caret_w).min(0.0);
+
+    elements.push(MenuElement::ScissorPush {
+        x: field_x,
+        y: panel.oy + 20.0 * s,
+        w: field_w,
+        h: 16.0 * s,
+    });
+    elements.push(MenuElement::Text {
+        x: field_x + shift,
+        y: text_y,
+        text: state.text.clone(),
+        scale: fs,
+        color: WHITE,
+        centered: false,
+    });
+    if editable && state.blink.elapsed().as_millis() % 1000 < 500 {
+        elements.push(MenuElement::Text {
+            x: field_x + shift + tw,
+            y: text_y,
+            text: "_".into(),
+            scale: fs,
+            color: WHITE,
+            centered: false,
+        });
+    }
+    elements.push(MenuElement::ScissorPop);
+}
+
+/// The right-aligned repair cost line (vanilla `AnvilScreen.extractLabels`):
+/// hidden at cost 0 or with no result, "Too Expensive!" from cost 40 outside
+/// creative, red when the player can't afford the levels.
+fn push_cost_label(
+    elements: &mut Vec<MenuElement>,
+    panel: &Panel,
+    cost: u16,
+    has_result: bool,
+    experience_level: i32,
+    creative: bool,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
+) {
+    if cost == 0 {
+        return;
+    }
+    let (line, color) = if cost >= 40 && !creative {
+        ("Too Expensive!".to_string(), COST_RED)
+    } else if !has_result {
+        return;
+    } else if !creative && experience_level < cost as i32 {
+        (format!("Enchantment Cost: {cost}"), COST_RED)
+    } else {
+        (format!("Enchantment Cost: {cost}"), COST_GREEN)
+    };
+
+    let s = panel.scale;
+    let fs = FONT_SIZE * s;
+    let tx = 166.0 * s - text_width_fn(&line, fs);
+    elements.push(MenuElement::Rect {
+        x: panel.ox + tx - 2.0 * s,
+        y: panel.oy + 67.0 * s,
+        w: 168.0 * s - tx + 2.0 * s,
+        h: 12.0 * s,
+        corner_radius: 0.0,
+        color: [0.0, 0.0, 0.0, 0.31],
+    });
+    elements.push(MenuElement::Text {
+        x: panel.ox + tx,
+        y: panel.oy + 69.0 * s,
+        text: line,
+        scale: fs,
+        color,
+        centered: false,
+    });
+}

--- a/pomme-client/src/ui/chest.rs
+++ b/pomme-client/src/ui/chest.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use azalea_inventory::ItemStack;
 
-use super::common::{SLOT_STRIDE, WHITE};
+use super::common::SLOT_STRIDE;
 use super::container::{
     ContainerInput, ContainerResult, DragState, Panel, SlotCtx, push_backdrop, push_clipped_sprite,
     push_cursor_stack, push_panel, resolve_gesture,
@@ -46,14 +46,14 @@ pub fn build_chest(
         [0.0, 0.0, 176.0, TOP_TEX_H],
         [0.0, 0.0, 176.0, split],
     );
-    elements.push(MenuElement::Image {
-        x: panel.ox,
-        y: panel.oy + split * panel.scale,
-        w: panel.w,
-        h: BOTTOM_TEX_H * panel.scale,
-        sprite: SpriteId::Generic54Bottom,
-        tint: WHITE,
-    });
+    panel.image(
+        elements,
+        SpriteId::Generic54Bottom,
+        0.0,
+        split,
+        176.0,
+        BOTTOM_TEX_H,
+    );
     panel.label(elements, 8.0, 6.0, title);
     panel.label(elements, 8.0, rows_h + 20.0, "Inventory");
 

--- a/pomme-client/src/ui/chest.rs
+++ b/pomme-client/src/ui/chest.rs
@@ -1,0 +1,166 @@
+//! The generic 9xN chest screen (vanilla `ContainerScreen` + `ChestMenu`) and
+//! the shulker box screen (`ShulkerBoxScreen` + `ShulkerBoxMenu`): contents
+//! slots 0..rows*9, then player inventory and hotbar.
+
+use std::time::Instant;
+
+use azalea_inventory::ItemStack;
+
+use super::common::{SLOT_STRIDE, WHITE};
+use super::container::{
+    ContainerInput, ContainerResult, DragState, Panel, SlotCtx, push_backdrop, push_clipped_sprite,
+    push_cursor_stack, push_panel, resolve_gesture,
+};
+use crate::player::menu_click::ContainerKind;
+use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
+
+/// The generic_54 texture's top (rows) piece is 176x125; the player-inventory
+/// piece below it is 176x96 and completes any row count's background.
+const TOP_TEX_H: f32 = 125.0;
+const BOTTOM_TEX_H: f32 = 96.0;
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_chest(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    cursor: (f32, f32),
+    input: &ContainerInput,
+    rows: u8,
+    slots: &[ItemStack],
+    title: &str,
+    cursor_item: &ItemStack,
+    drag: &mut Option<DragState>,
+    last_click: &mut Option<(u16, Instant)>,
+    gs: f32,
+) -> ContainerResult {
+    let rows_h = rows as f32 * SLOT_STRIDE;
+    let panel = push_backdrop(elements, screen_w, screen_h, gs, 176.0, 114.0 + rows_h);
+    // Vanilla ContainerScreen draws generic_54 in two pieces: the top slice
+    // cut off after the last contents row, then the player-inventory strip.
+    let split = rows_h + 17.0;
+    push_clipped_sprite(
+        elements,
+        &panel,
+        SpriteId::Generic54Top,
+        [0.0, 0.0, 176.0, TOP_TEX_H],
+        [0.0, 0.0, 176.0, split],
+    );
+    elements.push(MenuElement::Image {
+        x: panel.ox,
+        y: panel.oy + split * panel.scale,
+        w: panel.w,
+        h: BOTTOM_TEX_H * panel.scale,
+        sprite: SpriteId::Generic54Bottom,
+        tint: WHITE,
+    });
+    panel.label(elements, 8.0, 6.0, title);
+    panel.label(elements, 8.0, rows_h + 20.0, "Inventory");
+
+    build_contents(
+        elements,
+        &panel,
+        cursor,
+        input,
+        ContainerKind::Chest { rows },
+        rows_h + 31.0,
+        slots,
+        cursor_item,
+        drag,
+        last_click,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_shulker_box(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    cursor: (f32, f32),
+    input: &ContainerInput,
+    slots: &[ItemStack],
+    title: &str,
+    cursor_item: &ItemStack,
+    drag: &mut Option<DragState>,
+    last_click: &mut Option<(u16, Instant)>,
+    gs: f32,
+) -> ContainerResult {
+    let panel = push_panel(
+        elements,
+        screen_w,
+        screen_h,
+        gs,
+        167.0,
+        SpriteId::ShulkerBoxBackground,
+    );
+    panel.label(elements, 8.0, 6.0, title);
+    panel.label(elements, 8.0, 73.0, "Inventory");
+
+    build_contents(
+        elements,
+        &panel,
+        cursor,
+        input,
+        ContainerKind::ShulkerBox,
+        84.0,
+        slots,
+        cursor_item,
+        drag,
+        last_click,
+    )
+}
+
+/// The contents grid at GUI-unit y 18, the player rows at `main_y`, and the
+/// shared gesture tail.
+#[allow(clippy::too_many_arguments)]
+fn build_contents(
+    elements: &mut Vec<MenuElement>,
+    panel: &Panel,
+    cursor: (f32, f32),
+    input: &ContainerInput,
+    kind: ContainerKind,
+    main_y: f32,
+    slots: &[ItemStack],
+    cursor_item: &ItemStack,
+    drag: &mut Option<DragState>,
+    last_click: &mut Option<(u16, Instant)>,
+) -> ContainerResult {
+    let mut ctx = SlotCtx::new(elements, panel, cursor, kind, slots, cursor_item, drag);
+
+    let main_base = kind.inv_start() as u16;
+    ctx.player_rows(slots, main_base, main_base + 27, main_y);
+
+    for row in 0..main_base / 9 {
+        for col in 0..9u16 {
+            let num = row * 9 + col;
+            let item = slots.get(num as usize).unwrap_or(&ItemStack::Empty);
+            ctx.slot(
+                8.0 + col as f32 * SLOT_STRIDE,
+                18.0 + row as f32 * SLOT_STRIDE,
+                item,
+                None,
+                num,
+            );
+        }
+    }
+
+    let (hovered, shown_cursor) = ctx.finish(cursor_item);
+    push_cursor_stack(elements, cursor, panel.scale, &shown_cursor);
+
+    let (ops, clicked_outside) = resolve_gesture(
+        input,
+        hovered,
+        panel,
+        cursor,
+        kind,
+        slots,
+        cursor_item,
+        drag,
+        last_click,
+    );
+
+    ContainerResult {
+        clicked_outside,
+        ops,
+    }
+}

--- a/pomme-client/src/ui/container.rs
+++ b/pomme-client/src/ui/container.rs
@@ -17,8 +17,6 @@ use super::common::{
 use crate::player::menu_click::{self, ContainerKind};
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
 
-const TEX_W: f32 = 176.0;
-const TEX_H: f32 = 166.0;
 const DOUBLE_CLICK_MS: u128 = 250;
 
 /// Active click-drag: which button, and the slots covered so far.
@@ -41,7 +39,7 @@ pub struct ContainerInput {
     pub shift: bool,
 }
 
-/// The centered 176x166 container panel's placement on screen.
+/// The centered container panel's placement on screen.
 pub struct Panel {
     pub scale: f32,
     pub ox: f32,
@@ -67,17 +65,19 @@ impl Panel {
     }
 }
 
-/// The dimmed backdrop and the centered container background sprite.
-pub fn push_panel(
+/// The dimmed backdrop and the centered panel placement for a `panel_w` x
+/// `panel_h` (GUI units) container, without a background sprite.
+pub fn push_backdrop(
     elements: &mut Vec<MenuElement>,
     screen_w: f32,
     screen_h: f32,
     gs: f32,
-    sprite: SpriteId,
+    panel_w: f32,
+    panel_h: f32,
 ) -> Panel {
-    let scale = gs.min(screen_w / TEX_W).min(screen_h / TEX_H);
-    let w = TEX_W * scale;
-    let h = TEX_H * scale;
+    let scale = gs.min(screen_w / panel_w).min(screen_h / panel_h);
+    let w = panel_w * scale;
+    let h = panel_h * scale;
     let ox = (screen_w - w) / 2.0;
     let oy = (screen_h - h) / 2.0;
 
@@ -88,14 +88,6 @@ pub fn push_panel(
         [0.0627, 0.0627, 0.0627, 0.7529],
         [0.0627, 0.0627, 0.0627, 0.8157],
     );
-    elements.push(MenuElement::Image {
-        x: ox,
-        y: oy,
-        w,
-        h,
-        sprite,
-        tint: WHITE,
-    });
 
     Panel {
         scale,
@@ -104,6 +96,57 @@ pub fn push_panel(
         w,
         h,
     }
+}
+
+/// The dimmed backdrop and the centered 176 x `panel_h` container background
+/// sprite.
+pub fn push_panel(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    gs: f32,
+    panel_h: f32,
+    sprite: SpriteId,
+) -> Panel {
+    let panel = push_backdrop(elements, screen_w, screen_h, gs, 176.0, panel_h);
+    elements.push(MenuElement::Image {
+        x: panel.ox,
+        y: panel.oy,
+        w: panel.w,
+        h: panel.h,
+        sprite,
+        tint: WHITE,
+    });
+    panel
+}
+
+/// A sprite scissored to a sub-rectangle, both `[x, y, w, h]` in GUI units.
+pub fn push_clipped_sprite(
+    elements: &mut Vec<MenuElement>,
+    panel: &Panel,
+    sprite: SpriteId,
+    rect: [f32; 4],
+    clip: [f32; 4],
+) {
+    let s = panel.scale;
+    let px = |v: [f32; 4]| [panel.ox + v[0] * s, panel.oy + v[1] * s, v[2] * s, v[3] * s];
+    let [cx, cy, cw, ch] = px(clip);
+    let [x, y, w, h] = px(rect);
+    elements.push(MenuElement::ScissorPush {
+        x: cx,
+        y: cy,
+        w: cw,
+        h: ch,
+    });
+    elements.push(MenuElement::Image {
+        x,
+        y,
+        w,
+        h,
+        sprite,
+        tint: WHITE,
+    });
+    elements.push(MenuElement::ScissorPop);
 }
 
 /// The (inert) recipe book toggle at GUI-unit position.
@@ -197,16 +240,22 @@ impl<'e> SlotCtx<'e> {
         }
     }
 
-    /// The three main-inventory rows and the hotbar at their standard
-    /// positions, reading container slots starting at the given bases.
-    pub fn player_rows(&mut self, slots: &[ItemStack], main_base: u16, hotbar_base: u16) {
+    /// The three main-inventory rows starting at GUI-unit `main_y` and the
+    /// hotbar 58 below, reading container slots starting at the given bases.
+    pub fn player_rows(
+        &mut self,
+        slots: &[ItemStack],
+        main_base: u16,
+        hotbar_base: u16,
+        main_y: f32,
+    ) {
         for row in 0..3u16 {
             for col in 0..9u16 {
                 let num = main_base + row * 9 + col;
                 let item = slots.get(num as usize).unwrap_or(&ItemStack::Empty);
                 self.slot(
                     8.0 + col as f32 * SLOT_STRIDE,
-                    84.0 + row as f32 * SLOT_STRIDE,
+                    main_y + row as f32 * SLOT_STRIDE,
                     item,
                     None,
                     num,
@@ -216,7 +265,13 @@ impl<'e> SlotCtx<'e> {
         for col in 0..9u16 {
             let num = hotbar_base + col;
             let item = slots.get(num as usize).unwrap_or(&ItemStack::Empty);
-            self.slot(8.0 + col as f32 * SLOT_STRIDE, 142.0, item, None, num);
+            self.slot(
+                8.0 + col as f32 * SLOT_STRIDE,
+                main_y + 58.0,
+                item,
+                None,
+                num,
+            );
         }
     }
 

--- a/pomme-client/src/ui/container.rs
+++ b/pomme-client/src/ui/container.rs
@@ -63,6 +63,26 @@ impl Panel {
             color: SLOT_LABEL_COLOR,
         });
     }
+
+    /// An untinted sprite at a GUI-unit rectangle.
+    pub fn image(
+        &self,
+        elements: &mut Vec<MenuElement>,
+        sprite: SpriteId,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+    ) {
+        elements.push(MenuElement::Image {
+            x: self.ox + x * self.scale,
+            y: self.oy + y * self.scale,
+            w: w * self.scale,
+            h: h * self.scale,
+            sprite,
+            tint: WHITE,
+        });
+    }
 }
 
 /// The dimmed backdrop and the centered panel placement for a `panel_w` x
@@ -109,14 +129,7 @@ pub fn push_panel(
     sprite: SpriteId,
 ) -> Panel {
     let panel = push_backdrop(elements, screen_w, screen_h, gs, 176.0, panel_h);
-    elements.push(MenuElement::Image {
-        x: panel.ox,
-        y: panel.oy,
-        w: panel.w,
-        h: panel.h,
-        sprite,
-        tint: WHITE,
-    });
+    panel.image(elements, sprite, 0.0, 0.0, 176.0, panel_h);
     panel
 }
 
@@ -129,23 +142,13 @@ pub fn push_clipped_sprite(
     clip: [f32; 4],
 ) {
     let s = panel.scale;
-    let px = |v: [f32; 4]| [panel.ox + v[0] * s, panel.oy + v[1] * s, v[2] * s, v[3] * s];
-    let [cx, cy, cw, ch] = px(clip);
-    let [x, y, w, h] = px(rect);
     elements.push(MenuElement::ScissorPush {
-        x: cx,
-        y: cy,
-        w: cw,
-        h: ch,
+        x: panel.ox + clip[0] * s,
+        y: panel.oy + clip[1] * s,
+        w: clip[2] * s,
+        h: clip[3] * s,
     });
-    elements.push(MenuElement::Image {
-        x,
-        y,
-        w,
-        h,
-        sprite,
-        tint: WHITE,
-    });
+    panel.image(elements, sprite, rect[0], rect[1], rect[2], rect[3]);
     elements.push(MenuElement::ScissorPop);
 }
 

--- a/pomme-client/src/ui/container.rs
+++ b/pomme-client/src/ui/container.rs
@@ -1,5 +1,5 @@
-//! Shared pieces for container screens (survival inventory, crafting table):
-//! the click/drag gesture state machine and per-frame slot drawing.
+//! Shared pieces for container screens (survival inventory, crafting table,
+//! furnace): the click/drag gesture state machine and per-frame slot drawing.
 
 use std::collections::HashMap;
 use std::time::Instant;
@@ -23,6 +23,14 @@ const DOUBLE_CLICK_MS: u128 = 250;
 
 /// Active click-drag: which button, and the slots covered so far.
 pub type DragState = (QuickCraftKind, Vec<u16>);
+
+/// What a container screen's frame produced.
+pub struct ContainerResult {
+    pub clicked_outside: bool,
+    /// Container-click operations to send this frame (usually 0-1; a drag
+    /// release emits a start/add.../end sequence).
+    pub ops: Vec<ClickOperation>,
+}
 
 /// Input for a container screen this frame.
 pub struct ContainerInput {

--- a/pomme-client/src/ui/crafting_table.rs
+++ b/pomme-client/src/ui/crafting_table.rs
@@ -4,28 +4,19 @@
 use std::time::Instant;
 
 use azalea_inventory::ItemStack;
-use azalea_inventory::operations::ClickOperation;
 
 use super::common::SLOT_STRIDE;
 use super::container::{
-    ContainerInput, DragState, SlotCtx, push_cursor_stack, push_panel, push_recipe_book_button,
-    resolve_gesture,
+    ContainerInput, ContainerResult, DragState, SlotCtx, push_cursor_stack, push_panel,
+    push_recipe_book_button, resolve_gesture,
 };
 use crate::player::menu_click::ContainerKind;
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
 
-pub const SLOT_COUNT: usize = 46;
 const SLOT_RESULT: u16 = 0;
 const SLOT_GRID_BASE: u16 = 1;
 const SLOT_MAIN_BASE: u16 = 10;
 const SLOT_HOTBAR_BASE: u16 = 37;
-
-pub struct CraftingResult {
-    pub clicked_outside: bool,
-    /// Container-click operations to send this frame (usually 0-1; a drag
-    /// release emits a start/add.../end sequence).
-    pub ops: Vec<ClickOperation>,
-}
 
 #[allow(clippy::too_many_arguments)]
 pub fn build_crafting_table(
@@ -40,7 +31,7 @@ pub fn build_crafting_table(
     drag: &mut Option<DragState>,
     last_click: &mut Option<(u16, Instant)>,
     gs: f32,
-) -> CraftingResult {
+) -> ContainerResult {
     let panel = push_panel(
         elements,
         screen_w,
@@ -97,7 +88,7 @@ pub fn build_crafting_table(
         last_click,
     );
 
-    CraftingResult {
+    ContainerResult {
         clicked_outside,
         ops,
     }

--- a/pomme-client/src/ui/crafting_table.rs
+++ b/pomme-client/src/ui/crafting_table.rs
@@ -37,6 +37,7 @@ pub fn build_crafting_table(
         screen_w,
         screen_h,
         gs,
+        166.0,
         SpriteId::CraftingTableBackground,
     );
     panel.label(elements, 29.0, 6.0, title);
@@ -52,7 +53,7 @@ pub fn build_crafting_table(
         drag,
     );
 
-    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE);
+    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE, 84.0);
 
     for row in 0..3u16 {
         for col in 0..3u16 {

--- a/pomme-client/src/ui/creative_inventory.rs
+++ b/pomme-client/src/ui/creative_inventory.rs
@@ -229,7 +229,7 @@ impl CreativeTab {
         }
     }
 
-    fn captures_typing(self) -> bool {
+    pub fn captures_typing(self) -> bool {
         matches!(self, CreativeTab::Search)
     }
 }

--- a/pomme-client/src/ui/furnace.rs
+++ b/pomme-client/src/ui/furnace.rs
@@ -7,10 +7,10 @@ use std::time::Instant;
 
 use azalea_inventory::ItemStack;
 
-use super::common::{FONT_SIZE, WHITE};
+use super::common::FONT_SIZE;
 use super::container::{
-    ContainerInput, ContainerResult, DragState, Panel, SlotCtx, push_cursor_stack, push_panel,
-    push_recipe_book_button, resolve_gesture,
+    ContainerInput, ContainerResult, DragState, Panel, SlotCtx, push_clipped_sprite,
+    push_cursor_stack, push_panel, push_recipe_book_button, resolve_gesture,
 };
 use crate::player::menu_click::ContainerKind;
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
@@ -76,7 +76,7 @@ pub fn build_furnace(
     text_width_fn: &dyn Fn(&str, f32) -> f32,
 ) -> ContainerResult {
     let (background, lit_sprite, burn_sprite) = variant.sprites();
-    let panel = push_panel(elements, screen_w, screen_h, gs, background);
+    let panel = push_panel(elements, screen_w, screen_h, gs, 166.0, background);
     // Vanilla centers the furnace title: (imageWidth - font.width(title)) / 2.
     let title_x = ((176.0 - text_width_fn(title, FONT_SIZE)) / 2.0).floor();
     panel.label(elements, title_x, 6.0, title);
@@ -94,7 +94,7 @@ pub fn build_furnace(
         drag,
     );
 
-    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE);
+    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE, 84.0);
 
     let item = |num: u16| slots.get(num as usize).unwrap_or(&ItemStack::Empty);
     ctx.slot(56.0, 17.0, item(SLOT_INGREDIENT), None, SLOT_INGREDIENT);
@@ -168,33 +168,4 @@ fn push_progress_overlays(
             [79.0, 34.0, w, 16.0],
         );
     }
-}
-
-/// A sprite scissored to a sub-rectangle, both `[x, y, w, h]` in GUI units.
-fn push_clipped_sprite(
-    elements: &mut Vec<MenuElement>,
-    panel: &Panel,
-    sprite: SpriteId,
-    rect: [f32; 4],
-    clip: [f32; 4],
-) {
-    let s = panel.scale;
-    let px = |v: [f32; 4]| [panel.ox + v[0] * s, panel.oy + v[1] * s, v[2] * s, v[3] * s];
-    let [cx, cy, cw, ch] = px(clip);
-    let [x, y, w, h] = px(rect);
-    elements.push(MenuElement::ScissorPush {
-        x: cx,
-        y: cy,
-        w: cw,
-        h: ch,
-    });
-    elements.push(MenuElement::Image {
-        x,
-        y,
-        w,
-        h,
-        sprite,
-        tint: WHITE,
-    });
-    elements.push(MenuElement::ScissorPop);
 }

--- a/pomme-client/src/ui/furnace.rs
+++ b/pomme-client/src/ui/furnace.rs
@@ -1,0 +1,200 @@
+//! The furnace family screen (vanilla `AbstractFurnaceScreen` +
+//! `AbstractFurnaceMenu`): ingredient slot 0, fuel 1, result 2, player
+//! inventory 3..29, hotbar 30..38. Covers the furnace, blast furnace, and
+//! smoker, which differ only in textures.
+
+use std::time::Instant;
+
+use azalea_inventory::ItemStack;
+
+use super::common::{FONT_SIZE, WHITE};
+use super::container::{
+    ContainerInput, ContainerResult, DragState, Panel, SlotCtx, push_cursor_stack, push_panel,
+    push_recipe_book_button, resolve_gesture,
+};
+use crate::player::menu_click::ContainerKind;
+use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
+
+const SLOT_INGREDIENT: u16 = 0;
+const SLOT_FUEL: u16 = 1;
+const SLOT_RESULT: u16 = 2;
+const SLOT_MAIN_BASE: u16 = 3;
+const SLOT_HOTBAR_BASE: u16 = 30;
+
+/// Indices into the menu's data values (`ClientboundContainerSetData`),
+/// matching vanilla `AbstractFurnaceBlockEntity`.
+const DATA_LIT_TIME: usize = 0;
+const DATA_LIT_DURATION: usize = 1;
+const DATA_COOKING_PROGRESS: usize = 2;
+const DATA_COOKING_TOTAL_TIME: usize = 3;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FurnaceVariant {
+    Furnace,
+    BlastFurnace,
+    Smoker,
+}
+
+impl FurnaceVariant {
+    /// This variant's (background, lit progress, burn progress) sprites.
+    fn sprites(self) -> (SpriteId, SpriteId, SpriteId) {
+        match self {
+            Self::Furnace => (
+                SpriteId::FurnaceBackground,
+                SpriteId::FurnaceLitProgress,
+                SpriteId::FurnaceBurnProgress,
+            ),
+            Self::BlastFurnace => (
+                SpriteId::BlastFurnaceBackground,
+                SpriteId::BlastFurnaceLitProgress,
+                SpriteId::BlastFurnaceBurnProgress,
+            ),
+            Self::Smoker => (
+                SpriteId::SmokerBackground,
+                SpriteId::SmokerLitProgress,
+                SpriteId::SmokerBurnProgress,
+            ),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_furnace(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    cursor: (f32, f32),
+    input: &ContainerInput,
+    variant: FurnaceVariant,
+    slots: &[ItemStack],
+    data: [u16; 4],
+    title: &str,
+    cursor_item: &ItemStack,
+    drag: &mut Option<DragState>,
+    last_click: &mut Option<(u16, Instant)>,
+    gs: f32,
+    text_width_fn: &dyn Fn(&str, f32) -> f32,
+) -> ContainerResult {
+    let (background, lit_sprite, burn_sprite) = variant.sprites();
+    let panel = push_panel(elements, screen_w, screen_h, gs, background);
+    // Vanilla centers the furnace title: (imageWidth - font.width(title)) / 2.
+    let title_x = ((176.0 - text_width_fn(title, FONT_SIZE)) / 2.0).floor();
+    panel.label(elements, title_x, 6.0, title);
+    panel.label(elements, 8.0, 72.0, "Inventory");
+
+    push_progress_overlays(elements, &panel, lit_sprite, burn_sprite, data);
+
+    let mut ctx = SlotCtx::new(
+        elements,
+        &panel,
+        cursor,
+        ContainerKind::Furnace,
+        slots,
+        cursor_item,
+        drag,
+    );
+
+    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE);
+
+    let item = |num: u16| slots.get(num as usize).unwrap_or(&ItemStack::Empty);
+    ctx.slot(56.0, 17.0, item(SLOT_INGREDIENT), None, SLOT_INGREDIENT);
+    ctx.slot(56.0, 53.0, item(SLOT_FUEL), None, SLOT_FUEL);
+    ctx.slot(116.0, 35.0, item(SLOT_RESULT), None, SLOT_RESULT);
+
+    let (hovered, shown_cursor) = ctx.finish(cursor_item);
+
+    push_recipe_book_button(elements, &panel, cursor, 20.0, 34.0);
+    push_cursor_stack(elements, cursor, panel.scale, &shown_cursor);
+
+    let (ops, clicked_outside) = resolve_gesture(
+        input,
+        hovered,
+        &panel,
+        cursor,
+        ContainerKind::Furnace,
+        slots,
+        cursor_item,
+        drag,
+        last_click,
+    );
+
+    ContainerResult {
+        clicked_outside,
+        ops,
+    }
+}
+
+/// The flame (remaining fuel, bottom-anchored) and arrow (cook progress,
+/// left-anchored), scissored to the filled fraction like vanilla's
+/// `blitSprite` source crop.
+fn push_progress_overlays(
+    elements: &mut Vec<MenuElement>,
+    panel: &Panel,
+    lit_sprite: SpriteId,
+    burn_sprite: SpriteId,
+    data: [u16; 4],
+) {
+    if data[DATA_LIT_TIME] > 0 {
+        // ceil(progress * 13) + 1 rows of the 14px flame, from the bottom.
+        let lit_duration = if data[DATA_LIT_DURATION] == 0 {
+            200
+        } else {
+            data[DATA_LIT_DURATION]
+        };
+        let lit = (data[DATA_LIT_TIME] as f32 / lit_duration as f32).clamp(0.0, 1.0);
+        let h = (lit * 13.0).ceil() + 1.0;
+        push_clipped_sprite(
+            elements,
+            panel,
+            lit_sprite,
+            [56.0, 36.0, 14.0, 14.0],
+            [56.0, 50.0 - h, 14.0, h],
+        );
+    }
+
+    let cook = if data[DATA_COOKING_TOTAL_TIME] == 0 || data[DATA_COOKING_PROGRESS] == 0 {
+        0.0
+    } else {
+        (data[DATA_COOKING_PROGRESS] as f32 / data[DATA_COOKING_TOTAL_TIME] as f32).clamp(0.0, 1.0)
+    };
+    // ceil(progress * 24) columns of the 24px arrow, from the left.
+    let w = (cook * 24.0).ceil();
+    if w > 0.0 {
+        push_clipped_sprite(
+            elements,
+            panel,
+            burn_sprite,
+            [79.0, 34.0, 24.0, 16.0],
+            [79.0, 34.0, w, 16.0],
+        );
+    }
+}
+
+/// A sprite scissored to a sub-rectangle, both `[x, y, w, h]` in GUI units.
+fn push_clipped_sprite(
+    elements: &mut Vec<MenuElement>,
+    panel: &Panel,
+    sprite: SpriteId,
+    rect: [f32; 4],
+    clip: [f32; 4],
+) {
+    let s = panel.scale;
+    let px = |v: [f32; 4]| [panel.ox + v[0] * s, panel.oy + v[1] * s, v[2] * s, v[3] * s];
+    let [cx, cy, cw, ch] = px(clip);
+    let [x, y, w, h] = px(rect);
+    elements.push(MenuElement::ScissorPush {
+        x: cx,
+        y: cy,
+        w: cw,
+        h: ch,
+    });
+    elements.push(MenuElement::Image {
+        x,
+        y,
+        w,
+        h,
+        sprite,
+        tint: WHITE,
+    });
+    elements.push(MenuElement::ScissorPop);
+}

--- a/pomme-client/src/ui/inventory.rs
+++ b/pomme-client/src/ui/inventory.rs
@@ -54,6 +54,7 @@ pub fn build_inventory(
         screen_w,
         screen_h,
         gs,
+        166.0,
         SpriteId::InventoryBackground,
     );
     panel.label(elements, 97.0, 6.0, "Crafting");
@@ -69,7 +70,7 @@ pub fn build_inventory(
         drag,
     );
 
-    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE);
+    ctx.player_rows(slots, SLOT_MAIN_BASE, SLOT_HOTBAR_BASE, 84.0);
 
     let armor_ys = [8.0, 26.0, 44.0, 62.0];
     for i in 0..4u16 {

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod death;
 #[allow(dead_code)]
 pub mod font;
 pub mod friends;
+pub mod furnace;
 pub mod hud;
 pub mod inventory;
 pub mod menu;

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat;
+pub mod chest;
 pub mod common;
 pub mod container;
 pub mod crafting_table;

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod anvil;
 pub mod chat;
 pub mod chest;
 pub mod common;


### PR DESCRIPTION
Adds the furnace family (furnace, blast furnace, smoker), generic 9xN chests (chest, double, trapped, ender, barrel, minecart/boat), shulker box, and anvil screens.

- Furnace: lit/cook progress from container data, scissored sprite fills
- Chests: variable-height panel from the two-piece generic_54 background, quick-move port with reversed fill and no full-container hotbar toggle
- Anvil: rename field with text capture (E and digits type instead of acting as hotkeys), cost label, rename packet on accepted name changes
- Fixes creative search reading an already-drained input buffer