### PR TITLE
Fix startup skin fetch warning for offline identities

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -266,6 +266,12 @@ impl AppCore {
         }
         self.requested_player_skins.insert(uuid, textures.clone());
 
+        // Name-derived (v3) UUIDs from offline-mode servers have no Mojang
+        // profile to fetch; keep the default skin.
+        if textures.is_none() && uuid.get_version_num() == 3 {
+            return;
+        }
+
         let tx = self.player_skin_tx.clone();
         let requested_textures = textures.clone();
         self.tokio_rt.spawn(async move {

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -118,7 +118,7 @@ impl App {
         Self {
             phase: StateSlot::new(AppPhase::Setup {
                 quick_access_multiplayer,
-                pending_skin_uuid: user.online.then_some(user.uuid),
+                pending_skin_uuid: user.has_profile.then_some(user.uuid),
             }),
             core: AppCore::new(version, data_dirs, tokio_rt, presence, user),
             occluded: false,

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -118,7 +118,7 @@ impl App {
         Self {
             phase: StateSlot::new(AppPhase::Setup {
                 quick_access_multiplayer,
-                pending_skin_uuid: Some(user.uuid),
+                pending_skin_uuid: user.online.then_some(user.uuid),
             }),
             core: AppCore::new(version, data_dirs, tokio_rt, presence, user),
             occluded: false,

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -2003,8 +2003,11 @@ fn error_chain(e: impl std::error::Error) -> String {
     let mut msg = e.to_string();
     let mut source = e.source();
     while let Some(s) = source {
-        msg.push_str(": ");
-        msg.push_str(&s.to_string());
+        let text = s.to_string();
+        if !msg.contains(&text) {
+            msg.push_str(": ");
+            msg.push_str(&text);
+        }
         source = s.source();
     }
     msg

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1923,12 +1923,19 @@ pub(crate) async fn fetch_skin_texture(uuid: &str) -> Result<SkinData, String> {
     }
 
     let url = format!("https://sessionserver.mojang.com/session/minecraft/profile/{uuid}");
-    let profile: SessionProfile = reqwest::get(&url)
-        .await
-        .map_err(|e| e.to_string())?
+    let response = reqwest::get(&url).await.map_err(error_chain)?;
+    if matches!(
+        response.status(),
+        reqwest::StatusCode::NO_CONTENT | reqwest::StatusCode::NOT_FOUND
+    ) {
+        return Err(format!("no profile for {uuid}"));
+    }
+    let profile: SessionProfile = response
+        .error_for_status()
+        .map_err(error_chain)?
         .json()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(error_chain)?;
 
     let value = &profile
         .properties
@@ -1978,8 +1985,8 @@ fn skin_url_from_texture_property(value: &str) -> Result<(String, bool), String>
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(value)
         .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(value))
-        .map_err(|e| e.to_string())?;
-    let payload: TexturesPayload = serde_json::from_slice(&decoded).map_err(|e| e.to_string())?;
+        .map_err(error_chain)?;
+    let payload: TexturesPayload = serde_json::from_slice(&decoded).map_err(error_chain)?;
 
     payload
         .textures
@@ -1991,15 +1998,29 @@ fn skin_url_from_texture_property(value: &str) -> Result<(String, bool), String>
         .ok_or_else(|| "No skin texture".to_string())
 }
 
+/// Error message including the source chain (`reqwest` hides the detail there).
+fn error_chain(e: impl std::error::Error) -> String {
+    let mut msg = e.to_string();
+    let mut source = e.source();
+    while let Some(s) = source {
+        msg.push_str(": ");
+        msg.push_str(&s.to_string());
+        source = s.source();
+    }
+    msg
+}
+
 async fn fetch_skin_image(skin_url: &str) -> Result<(Vec<u8>, u32, u32), String> {
     let skin_bytes = reqwest::get(skin_url)
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(error_chain)?
+        .error_for_status()
+        .map_err(error_chain)?
         .bytes()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(error_chain)?;
 
-    let img = image::load_from_memory(&skin_bytes).map_err(|e| e.to_string())?;
+    let img = image::load_from_memory(&skin_bytes).map_err(error_chain)?;
     let rgba = img.to_rgba8();
     let w = rgba.width();
     let h = rgba.height();

--- a/pomme-client/src/user.rs
+++ b/pomme-client/src/user.rs
@@ -4,7 +4,7 @@ pub struct UserData {
     pub access_token: Option<String>,
     /// True when `uuid` is a launcher-supplied profile UUID rather than a
     /// synthesized offline one (which has no Mojang profile to fetch).
-    pub online: bool,
+    pub has_profile: bool,
 }
 
 impl UserData {
@@ -16,14 +16,14 @@ impl UserData {
         let username = username.unwrap_or_else(|| "Steve".to_string());
 
         let uuid = uuid.and_then(|s| uuid::Uuid::parse_str(&s).ok());
-        let online = uuid.is_some();
+        let has_profile = uuid.is_some();
         let uuid = uuid.unwrap_or_else(|| Self::offline_uuid(&username));
 
         Self {
             username,
             uuid,
             access_token,
-            online,
+            has_profile,
         }
     }
 

--- a/pomme-client/src/user.rs
+++ b/pomme-client/src/user.rs
@@ -2,6 +2,9 @@ pub struct UserData {
     pub username: String,
     pub uuid: uuid::Uuid,
     pub access_token: Option<String>,
+    /// True when `uuid` is a launcher-supplied profile UUID rather than a
+    /// synthesized offline one (which has no Mojang profile to fetch).
+    pub online: bool,
 }
 
 impl UserData {
@@ -12,14 +15,15 @@ impl UserData {
     ) -> Self {
         let username = username.unwrap_or_else(|| "Steve".to_string());
 
-        let uuid = uuid
-            .and_then(|s| uuid::Uuid::parse_str(&s).ok())
-            .unwrap_or_else(|| Self::offline_uuid(&username));
+        let uuid = uuid.and_then(|s| uuid::Uuid::parse_str(&s).ok());
+        let online = uuid.is_some();
+        let uuid = uuid.unwrap_or_else(|| Self::offline_uuid(&username));
 
         Self {
             username,
             uuid,
             access_token,
+            online,
         }
     }
 


### PR DESCRIPTION
Skip the skin fetch for offline identities and surface HTTP status and error source chain in skin fetch failures.