### PR TITLE
Bump glam to 0.33.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.33.1"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "glib"

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -1,3 +1,4 @@
+use glam::camera::rh::{proj, view};
 use glam::{FloatExt, Mat4, Vec3};
 
 use crate::app::input::InputState;
@@ -319,8 +320,8 @@ impl Camera {
 
     pub fn sky_view_projection(&self) -> Mat4 {
         let (forward, up) = self.view_basis();
-        let view = Mat4::look_to_rh(Vec3::ZERO, forward, up);
-        let mut proj = Mat4::perspective_rh(
+        let view = view::look_to_mat4(Vec3::ZERO, forward, up);
+        let mut proj = proj::directx::perspective(
             self.fov_radians(self.render_partial_tick),
             self.aspect_ratio,
             NEAR,
@@ -336,8 +337,8 @@ impl Camera {
     /// pitch test.
     pub fn view_rotation_projection(&self) -> Mat4 {
         let (forward, up) = self.view_basis();
-        let view = Mat4::look_to_rh(Vec3::ZERO, forward, up);
-        let proj = Mat4::perspective_rh_gl(
+        let view = view::look_to_mat4(Vec3::ZERO, forward, up);
+        let proj = proj::opengl::perspective(
             self.fov_radians(self.render_partial_tick),
             self.aspect_ratio,
             NEAR,
@@ -365,8 +366,8 @@ impl Camera {
     pub fn view_projection_with_fov(&self, fov: f32) -> Mat4 {
         let offset = self.third_person_offset();
         let (forward, up) = self.view_basis();
-        let view = self.bob_matrix() * Mat4::look_to_rh(offset, forward, up);
-        let mut proj = Mat4::perspective_rh(fov, self.aspect_ratio, NEAR, FAR);
+        let view = self.bob_matrix() * view::look_to_mat4(offset, forward, up);
+        let mut proj = proj::directx::perspective(fov, self.aspect_ratio, NEAR, FAR);
         proj.y_axis.y *= -1.0; // Vulkan NDC has +Y down
         proj * view
     }

--- a/pomme-client/src/renderer/pipelines/gui_item.rs
+++ b/pomme-client/src/renderer/pipelines/gui_item.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
+use glam::camera::rh::proj;
 use glam::{Mat4, Vec3};
 use pomme_gpu_allocator::vulkan::{Allocation, Allocator};
 use pyronyx::vk;
@@ -199,7 +200,8 @@ impl GuiItemPipeline {
     fn write_atlas_ortho(&mut self, atlas_px: f32) {
         // Bottom/top swapped to Y-invert the projection (matches vanilla's
         // `invertY=true`).
-        let view_proj = Mat4::orthographic_rh(0.0, atlas_px, atlas_px, 0.0, -10000.0, 10000.0);
+        let view_proj =
+            proj::directx::orthographic(0.0, atlas_px, atlas_px, 0.0, -10000.0, 10000.0);
         let uniform = CameraUniform::with_view_proj(view_proj);
         let bytes = bytemuck::bytes_of(&uniform);
         if let Some(alloc) = self.camera_alloc.as_mut() {

--- a/pomme-client/src/renderer/pipelines/hand.rs
+++ b/pomme-client/src/renderer/pipelines/hand.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
+use glam::camera::rh::proj;
 use glam::{Mat4, Vec3};
 use pomme_gpu_allocator::vulkan::{Allocation, Allocator};
 use pyronyx::vk;
@@ -353,7 +354,7 @@ impl HandPipeline {
 }
 
 pub(super) fn projection(aspect: f32) -> Mat4 {
-    let mut proj = Mat4::perspective_rh(
+    let mut proj = proj::directx::perspective(
         crate::renderer::camera::DEFAULT_FOV_DEGREES.to_radians(),
         aspect,
         NEAR,

--- a/pomme-client/src/renderer/pipelines/skin_preview.rs
+++ b/pomme-client/src/renderer/pipelines/skin_preview.rs
@@ -1,6 +1,7 @@
 use std::slice;
 use std::sync::{Arc, Mutex};
 
+use glam::camera::rh::{proj, view};
 use glam::{Mat4, Vec3};
 use pomme_gpu_allocator::vulkan::{Allocation, Allocator};
 use pyronyx::vk;
@@ -329,7 +330,7 @@ impl SkinPreviewPipeline {
         let head_x_rot_rad = head_x_rot_raw * 20.0f32.to_radians();
 
         let fov = 0.6f32;
-        let mut proj = Mat4::perspective_rh(fov, aspect, 0.1, 100.0);
+        let mut proj = proj::directx::perspective(fov, aspect, 0.1, 100.0);
         proj.y_axis.y *= -1.0;
 
         let ndc_x = screen_x * 2.0 - 1.0;
@@ -368,7 +369,7 @@ impl SkinPreviewPipeline {
         let units_to_px = 30.0 * p.gui_scale;
         let half_w = sw / (2.0 * units_to_px);
         let half_h = sh / (2.0 * units_to_px);
-        let mut proj = Mat4::orthographic_rh(-half_w, half_w, -half_h, half_h, 0.1, 100.0);
+        let mut proj = proj::directx::orthographic(-half_w, half_w, -half_h, half_h, 0.1, 100.0);
         proj.y_axis.y *= -1.0;
 
         let clip_offset =
@@ -522,7 +523,7 @@ impl SkinPreviewPipeline {
 }
 
 fn camera_view() -> Mat4 {
-    Mat4::look_at_rh(Vec3::new(0.0, 0.0, -4.5), Vec3::ZERO, Vec3::Y)
+    view::look_at_mat4(Vec3::new(0.0, 0.0, -4.5), Vec3::ZERO, Vec3::Y)
 }
 
 pub(crate) fn write_uniform(alloc: &mut Allocation, mvp: &Mat4) {


### PR DESCRIPTION
Replaces #348, which fails CI: 0.33.2 deprecates the Mat4 view/projection constructors and clippy's -D warnings rejects them. Migrates the 11 call sites to the glam::camera free functions; the directx module keeps the old 0..1 depth convention, so the math is unchanged.