### PR TITLE
Legacy skin rendering, slim model support, version label, menu overflow

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -40,7 +40,7 @@ pub type PackDownloadResult = Result<std::path::PathBuf, crate::resource_pack::P
 struct PlayerSkinResult {
     uuid: uuid::Uuid,
     textures: Option<String>,
-    result: Result<(Vec<u8>, u32, u32), String>,
+    result: Result<crate::renderer::SkinData, String>,
 }
 
 /// Queues `pos` and its already-loaded mesh neighborhood (de-duplicated): when
@@ -150,6 +150,7 @@ impl AppCore {
             &data_dirs.game_dir,
             Arc::clone(&tokio_rt),
             user.username.clone(),
+            version.clone(),
             user.access_token.clone(),
         );
 
@@ -288,8 +289,8 @@ impl AppCore {
                 continue;
             }
             match skin.result {
-                Ok((pixels, width, height)) => {
-                    renderer.update_player_entity_skin(&skin.uuid, &pixels, width, height);
+                Ok(data) => {
+                    renderer.update_player_entity_skin(&skin.uuid, &data);
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load entity player skin for {}: {e}", skin.uuid)

--- a/pomme-client/src/renderer/entity_model.rs
+++ b/pomme-client/src/renderer/entity_model.rs
@@ -300,7 +300,13 @@ pub fn bake_baby_pig_model() -> BakedEntityModel {
     bake_model(parts, 32, 32)
 }
 
-pub fn bake_player_model() -> BakedEntityModel {
+/// `slim` is the 3px-wide-arm (Alex) layout; same texture offsets and pivots,
+/// only the arm boxes differ.
+// TODO: jacket/sleeve/pants overlay layers (only the hat is modeled here).
+// TODO: default-skin-by-UUID selection for players without a fetched skin.
+pub fn bake_player_model(slim: bool) -> BakedEntityModel {
+    let arm_w = if slim { 3.0 } else { 4.0 };
+    let right_arm_ox = if slim { -2.0 } else { -3.0 };
     let parts = vec![
         EntityPart {
             name: "head".into(),
@@ -343,8 +349,8 @@ pub fn bake_player_model() -> BakedEntityModel {
             offset: Vec3::new(-5.0, 2.0, 0.0),
             default_rotation: Vec3::ZERO,
             cubes: vec![ModelCube {
-                origin: Vec3::new(-3.0, -2.0, -2.0),
-                size: Vec3::new(4.0, 12.0, 4.0),
+                origin: Vec3::new(right_arm_ox, -2.0, -2.0),
+                size: Vec3::new(arm_w, 12.0, 4.0),
                 tex_offset: (40, 16),
                 deformation: 0.0,
                 mirror: false,
@@ -357,7 +363,7 @@ pub fn bake_player_model() -> BakedEntityModel {
             default_rotation: Vec3::ZERO,
             cubes: vec![ModelCube {
                 origin: Vec3::new(-1.0, -2.0, -2.0),
-                size: Vec3::new(4.0, 12.0, 4.0),
+                size: Vec3::new(arm_w, 12.0, 4.0),
                 tex_offset: (32, 48),
                 deformation: 0.0,
                 mirror: false,

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -297,12 +297,14 @@ impl Renderer {
 
         splash(&mut menu_pipeline, 0.9, "Finalizing...");
 
+        // Wide arms until the profile's skin (and its model flag) is fetched.
         let skin_preview = SkinPreviewPipeline::new(
             &ctx.device,
             swapchain_state.render_pass,
             &ctx.allocator,
             hand_pipeline.skin_view(),
             hand_pipeline.skin_sampler(),
+            false,
         );
 
         let blur_pipeline = BlurPipeline::new(
@@ -1109,47 +1111,43 @@ impl Renderer {
 
     pub fn load_player_skin(&mut self, uuid: &uuid::Uuid, rt: &tokio::runtime::Runtime) {
         let uuid_str = uuid.to_string().replace('-', "");
-        let skin_pixels = rt.block_on(async { fetch_skin_texture(&uuid_str).await });
-        match skin_pixels {
-            Ok((pixels, w, h)) => {
+        let skin = rt.block_on(async { fetch_skin_texture(&uuid_str).await });
+        match skin {
+            Ok(skin) => {
+                // In-flight frames may still reference the old skin texture,
+                // hand mesh, and preview pipeline about to be destroyed.
+                let _ = self.ctx.device.wait_idle();
                 self.hand_pipeline.reload_skin(
                     &self.ctx.device,
                     self.ctx.graphics_queue,
                     self.ctx.command_pool,
                     &self.ctx.allocator,
-                    &pixels,
-                    w,
-                    h,
+                    &skin,
                 );
+                self.skin_preview
+                    .destroy(&self.ctx.device, &self.ctx.allocator);
                 self.skin_preview = SkinPreviewPipeline::new(
                     &self.ctx.device,
                     self.swapchain.render_pass,
                     &self.ctx.allocator,
                     self.hand_pipeline.skin_view(),
                     self.hand_pipeline.skin_sampler(),
+                    skin.slim,
                 );
-                self.update_player_entity_skin(uuid, &pixels, w, h);
+                self.update_player_entity_skin(uuid, &skin);
             }
             Err(e) => tracing::warn!("Failed to load player skin: {e}"),
         }
     }
 
-    pub fn update_player_entity_skin(
-        &mut self,
-        uuid: &uuid::Uuid,
-        pixels: &[u8],
-        width: u32,
-        height: u32,
-    ) {
+    pub fn update_player_entity_skin(&mut self, uuid: &uuid::Uuid, skin: &SkinData) {
         self.entity_renderer.update_player_skin(
             &self.ctx.device,
             self.ctx.graphics_queue,
             self.ctx.command_pool,
             &self.ctx.allocator,
             uuid,
-            pixels,
-            width,
-            height,
+            skin,
         );
     }
 
@@ -1845,7 +1843,16 @@ fn warm_item_meshes(
     }
 }
 
-pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32), String> {
+/// Decoded skin ready for upload: always a 64x64 RGBA sheet (legacy 64x32
+/// skins are converted), plus the profile's arm model.
+pub(crate) struct SkinData {
+    pub pixels: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub slim: bool,
+}
+
+pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<SkinData, String> {
     #[derive(serde::Deserialize)]
     struct SessionProfile {
         properties: Vec<ProfileProperty>,
@@ -1877,12 +1884,18 @@ pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<(Vec<u8>, u32, u32)
 
 pub(crate) async fn fetch_skin_texture_from_profile_property(
     value: &str,
-) -> Result<(Vec<u8>, u32, u32), String> {
-    let skin_url = skin_url_from_texture_property(value)?;
-    fetch_skin_image(&skin_url).await
+) -> Result<SkinData, String> {
+    let (skin_url, slim) = skin_url_from_texture_property(value)?;
+    let (pixels, width, height) = fetch_skin_image(&skin_url).await?;
+    Ok(SkinData {
+        pixels,
+        width,
+        height,
+        slim,
+    })
 }
 
-fn skin_url_from_texture_property(value: &str) -> Result<String, String> {
+fn skin_url_from_texture_property(value: &str) -> Result<(String, bool), String> {
     #[derive(serde::Deserialize)]
     struct TexturesPayload {
         textures: Textures,
@@ -1895,6 +1908,11 @@ fn skin_url_from_texture_property(value: &str) -> Result<String, String> {
     #[derive(serde::Deserialize)]
     struct SkinTexture {
         url: String,
+        metadata: Option<SkinMetadata>,
+    }
+    #[derive(serde::Deserialize)]
+    struct SkinMetadata {
+        model: Option<String>,
     }
 
     use base64::Engine;
@@ -1907,7 +1925,10 @@ fn skin_url_from_texture_property(value: &str) -> Result<String, String> {
     payload
         .textures
         .skin
-        .map(|s| s.url)
+        .map(|s| {
+            let slim = s.metadata.as_ref().and_then(|m| m.model.as_deref()) == Some("slim");
+            (s.url, slim)
+        })
         .ok_or_else(|| "No skin texture".to_string())
 }
 
@@ -1923,7 +1944,100 @@ async fn fetch_skin_image(skin_url: &str) -> Result<(Vec<u8>, u32, u32), String>
     let rgba = img.to_rgba8();
     let w = rgba.width();
     let h = rgba.height();
-    Ok((rgba.into_raw(), w, h))
+    process_legacy_skin(rgba.into_raw(), w, h)
+}
+
+const SKIN_W: u32 = 64;
+
+fn skin_px(x: u32, y: u32) -> usize {
+    ((y * SKIN_W + x) * 4) as usize
+}
+
+/// `SkinTextureDownloader.processLegacySkin`: rejects bad sizes, upgrades
+/// legacy 64x32 sheets to 64x64 by mirroring the right limbs into the modern
+/// left-limb slots, and applies the alpha fixups.
+fn process_legacy_skin(
+    pixels: Vec<u8>,
+    width: u32,
+    height: u32,
+) -> Result<(Vec<u8>, u32, u32), String> {
+    if width != 64 || (height != 32 && height != 64) {
+        return Err(format!(
+            "Discarding incorrectly sized ({width}x{height}) skin texture"
+        ));
+    }
+    let legacy = height == 32;
+    let mut img = if legacy {
+        let mut full = vec![0u8; (SKIN_W * SKIN_W * 4) as usize];
+        full[..pixels.len()].copy_from_slice(&pixels);
+        full
+    } else {
+        pixels
+    };
+
+    if legacy {
+        // (x, y, dx, dy, w, h): mirror the right leg/arm into the left slots.
+        const COPIES: [(u32, u32, i32, i32, u32, u32); 12] = [
+            (4, 16, 16, 32, 4, 4),
+            (8, 16, 16, 32, 4, 4),
+            (0, 20, 24, 32, 4, 12),
+            (4, 20, 16, 32, 4, 12),
+            (8, 20, 8, 32, 4, 12),
+            (12, 20, 16, 32, 4, 12),
+            (44, 16, -8, 32, 4, 4),
+            (48, 16, -8, 32, 4, 4),
+            (40, 20, 0, 32, 4, 12),
+            (44, 20, -8, 32, 4, 12),
+            (48, 20, -16, 32, 4, 12),
+            (52, 20, -8, 32, 4, 12),
+        ];
+        for (x, y, dx, dy, w, h) in COPIES {
+            copy_rect_mirrored(&mut img, x, y, dx, dy, w, h);
+        }
+    }
+    set_no_alpha(&mut img, 0, 0, 32, 16);
+    if legacy {
+        strip_alpha_if_opaque(&mut img, 32, 0, 64, 32);
+    }
+    set_no_alpha(&mut img, 0, 16, 64, 32);
+    set_no_alpha(&mut img, 16, 48, 48, 64);
+    Ok((img, SKIN_W, SKIN_W))
+}
+
+/// `NativeImage.copyRect(x, y, dx, dy, w, h, true, false)`: copies the rect at
+/// (x, y) to (x + dx, y + dy) with each row written right-to-left.
+fn copy_rect_mirrored(img: &mut [u8], x: u32, y: u32, dx: i32, dy: i32, w: u32, h: u32) {
+    for row in 0..h {
+        for col in 0..w {
+            let src = skin_px(x + col, y + row);
+            let dst_x = (x as i32 + dx) as u32 + (w - 1 - col);
+            let dst_y = (y as i32 + dy) as u32 + row;
+            let dst = skin_px(dst_x, dst_y);
+            img.copy_within(src..src + 4, dst);
+        }
+    }
+}
+
+/// Forces the rect fully opaque (base layer regions never carry transparency).
+fn set_no_alpha(img: &mut [u8], x0: u32, y0: u32, x1: u32, y1: u32) {
+    for y in y0..y1 {
+        for x in x0..x1 {
+            img[skin_px(x, y) + 3] = 0xFF;
+        }
+    }
+}
+
+/// The "Notch transparency hack": a fully opaque hat region predates hat
+/// transparency, so strip its alpha entirely instead of drawing a solid box.
+fn strip_alpha_if_opaque(img: &mut [u8], x0: u32, y0: u32, x1: u32, y1: u32) {
+    let all_opaque = (y0..y1).all(|y| (x0..x1).all(|x| img[skin_px(x, y) + 3] >= 128));
+    if all_opaque {
+        for y in y0..y1 {
+            for x in x0..x1 {
+                img[skin_px(x, y) + 3] = 0;
+            }
+        }
+    }
 }
 
 impl Drop for Renderer {
@@ -1993,7 +2107,10 @@ mod tests {
 
         assert_eq!(
             skin_url_from_texture_property(&value).unwrap(),
-            "https://textures.minecraft.net/texture/testskin"
+            (
+                "https://textures.minecraft.net/texture/testskin".into(),
+                false
+            )
         );
     }
 
@@ -2008,7 +2125,80 @@ mod tests {
 
         assert_eq!(
             skin_url_from_texture_property(value).unwrap(),
-            "https://textures.minecraft.net/texture/testskin"
+            (
+                "https://textures.minecraft.net/texture/testskin".into(),
+                false
+            )
         );
+    }
+
+    #[test]
+    fn decodes_slim_model_from_textures_property() {
+        use base64::Engine;
+
+        let payload = r#"{"textures":{"SKIN":{"url":"https://textures.minecraft.net/texture/testskin","metadata":{"model":"slim"}}}}"#;
+        let value = base64::engine::general_purpose::STANDARD.encode(payload);
+
+        assert_eq!(
+            skin_url_from_texture_property(&value).unwrap(),
+            (
+                "https://textures.minecraft.net/texture/testskin".into(),
+                true
+            )
+        );
+    }
+
+    fn set_px(img: &mut [u8], x: u32, y: u32, rgba: [u8; 4]) {
+        img[skin_px(x, y)..skin_px(x, y) + 4].copy_from_slice(&rgba);
+    }
+
+    fn get_px(img: &[u8], x: u32, y: u32) -> [u8; 4] {
+        img[skin_px(x, y)..skin_px(x, y) + 4].try_into().unwrap()
+    }
+
+    #[test]
+    fn rejects_incorrectly_sized_skins() {
+        assert!(process_legacy_skin(vec![0; 128 * 128 * 4], 128, 128).is_err());
+        assert!(process_legacy_skin(vec![0; 64 * 16 * 4], 64, 16).is_err());
+    }
+
+    #[test]
+    fn passes_64x64_skins_through() {
+        let mut img = vec![0u8; 64 * 64 * 4];
+        set_px(&mut img, 20, 50, [1, 2, 3, 200]);
+        let (out, w, h) = process_legacy_skin(img, 64, 64).unwrap();
+        assert_eq!((w, h), (64, 64));
+        // Base region alpha is forced opaque, rgb untouched.
+        assert_eq!(get_px(&out, 20, 50), [1, 2, 3, 255]);
+    }
+
+    #[test]
+    fn converts_legacy_skins_to_64x64() {
+        let mut img = vec![0u8; 64 * 32 * 4];
+        // Right leg front, top-left pixel: (4, 20).
+        set_px(&mut img, 4, 20, [10, 20, 30, 255]);
+        // Right arm front, top-left pixel: (44, 20).
+        set_px(&mut img, 44, 20, [40, 50, 60, 255]);
+        let (out, w, h) = process_legacy_skin(img, 64, 32).unwrap();
+        assert_eq!((w, h), (64, 64));
+
+        // copyRect(4, 20, 16, 32, 4, 12, mirrored): left leg front spans
+        // x 20..24, and mirroring puts the source's left edge on the right.
+        assert_eq!(get_px(&out, 23, 52), [10, 20, 30, 255]);
+        // copyRect(44, 20, -8, 32, 4, 12, mirrored): left arm front x 36..40.
+        assert_eq!(get_px(&out, 39, 52), [40, 50, 60, 255]);
+    }
+
+    #[test]
+    fn strips_alpha_of_fully_opaque_legacy_hat() {
+        let mut img = vec![0u8; 64 * 32 * 4];
+        for y in 0..32 {
+            for x in 32..64 {
+                set_px(&mut img, x, y, [9, 9, 9, 255]);
+            }
+        }
+        let (out, _, _) = process_legacy_skin(img, 64, 32).unwrap();
+        // A fully opaque hat region predates hat transparency: alpha stripped.
+        assert_eq!(get_px(&out, 40, 8)[3], 0);
     }
 }

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -95,6 +95,7 @@ struct PlayerSkinTexture {
     view: vk::ImageView,
     allocation: Allocation,
     set: vk::DescriptorSet,
+    slim: bool,
 }
 
 impl MobEntry {
@@ -221,7 +222,7 @@ struct VariantDef {
 struct MobDef {
     kind: EntityKind,
     anim: AnimationType,
-    adult: VariantDef,
+    adult: Vec<VariantDef>,
     baby: Option<VariantDef>,
     adult_overlays: Vec<VariantDef>,
     baby_overlays: Vec<VariantDef>,
@@ -280,7 +281,7 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Pig,
             anim: AnimationType::Quadruped,
-            adult: opaque(entity_model::bake_pig_model(), PIG_ADULT_TEX, 64),
+            adult: vec![opaque(entity_model::bake_pig_model(), PIG_ADULT_TEX, 64)],
             baby: Some(opaque(
                 entity_model::bake_baby_pig_model(),
                 PIG_BABY_TEX,
@@ -292,7 +293,7 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Cow,
             anim: AnimationType::Quadruped,
-            adult: opaque(entity_model::bake_cow_model(), COW_ADULT_TEX, 64),
+            adult: vec![opaque(entity_model::bake_cow_model(), COW_ADULT_TEX, 64)],
             baby: Some(opaque(
                 entity_model::bake_baby_cow_model(),
                 COW_BABY_TEX,
@@ -304,7 +305,11 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Sheep,
             anim: AnimationType::Quadruped,
-            adult: opaque(entity_model::bake_sheep_model(), SHEEP_ADULT_TEX, 64),
+            adult: vec![opaque(
+                entity_model::bake_sheep_model(),
+                SHEEP_ADULT_TEX,
+                64,
+            )],
             baby: Some(opaque(
                 entity_model::bake_baby_sheep_model(),
                 SHEEP_BABY_TEX,
@@ -327,7 +332,12 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Player,
             anim: AnimationType::Humanoid,
-            adult: opaque(entity_model::bake_player_model(), PLAYER_TEX, 64),
+            // Variant 0 = classic (wide) arms, 1 = slim; picked per player from
+            // the skin's model metadata (effective_variant_index).
+            adult: vec![
+                opaque(entity_model::bake_player_model(false), PLAYER_TEX, 64),
+                opaque(entity_model::bake_player_model(true), PLAYER_TEX, 64),
+            ],
             baby: None,
             adult_overlays: vec![],
             baby_overlays: vec![],
@@ -335,7 +345,7 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Zombie,
             anim: AnimationType::Zombie,
-            adult: opaque(entity_model::bake_zombie_model(), ZOMBIE_TEX, 64),
+            adult: vec![opaque(entity_model::bake_zombie_model(), ZOMBIE_TEX, 64)],
             baby: Some(opaque(
                 entity_model::bake_baby_zombie_model(),
                 ZOMBIE_TEX,
@@ -347,7 +357,11 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Skeleton,
             anim: AnimationType::Skeleton,
-            adult: opaque(entity_model::bake_skeleton_model(), SKELETON_TEX, 64),
+            adult: vec![opaque(
+                entity_model::bake_skeleton_model(),
+                SKELETON_TEX,
+                64,
+            )],
             baby: None,
             adult_overlays: vec![],
             baby_overlays: vec![],
@@ -355,7 +369,7 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Creeper,
             anim: AnimationType::Quadruped,
-            adult: opaque(entity_model::bake_creeper_model(), CREEPER_TEX, 64),
+            adult: vec![opaque(entity_model::bake_creeper_model(), CREEPER_TEX, 64)],
             baby: None,
             // Slot 0: charged-creeper energy swirl (additive, scrolling), shown only
             // when `powered` (gated via overlay_tints in entity_extras).
@@ -370,7 +384,7 @@ fn mob_definitions() -> Vec<MobDef> {
         MobDef {
             kind: EntityKind::Spider,
             anim: AnimationType::Spider,
-            adult: opaque(entity_model::bake_spider_model(), SPIDER_TEX, 64),
+            adult: vec![opaque(entity_model::bake_spider_model(), SPIDER_TEX, 64)],
             baby: None,
             // Slot 0: glowing eyes (translucent, full-bright), always visible.
             adult_overlays: vec![VariantDef {
@@ -422,7 +436,7 @@ impl EntityRenderer {
         let tex_count: u32 = defs
             .iter()
             .map(|d| {
-                let mut n = d.adult.tex_variants.len() as u32;
+                let mut n: u32 = d.adult.iter().map(|v| v.tex_variants.len() as u32).sum();
                 if let Some(b) = &d.baby {
                     n += b.tex_variants.len() as u32;
                 }
@@ -491,7 +505,8 @@ impl EntityRenderer {
                     v,
                 )
             };
-            let adult_variants = build(def.adult);
+            let adult_variants: Vec<MobVariant> =
+                def.adult.into_iter().flat_map(&mut build).collect();
             let baby_variants = def.baby.map(&mut build);
             let adult_overlays: Vec<MobVariant> = def
                 .adult_overlays
@@ -547,7 +562,6 @@ impl EntityRenderer {
             .copy_from_slice(bytes);
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn update_player_skin(
         &mut self,
         device: &vk::Device,
@@ -555,9 +569,7 @@ impl EntityRenderer {
         command_pool: vk::CommandPool,
         allocator: &Arc<Mutex<Allocator>>,
         uuid: &uuid::Uuid,
-        pixels: &[u8],
-        width: u32,
-        height: u32,
+        skin: &crate::renderer::SkinData,
     ) {
         if !self.player_skins.contains_key(uuid) && self.player_skins.len() >= MAX_PLAYER_SKINS {
             tracing::warn!("Player skin cache full; keeping fallback texture for {uuid}");
@@ -569,9 +581,9 @@ impl EntityRenderer {
             queue,
             command_pool,
             allocator,
-            pixels,
-            width,
-            height,
+            &skin.pixels,
+            skin.width,
+            skin.height,
         );
         let set = if let Some(old) = self.player_skins.get(uuid) {
             old.set
@@ -611,6 +623,7 @@ impl EntityRenderer {
                 view,
                 allocation,
                 set,
+                slim: skin.slim,
             },
         ) {
             device.destroy_image_view(old.view, None);
@@ -618,7 +631,11 @@ impl EntityRenderer {
             allocator.lock().unwrap().free(old.allocation).ok();
         }
 
-        tracing::debug!("Player skin loaded for {uuid}: {width}x{height}");
+        tracing::debug!(
+            "Player skin loaded for {uuid}: {}x{}",
+            skin.width,
+            skin.height
+        );
     }
 
     pub fn remove_player_skin(
@@ -639,19 +656,26 @@ impl EntityRenderer {
         }
     }
 
+    fn player_skin(&self, info: &EntityRenderInfo) -> Option<&PlayerSkinTexture> {
+        if info.entity_kind != EntityKind::Player {
+            return None;
+        }
+        self.player_skins.get(info.player_uuid.as_ref()?)
+    }
+
     fn player_texture_set(
         &self,
         info: &EntityRenderInfo,
         fallback: vk::DescriptorSet,
     ) -> vk::DescriptorSet {
-        if info.entity_kind == EntityKind::Player
-            && let Some(uuid) = &info.player_uuid
-            && let Some(skin) = self.player_skins.get(uuid)
-        {
-            skin.set
-        } else {
-            fallback
-        }
+        self.player_skin(info).map_or(fallback, |skin| skin.set)
+    }
+
+    /// Players pick their model variant (0 = wide, 1 = slim) from the fetched
+    /// skin's metadata rather than the caller-supplied index.
+    fn effective_variant_index(&self, info: &EntityRenderInfo) -> u32 {
+        self.player_skin(info)
+            .map_or(info.variant_index, |skin| skin.slim as u32)
     }
 
     fn compute_anim(
@@ -741,7 +765,7 @@ impl EntityRenderer {
                 if !info.skip_cull && !entity_visible(info, frustum, eye, cull_dist_sq) {
                     continue;
                 }
-                let variant = entry.base_variant(info.is_baby, info.variant_index);
+                let variant = entry.base_variant(info.is_baby, self.effective_variant_index(info));
                 let entity_mat = Self::entity_matrix(info);
                 let anim = self.compute_anim(entry.anim, &variant.model, info);
                 vis.push(VisEntity {
@@ -763,7 +787,9 @@ impl EntityRenderer {
                 } else {
                     NO_OVERLAY
                 };
-                let base = v.entry.base_variant(v.info.is_baby, v.info.variant_index);
+                let base = v
+                    .entry
+                    .base_variant(v.info.is_baby, self.effective_variant_index(v.info));
                 let texture_set = self.player_texture_set(v.info, base.texture_set);
                 opaque.add(
                     base,

--- a/pomme-client/src/renderer/pipelines/hand.rs
+++ b/pomme-client/src/renderer/pipelines/hand.rs
@@ -7,7 +7,7 @@ use pomme_gpu_allocator::vulkan::{Allocation, Allocator};
 use pyronyx::vk;
 
 use crate::assets::{AssetIndex, resolve_asset_path};
-use crate::renderer::{MAX_FRAMES_IN_FLIGHT, shader, util};
+use crate::renderer::{MAX_FRAMES_IN_FLIGHT, SkinData, shader, util};
 const NEAR: f32 = 0.05;
 const FAR: f32 = 10.0;
 
@@ -163,16 +163,9 @@ impl HandPipeline {
 
         update_skin_descriptor(device, skin_set, skin_view, skin_sampler);
 
-        let vertices = build_arm_vertices(skin_w, skin_h);
-        let vertex_count = vertices.len() as u32;
-        let vertex_bytes = bytemuck::cast_slice::<HandVertex, u8>(&vertices);
-        let (vertex_buffer, vertex_allocation) = util::create_mapped_buffer(
-            device,
-            allocator,
-            vertex_bytes,
-            vk::BufferUsageFlags::VertexBuffer,
-            "hand_vertices",
-        );
+        // Wide arms until the profile's skin (and its model flag) is fetched.
+        let (vertex_buffer, vertex_allocation, vertex_count) =
+            create_arm_vertex_buffer(device, allocator, skin_w, skin_h, false);
 
         tracing::info!(
             "Hand pipeline initialized ({vertex_count} vertices, skin {skin_w}x{skin_h})"
@@ -261,25 +254,22 @@ impl HandPipeline {
         self.skin_sampler
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn reload_skin(
         &mut self,
         device: &vk::Device,
         queue: vk::Queue,
         command_pool: vk::CommandPool,
         allocator: &Arc<Mutex<Allocator>>,
-        pixels: &[u8],
-        width: u32,
-        height: u32,
+        skin: &SkinData,
     ) {
         let (image, view, allocation) = upload_skin_to_gpu(
             device,
             queue,
             command_pool,
             allocator,
-            pixels,
-            width,
-            height,
+            &skin.pixels,
+            skin.width,
+            skin.height,
         );
 
         device.destroy_image_view(self.skin_view, None);
@@ -297,7 +287,26 @@ impl HandPipeline {
         self.skin_allocation = allocation;
         update_skin_descriptor(device, self.skin_set, self.skin_view, self.skin_sampler);
 
-        tracing::info!("Skin reloaded: {width}x{height}");
+        device.destroy_buffer(self.vertex_buffer, None);
+        allocator
+            .lock()
+            .unwrap()
+            .free(std::mem::replace(&mut self.vertex_allocation, unsafe {
+                std::mem::zeroed()
+            }))
+            .ok();
+        let (vertex_buffer, vertex_allocation, vertex_count) =
+            create_arm_vertex_buffer(device, allocator, skin.width, skin.height, skin.slim);
+        self.vertex_buffer = vertex_buffer;
+        self.vertex_allocation = vertex_allocation;
+        self.vertex_count = vertex_count;
+
+        tracing::info!(
+            "Skin reloaded: {}x{} (slim: {})",
+            skin.width,
+            skin.height,
+            skin.slim
+        );
     }
 
     pub fn recreate_pipeline(&mut self, device: &vk::Device, render_pass: vk::RenderPass) {
@@ -354,23 +363,43 @@ pub(super) fn projection(aspect: f32) -> Mat4 {
     proj
 }
 
-fn build_arm_vertices(skin_w: u32, skin_h: u32) -> Vec<HandVertex> {
+fn create_arm_vertex_buffer(
+    device: &vk::Device,
+    allocator: &Arc<Mutex<Allocator>>,
+    skin_w: u32,
+    skin_h: u32,
+    slim: bool,
+) -> (vk::Buffer, Allocation, u32) {
+    let vertices = build_arm_vertices(skin_w, skin_h, slim);
+    let vertex_bytes = bytemuck::cast_slice::<HandVertex, u8>(&vertices);
+    let (buffer, allocation) = util::create_mapped_buffer(
+        device,
+        allocator,
+        vertex_bytes,
+        vk::BufferUsageFlags::VertexBuffer,
+        "hand_vertices",
+    );
+    (buffer, allocation, vertices.len() as u32)
+}
+
+fn build_arm_vertices(skin_w: u32, skin_h: u32, slim: bool) -> Vec<HandVertex> {
     let sw = skin_w as f32;
     let sh = skin_h as f32;
 
-    // Vanilla addBox(-3, -2, -2, 4, 12, 4) scaled to blocks (1/16).
+    // Vanilla right arm addBox(-3, -2, -2, 4, 12, 4), or the slim layout's
+    // addBox(-2, -2, -2, 3, 12, 4), scaled to blocks (1/16).
     // Model space is Y-down: y0 is the shoulder end, y1 the hand end.
-    let x0: f32 = -3.0 / 16.0;
-    let x1: f32 = 1.0 / 16.0;
+    let w = if slim { 3.0 } else { 4.0 };
+    let x0: f32 = if slim { -2.0 } else { -3.0 } / 16.0;
+    let x1: f32 = x0 + w / 16.0;
     let y0: f32 = -2.0 / 16.0;
     let y1: f32 = 10.0 / 16.0;
     let z0: f32 = -2.0 / 16.0;
     let z1: f32 = 2.0 / 16.0;
 
-    // texOffs(40, 16) on Steve skin, box dimensions w=4 h=12 d=4
+    // texOffs(40, 16), box dimensions h=12 d=4
     let u0 = 40.0;
     let v0 = 16.0;
-    let w = 4.0;
     let h = 12.0;
     let d = 4.0;
 

--- a/pomme-client/src/renderer/pipelines/skin_preview.rs
+++ b/pomme-client/src/renderer/pipelines/skin_preview.rs
@@ -55,6 +55,7 @@ impl SkinPreviewPipeline {
         allocator: &Arc<Mutex<Allocator>>,
         skin_view: vk::ImageView,
         skin_sampler: vk::Sampler,
+        slim: bool,
     ) -> Self {
         let mvp_layout = util::create_descriptor_set_layout(
             device,
@@ -238,7 +239,7 @@ impl SkinPreviewPipeline {
         };
         device.update_descriptor_sets(&[tex_write], &[]);
 
-        let body_verts = build_body_mesh();
+        let body_verts = build_body_mesh(slim);
         let body_bytes = bytemuck::cast_slice(&body_verts);
         let (body_buffer, body_allocation) = util::create_mapped_buffer(
             device,
@@ -248,7 +249,7 @@ impl SkinPreviewPipeline {
             "skin_body",
         );
 
-        let arm_verts = build_right_arm_mesh();
+        let arm_verts = build_right_arm_mesh(slim);
         let arm_bytes = bytemuck::cast_slice(&arm_verts);
         let (arm_buffer, arm_allocation) = util::create_mapped_buffer(
             device,
@@ -781,9 +782,11 @@ fn build_head_mesh() -> Vec<Vertex> {
     v
 }
 
-fn build_body_mesh() -> Vec<Vertex> {
+fn build_body_mesh(slim: bool) -> Vec<Vertex> {
     let mut v = Vec::new();
     let e = 0.25; // overlay inflation for body/limbs
+    let arm_tw: u32 = if slim { 3 } else { 4 };
+    let arm_w = arm_tw as f32;
 
     // Body: addBox(-4, 0, -2, 8, 12, 4) @ (0, 0, 0), UV (16, 16)
     add_box(
@@ -808,9 +811,9 @@ fn build_body_mesh() -> Vec<Vertex> {
         4,
     );
 
-    // Left arm: addBox(-1, -2, -2, 4, 12, 4) @ (5, 2, 0), UV (32, 48)
+    // Left arm: addBox(-1, -2, -2, 4|3, 12, 4) @ (5, 2, 0), UV (32, 48)
     add_box(
-        &mut v, 5.0, 2.0, 0.0, -1.0, -2.0, -2.0, 4.0, 12.0, 4.0, 32, 48, 4, 12, 4,
+        &mut v, 5.0, 2.0, 0.0, -1.0, -2.0, -2.0, arm_w, 12.0, 4.0, 32, 48, arm_tw, 12, 4,
     );
     // Left sleeve overlay: UV (48, 48)
     add_box(
@@ -821,12 +824,12 @@ fn build_body_mesh() -> Vec<Vertex> {
         -1.0 - e,
         -2.0 - e,
         -2.0 - e,
-        4.0 + e * 2.0,
+        arm_w + e * 2.0,
         12.0 + e * 2.0,
         4.0 + e * 2.0,
         48,
         48,
-        4,
+        arm_tw,
         12,
         4,
     );
@@ -879,26 +882,31 @@ fn build_body_mesh() -> Vec<Vertex> {
     v
 }
 
-fn build_right_arm_mesh() -> Vec<Vertex> {
+fn build_right_arm_mesh(slim: bool) -> Vec<Vertex> {
     let mut v = Vec::new();
     let e = 0.25;
+    let arm_tw: u32 = if slim { 3 } else { 4 };
+    let arm_w = arm_tw as f32;
+    let ox = if slim { -2.0 } else { -3.0 };
+    // Right arm: addBox(-3|-2, -2, -2, 4|3, 12, 4) @ (-5, 2, 0), UV (40, 16)
     add_box(
-        &mut v, -5.0, 2.0, 0.0, -3.0, -2.0, -2.0, 4.0, 12.0, 4.0, 40, 16, 4, 12, 4,
+        &mut v, -5.0, 2.0, 0.0, ox, -2.0, -2.0, arm_w, 12.0, 4.0, 40, 16, arm_tw, 12, 4,
     );
+    // Right sleeve overlay: UV (40, 32)
     add_box(
         &mut v,
         -5.0,
         2.0,
         0.0,
-        -3.0 - e,
+        ox - e,
         -2.0 - e,
         -2.0 - e,
-        4.0 + e * 2.0,
+        arm_w + e * 2.0,
         12.0 + e * 2.0,
         4.0 + e * 2.0,
         40,
         32,
-        4,
+        arm_tw,
         12,
         4,
     );

--- a/pomme-client/src/ui/friends.rs
+++ b/pomme-client/src/ui/friends.rs
@@ -151,10 +151,12 @@ pub fn refresh_friends(
                     }
                     let faces = Arc::clone(&faces);
                     rt.spawn(async move {
-                        if let Ok((rgba, w, h)) = crate::renderer::fetch_skin_texture(&uuid).await
+                        if let Ok(skin) = crate::renderer::fetch_skin_texture(&uuid).await
                             && let Some(face) =
                                 crate::renderer::pipelines::menu_overlay::extract_face_8x8(
-                                    &rgba, w, h,
+                                    &skin.pixels,
+                                    skin.width,
+                                    skin.height,
                                 )
                         {
                             faces.write().insert(uuid, face);

--- a/pomme-client/src/ui/menu/helpers.rs
+++ b/pomme-client/src/ui/menu/helpers.rs
@@ -428,6 +428,7 @@ pub(super) fn push_bottom_text(
     screen_w: f32,
     screen_h: f32,
     gs: f32,
+    version: &str,
     text_width_fn: &dyn Fn(&str, f32) -> f32,
 ) {
     let fs = 7.0 * gs;
@@ -438,7 +439,7 @@ pub(super) fn push_bottom_text(
     elements.push(MenuElement::Text {
         x: pad,
         y,
-        text: "Minecraft 1.21.11".into(),
+        text: format!("Minecraft {version}"),
         scale: fs,
         color: col,
         centered: false,

--- a/pomme-client/src/ui/menu/main_screen.rs
+++ b/pomme-client/src/ui/menu/main_screen.rs
@@ -52,7 +52,9 @@ impl MainMenu {
             },
         ];
 
-        let s = (screen_h / 400.0).max(1.0);
+        // Clamp by width too: past this the panel width clamp would bind and
+        // text scaled by height alone would outgrow the panel.
+        let s = (screen_h / 400.0).max(1.0).min(screen_w * 0.4 / 260.0);
         let panel_w = (260.0 * s).min(screen_w * 0.4);
         let panel_pad = 28.0 * s;
         let panel_r = 14.0 * s;
@@ -492,7 +494,7 @@ impl MainMenu {
         elements.push(MenuElement::Text {
             x: footer_pad,
             y: footer_y,
-            text: "1.21.11".into(),
+            text: self.version.clone(),
             scale: footer_size,
             color: footer_col,
             centered: false,

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -319,6 +319,7 @@ fn atlas_dirty(count: usize, last: &mut usize, since: &mut Option<Instant>) -> b
 
 pub struct MainMenu {
     username: String,
+    version: String,
     screen: Screen,
     server_list: ServerList,
     selected_server: Option<usize>,
@@ -406,6 +407,7 @@ impl MainMenu {
         game_dir: &Path,
         rt: Arc<tokio::runtime::Runtime>,
         username: String,
+        version: String,
         access_token: Option<String>,
     ) -> Self {
         let server_list = ServerList::load(game_dir);
@@ -414,6 +416,7 @@ impl MainMenu {
         let settings = load_settings(game_dir);
         Self {
             username,
+            version,
             screen: Screen::Main,
             server_list,
             selected_server: None,

--- a/pomme-client/src/ui/menu/servers.rs
+++ b/pomme-client/src/ui/menu/servers.rs
@@ -465,7 +465,14 @@ impl MainMenu {
             self.set_screen(Screen::Main);
         }
 
-        push_bottom_text(&mut elements, screen_w, screen_h, gs, text_width_fn);
+        push_bottom_text(
+            &mut elements,
+            screen_w,
+            screen_h,
+            gs,
+            &self.version,
+            text_width_fn,
+        );
         MainMenuResult {
             elements,
             action,
@@ -563,7 +570,14 @@ impl MainMenu {
             self.set_screen(Screen::ServerList);
         }
 
-        push_bottom_text(&mut elements, screen_w, screen_h, gs, text_width_fn);
+        push_bottom_text(
+            &mut elements,
+            screen_w,
+            screen_h,
+            gs,
+            &self.version,
+            text_width_fn,
+        );
         MainMenuResult {
             elements,
             action: MenuAction::None,
@@ -683,7 +697,14 @@ impl MainMenu {
             self.set_screen(Screen::ServerList);
         }
 
-        push_bottom_text(&mut elements, screen_w, screen_h, gs, text_width_fn);
+        push_bottom_text(
+            &mut elements,
+            screen_w,
+            screen_h,
+            gs,
+            &self.version,
+            text_width_fn,
+        );
         MainMenuResult {
             elements,
             action,
@@ -839,7 +860,14 @@ impl MainMenu {
             self.set_screen(Screen::ServerList);
         }
 
-        push_bottom_text(&mut elements, screen_w, screen_h, gs, text_width_fn);
+        push_bottom_text(
+            &mut elements,
+            screen_w,
+            screen_h,
+            gs,
+            &self.version,
+            text_width_fn,
+        );
         MainMenuResult {
             elements,
             action: MenuAction::None,

--- a/pomme-launcher/src/styles.css
+++ b/pomme-launcher/src/styles.css
@@ -366,7 +366,8 @@ body {
   height: 28px;
   border-radius: 4px;
   image-rendering: pixelated;
-  background-size: 800% 800%;
+  /* auto height keeps legacy 64x32 skins from stretching to a square */
+  background-size: 800% auto;
   background-position: -28px -28px;
   background-color: #555;
 }
@@ -622,7 +623,7 @@ body {
 .mc-head-sm {
   width: 24px;
   height: 24px;
-  background-size: 192px 192px;
+  background-size: 192px auto;
   background-position: -24px -24px;
 }
 


### PR DESCRIPTION
- Legacy 64x32 skins are converted to the modern 64x64 layout on download (port of SkinTextureDownloader.processLegacySkin, with unit tests), fixing the scrambled menu preview and in-game rendering for old-format skins
- Slim (Alex) arm model parsed from the skin's textures metadata and applied to the menu preview, first person arm, and player entities
- Launcher face CSS no longer stretches 64x32 skins to a square
- Main menu and server screens show the launched version instead of hardcoded 1.21.11
- Main menu scale is clamped by width so the title and buttons no longer overflow on narrow windows

Also fixes a GPU resource leak when the skin preview pipeline is rebuilt after skin fetch.

TODOs left in code: jacket/sleeve/pants overlay layers on the entity player model, default-skin-by-UUID selection.