### PR TITLE
Fix slow server ping/join and MOTD base color

### DIFF
--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -7,7 +7,7 @@ use super::NetworkEvent;
 use super::commands::{CommandTree, SharedCommandTree};
 use super::sender::PacketSender;
 use crate::entity::components::Position;
-use crate::ui::text::{TextSpan, format_text_spans};
+use crate::ui::text::format_text_spans;
 
 pub fn handle_game_packet(
     packet: &ClientboundGamePacket,
@@ -232,13 +232,13 @@ pub fn handle_game_packet(
             });
         }
         ClientboundGamePacket::SystemChat(p) if !p.overlay => {
-            send_chat(event_tx, format_text_spans(&p.content));
+            send_chat(event_tx, &p.content);
         }
         ClientboundGamePacket::PlayerChat(p) => {
-            send_chat(event_tx, format_text_spans(&p.message()));
+            send_chat(event_tx, &p.message());
         }
         ClientboundGamePacket::DisguisedChat(p) => {
-            send_chat(event_tx, format_text_spans(&p.message));
+            send_chat(event_tx, &p.message);
         }
         ClientboundGamePacket::BlockUpdate(p) => {
             let _ = event_tx.try_send(NetworkEvent::BlockUpdate {
@@ -620,7 +620,8 @@ pub fn handle_game_packet(
     }
 }
 
-fn send_chat(event_tx: &Sender<NetworkEvent>, spans: Vec<TextSpan>) {
+fn send_chat(event_tx: &Sender<NetworkEvent>, message: &azalea_chat::FormattedText) {
+    let spans = format_text_spans(message, [1.0; 4]);
     let text: String = spans.iter().map(|s| s.text.as_str()).collect();
     tracing::info!("Chat: {text}");
     let _ = event_tx.try_send(NetworkEvent::ChatMessage { spans });

--- a/pomme-client/src/net/resolve.rs
+++ b/pomme-client/src/net/resolve.rs
@@ -31,16 +31,22 @@ pub async fn resolve_candidates(server: &ServerAddr) -> Result<Vec<SocketAddr>, 
         return Ok(candidates);
     }
 
-    // Bound azalea's SRV-aware resolution so a stalled SRV lookup can't hold
-    // the connection hostage; the system resolver runs concurrently as a
-    // fallback (it also covers `localhost`, which hickory can end up sending
-    // to DNS on Windows).
+    // Bound both lookups so a stalled resolver can't hold the connection
+    // hostage. The system resolver runs concurrently as a fallback; it also
+    // covers `localhost`, which hickory can end up sending to DNS on Windows.
     let (primary, extra) = tokio::join!(
         tokio::time::timeout(Duration::from_secs(2), resolve_address(server)),
-        tokio::net::lookup_host((server.host.as_str(), server.port)),
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            tokio::net::lookup_host((server.host.as_str(), server.port)),
+        ),
     );
     let primary = primary.unwrap_or_else(|_| Err(ResolveError::from("resolution timed out")));
-    let extra: Vec<SocketAddr> = extra.map(Iterator::collect).unwrap_or_default();
+    let extra: Vec<SocketAddr> = extra
+        .ok()
+        .and_then(Result::ok)
+        .map(Iterator::collect)
+        .unwrap_or_default();
 
     match primary {
         Ok(addr) => push_with_nat64(&mut candidates, addr),

--- a/pomme-client/src/net/resolve.rs
+++ b/pomme-client/src/net/resolve.rs
@@ -22,29 +22,53 @@ use tokio::net::TcpStream;
 /// Socket addresses to try in order: IPv4 first, the SRV-correct ones (derived
 /// from azalea's resolution) ahead of the system-resolver fallbacks.
 pub async fn resolve_candidates(server: &ServerAddr) -> Result<Vec<SocketAddr>, ResolveError> {
-    let primary = resolve_address(server).await?;
     let mut candidates: Vec<SocketAddr> = Vec::new();
 
-    // A NAT64-mapped IPv6 (well-known 64:ff9b::/96 prefix) embeds the real IPv4
-    // in its low 32 bits; that IPv4 is reachable even when the NAT64 gateway
-    // isn't. Prefer it, keeping azalea's (SRV-resolved) port.
-    if let IpAddr::V6(v6) = primary.ip()
-        && let Some(v4) = nat64_embedded_ipv4(v6)
-    {
-        candidates.push(SocketAddr::new(IpAddr::V4(v4), primary.port()));
+    // An IP literal needs no DNS; skip azalea's resolution, whose SRV lookup
+    // runs even for literals and stalls badly on resolvers that drop the query.
+    if let Ok(ip) = server.host.parse::<IpAddr>() {
+        push_with_nat64(&mut candidates, SocketAddr::new(ip, server.port));
+        return Ok(candidates);
     }
-    candidates.push(primary);
 
-    // System resolver as a general fallback (covers normal dual-stack hosts).
-    if let Ok(extra) = tokio::net::lookup_host((server.host.as_str(), server.port)).await {
-        candidates.extend(extra);
+    // Bound azalea's SRV-aware resolution so a stalled SRV lookup can't hold
+    // the connection hostage; the system resolver runs concurrently as a
+    // fallback (it also covers `localhost`, which hickory can end up sending
+    // to DNS on Windows).
+    let (primary, extra) = tokio::join!(
+        tokio::time::timeout(Duration::from_secs(2), resolve_address(server)),
+        tokio::net::lookup_host((server.host.as_str(), server.port)),
+    );
+    let primary = primary.unwrap_or_else(|_| Err(ResolveError::from("resolution timed out")));
+    let extra: Vec<SocketAddr> = extra.map(Iterator::collect).unwrap_or_default();
+
+    match primary {
+        Ok(addr) => push_with_nat64(&mut candidates, addr),
+        Err(e) if extra.is_empty() => return Err(e),
+        Err(e) => tracing::warn!(
+            "Resolving {} failed ({e}); using system resolver",
+            server.host
+        ),
     }
+    candidates.extend(extra);
 
     // IPv4 before IPv6 (stable, so the SRV-correct entries stay ahead), deduped.
     candidates.sort_by_key(SocketAddr::is_ipv6);
     let mut seen = HashSet::new();
     candidates.retain(|a| seen.insert(*a));
     Ok(candidates)
+}
+
+/// Push `addr`, preceded by its embedded IPv4 if it's a NAT64-mapped IPv6
+/// (well-known 64:ff9b::/96 prefix): that IPv4 is reachable even when the
+/// NAT64 gateway isn't. Keeps the original (possibly SRV-resolved) port.
+fn push_with_nat64(candidates: &mut Vec<SocketAddr>, addr: SocketAddr) {
+    if let IpAddr::V6(v6) = addr.ip()
+        && let Some(v4) = nat64_embedded_ipv4(v6)
+    {
+        candidates.push(SocketAddr::new(IpAddr::V4(v4), addr.port()));
+    }
+    candidates.push(addr);
 }
 
 /// The IPv4 embedded in a well-known-prefix (`64:ff9b::/96`) NAT64 address.

--- a/pomme-client/src/ui/server_list.rs
+++ b/pomme-client/src/ui/server_list.rs
@@ -153,7 +153,8 @@ async fn ping_server(
         let _ = conn.read().await.map_err(|e| format!("Pong failed: {e}"))?;
         let latency_ms = ping_start.elapsed().as_millis() as u64;
 
-        let motd = format_text_spans(&status.description);
+        // Vanilla MOTD base color: 0x808080.
+        let motd = format_text_spans(&status.description, [0.5, 0.5, 0.5, 1.0]);
         let version = status.version.name.clone();
         let protocol_match = status.version.protocol == azalea_protocol::packets::PROTOCOL_VERSION;
         let (online, max) = (status.players.online, status.players.max);

--- a/pomme-client/src/ui/text.rs
+++ b/pomme-client/src/ui/text.rs
@@ -30,12 +30,10 @@ impl TextSpan {
 }
 
 /// Flatten a `FormattedText` component into styled spans for rendering.
-pub fn format_text_spans(text: &FormattedText) -> Vec<TextSpan> {
-    let white: azalea_chat::style::TextColor = azalea_chat::style::ChatFormatting::White
-        .try_into()
-        .unwrap();
-    let white_style = Style::default().color(white);
-
+///
+/// `base_color` applies wherever the component carries no explicit color,
+/// mirroring vanilla `drawString`'s color argument.
+pub fn format_text_spans(text: &FormattedText, base_color: [f32; 4]) -> Vec<TextSpan> {
     let spans: RefCell<Vec<TextSpan>> = RefCell::new(Vec::new());
     let current_style: RefCell<Option<Style>> = RefCell::new(None);
 
@@ -48,7 +46,9 @@ pub fn format_text_spans(text: &FormattedText) -> Vec<TextSpan> {
             if !t.is_empty() {
                 let style = current_style.borrow();
                 let s = style.as_ref();
-                let color = s.map(style_to_rgba).unwrap_or([1.0, 1.0, 1.0, 1.0]);
+                let color = s
+                    .map(|s| style_to_rgba(s, base_color))
+                    .unwrap_or(base_color);
                 let bold = s.and_then(|s| s.bold).unwrap_or(false);
                 let italic = s.and_then(|s| s.italic).unwrap_or(false);
                 let strikethrough = s.and_then(|s| s.strikethrough).unwrap_or(false);
@@ -66,21 +66,21 @@ pub fn format_text_spans(text: &FormattedText) -> Vec<TextSpan> {
             String::new()
         },
         |_| String::new(),
-        &white_style,
+        &Style::default(),
     );
 
     let result = spans.into_inner();
     if result.is_empty() {
         let plain = format!("{text}");
         if !plain.is_empty() {
-            return vec![TextSpan::new(plain, [0.63, 0.63, 0.63, 1.0])];
+            return vec![TextSpan::new(plain, base_color)];
         }
     }
 
     result
 }
 
-fn style_to_rgba(style: &Style) -> [f32; 4] {
+fn style_to_rgba(style: &Style, base_color: [f32; 4]) -> [f32; 4] {
     if let Some(color) = &style.color {
         let v = color.value;
         [
@@ -90,6 +90,6 @@ fn style_to_rgba(style: &Style) -> [f32; 4] {
             1.0,
         ]
     } else {
-        [1.0, 1.0, 1.0, 1.0]
+        base_color
     }
 }


### PR DESCRIPTION
Fixes the 15-20s server list pings and slow joins for 127.0.0.1/localhost, plus the MOTD description color.

- Skip the SRV lookup for IP literals, bound it at 2s for hostnames, and run the system resolver concurrently as a working fallback
- Render MOTD text with base color 0x808080 instead of white, with formatting codes still overriding per span