### PR TITLE
Support joining 1.21.10 servers

### DIFF
--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -447,14 +447,17 @@ fn translate_set_time_774() {
     assert_eq!(clock.rate, 1.0);
 }
 
-/// 1.21.11 has no serverbound `attack`; the frame becomes an `interact`
-/// with the ATTACK action (`ServerboundInteractPacket` action bodies in the
-/// 1.21.11 reference).
+/// Neither 1.21.11 nor 1.21.10 has a serverbound `attack`; the frame
+/// becomes an `interact` with the ATTACK action (`ServerboundInteractPacket`
+/// action bodies in the references), through each version's id table.
 #[test]
-fn translate_attack_774() {
-    let frames = translation_for(774).translate_outbound_game_frame(wire::encode_attack(42));
-    let interact = old_id(774, Direction::Serverbound, "interact");
-    assert_eq!(frames, [[interact as u8, 42, 1, 0]]);
+fn translate_attack_old_versions() {
+    for protocol in [774, 773] {
+        let frames =
+            translation_for(protocol).translate_outbound_game_frame(wire::encode_attack(42));
+        let interact = old_id(protocol, Direction::Serverbound, "interact");
+        assert_eq!(frames, [[interact as u8, 42, 1, 0]], "{protocol}");
+    }
 }
 
 /// A 26.2 `interact` (hand + LpVec3 location) becomes the 1.21.11 pair a
@@ -562,15 +565,6 @@ fn translate_horse_screen_open_773() {
     assert_eq!(p.container_id, 1);
     assert_eq!(p.inventory_columns, 3);
     assert_eq!(p.entity_id, MinecraftEntityId(42));
-}
-
-/// 1.21.10, like 1.21.11, has no serverbound `attack`; the same reroute to
-/// `interact` with the ATTACK action applies through its own id table.
-#[test]
-fn translate_attack_773() {
-    let frames = translation_for(773).translate_outbound_game_frame(wire::encode_attack(42));
-    let interact = old_id(773, Direction::Serverbound, "interact");
-    assert_eq!(frames, [[interact as u8, 42, 1, 0]]);
 }
 
 #[test]

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -62,17 +62,33 @@ fn decode_lp_vec3(bytes: &[u8]) -> DVec3 {
     DVec3::new(v.x, v.y, v.z)
 }
 
-/// The 26.1 -> 26.2 translation under test; 26.1 wire layouts below are
-/// hand-built from the decompiled reference codecs
-/// (`reference/26.1/decompiled/.../network/protocol/`).
-fn translation() -> crate::net::translate::Translation {
-    crate::net::translate::Translation::for_protocol(775).expect("26.1 translation data")
+/// The wire translation under test for one protocol; the old-layout frames
+/// in the tests below are hand-built from that version's decompiled
+/// reference codecs (`reference/<version>/decompiled/.../network/`).
+fn translation_for(protocol: i32) -> crate::net::translate::Translation {
+    crate::net::translate::Translation::for_protocol(protocol).expect("translation data")
+}
+
+fn old_id(protocol: i32, dir: Direction, name: &str) -> u32 {
+    PacketTable::for_protocol(protocol)
+        .unwrap()
+        .id(Phase::Game, dir, name)
+        .unwrap()
+}
+
+/// Translates a hand-built old-version game frame and decodes the result
+/// with azalea's 26.2 codecs.
+fn translate_and_decode(protocol: i32, old: Vec<u8>) -> ClientboundGamePacket {
+    let translated = translation_for(protocol)
+        .translate_game_frame(old.into_boxed_slice())
+        .unwrap();
+    azalea_protocol::read::deserialize_packet(&mut std::io::Cursor::new(&translated)).unwrap()
 }
 
 /// Protocols outside `TRANSLATED` never build a translation.
 #[test]
 fn no_translation_without_coverage() {
-    assert!(crate::net::translate::Translation::for_protocol(773).is_none());
+    assert!(crate::net::translate::Translation::for_protocol(772).is_none());
 }
 
 /// 26.2 appended a trailing session-id UUID to login_finished
@@ -94,7 +110,7 @@ fn translate_login_finished_26_1() {
     // A 26.1 frame is the same bytes without the trailing UUID.
     let old = frame[..frame.len() - 16].to_vec().into_boxed_slice();
 
-    let translated = translation().translate_login_frame(old);
+    let translated = translation_for(775).translate_login_frame(old);
     let decoded: ClientboundLoginPacket =
         azalea_protocol::read::deserialize_packet(&mut std::io::Cursor::new(&translated)).unwrap();
     let ClientboundLoginPacket::LoginFinished(decoded) = decoded else {
@@ -148,7 +164,7 @@ fn translate_game_login_26_1() {
     let mut old = frame.to_vec();
     old.remove(old.len() - 2);
 
-    let translated = translation()
+    let translated = translation_for(775)
         .translate_game_frame(old.into_boxed_slice())
         .unwrap();
     assert_eq!(&translated[..], &frame[..]);
@@ -179,7 +195,7 @@ fn translate_set_player_team_26_1() {
     old.extend_from_slice(prefix);
     old.extend_from_slice(suffix);
 
-    let translated = translation()
+    let translated = translation_for(775)
         .translate_game_frame(old.into_boxed_slice())
         .unwrap();
 
@@ -217,7 +233,7 @@ fn translate_set_player_team_26_1_reset_color() {
     old.extend_from_slice(component);
     old.extend_from_slice(&[1, 3, b'b', b'o', b'b']); // player list
 
-    let translated = translation()
+    let translated = translation_for(775)
         .translate_game_frame(old.into_boxed_slice())
         .unwrap();
 
@@ -282,7 +298,7 @@ fn remap_add_entity_26_1() {
         y_head_rot: 0,
         data: 0,
     });
-    assert!(translation().remap_inbound(&mut packet));
+    assert!(translation_for(775).remap_inbound(&mut packet));
     let ClientboundGamePacket::AddEntity(p) = &packet else {
         unreachable!()
     };
@@ -314,7 +330,7 @@ fn strip_creative_components_26_1() {
                     component_patch: patch,
                 }),
             });
-        translation().remap_outbound(&mut packet);
+        translation_for(775).remap_outbound(&mut packet);
         let ServerboundGamePacket::SetCreativeModeSlot(p) = packet else {
             unreachable!()
         };
@@ -330,47 +346,24 @@ fn strip_creative_components_26_1() {
     assert_eq!(remap(DataComponentKind::Lock).iter().count(), 0);
 }
 
-/// The 1.21.11 -> 26.2 translation under test; 1.21.11 wire layouts below
-/// are hand-built from the decompiled reference codecs
-/// (`reference/1.21.11/decompiled/.../network/`).
-fn translation_774() -> crate::net::translate::Translation {
-    crate::net::translate::Translation::for_protocol(774).expect("1.21.11 translation data")
-}
-
-fn old_id_774(dir: Direction, name: &str) -> u32 {
-    PacketTable::for_protocol(774)
-        .unwrap()
-        .id(Phase::Game, dir, name)
-        .unwrap()
-}
-
-/// Translates a hand-built 1.21.11 game frame and decodes the result with
-/// azalea's 26.2 codecs.
-fn translate_and_decode_774(old: Vec<u8>) -> ClientboundGamePacket {
-    let translated = translation_774()
-        .translate_game_frame(old.into_boxed_slice())
-        .unwrap();
-    azalea_protocol::read::deserialize_packet(&mut std::io::Cursor::new(&translated)).unwrap()
-}
-
 /// 26.1's game ids match 26.2, so its frames pass through without the id
 /// remap or the outbound reroute; 1.21.11's diverge, so they don't.
 #[test]
 fn outbound_translation_gating() {
-    assert!(!translation().translates_outbound());
-    assert!(translation_774().translates_outbound());
+    assert!(!translation_for(775).translates_outbound());
+    assert!(translation_for(774).translates_outbound());
 }
 
 /// The id remap alone (`set_health` shifted between the versions).
 #[test]
 fn remap_game_ids_774() {
     let mut old = Vec::new();
-    wire::write_varint(&mut old, old_id_774(Direction::Clientbound, "set_health"));
+    wire::write_varint(&mut old, old_id(774, Direction::Clientbound, "set_health"));
     old.extend_from_slice(&18.0f32.to_be_bytes());
     wire::write_varint(&mut old, 19); // food
     old.extend_from_slice(&4.5f32.to_be_bytes());
 
-    let ClientboundGamePacket::SetHealth(p) = translate_and_decode_774(old) else {
+    let ClientboundGamePacket::SetHealth(p) = translate_and_decode(774, old) else {
         panic!("wrong packet");
     };
     assert_eq!(p.health, 18.0);
@@ -385,14 +378,14 @@ fn translate_entity_data_774() {
     let mut old = Vec::new();
     wire::write_varint(
         &mut old,
-        old_id_774(Direction::Clientbound, "set_entity_data"),
+        old_id(774, Direction::Clientbound, "set_entity_data"),
     );
     wire::write_varint(&mut old, 9); // entity id
     old.extend_from_slice(&[0, 0, 2]); // index 0, serializer byte, value 2
     old.extend_from_slice(&[17, 22, 4]); // index 17, cow_variant, holder id 4
     old.push(0xFF);
 
-    let ClientboundGamePacket::SetEntityData(p) = translate_and_decode_774(old) else {
+    let ClientboundGamePacket::SetEntityData(p) = translate_and_decode(774, old) else {
         panic!("wrong packet");
     };
     assert_eq!(p.id, MinecraftEntityId(9));
@@ -416,7 +409,7 @@ fn translate_chunk_774() {
     let mut old = Vec::new();
     wire::write_varint(
         &mut old,
-        old_id_774(Direction::Clientbound, "level_chunk_with_light"),
+        old_id(774, Direction::Clientbound, "level_chunk_with_light"),
     );
     old.extend_from_slice(&3i32.to_be_bytes()); // chunk x
     old.extend_from_slice(&(-2i32).to_be_bytes()); // chunk z
@@ -428,7 +421,7 @@ fn translate_chunk_774() {
     old.push(0); // no block entities
     old.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // empty light masks + lists
 
-    let ClientboundGamePacket::LevelChunkWithLight(p) = translate_and_decode_774(old) else {
+    let ClientboundGamePacket::LevelChunkWithLight(p) = translate_and_decode(774, old) else {
         panic!("wrong packet");
     };
     assert_eq!(p.x, 3);
@@ -440,12 +433,12 @@ fn translate_chunk_774() {
 #[test]
 fn translate_set_time_774() {
     let mut old = Vec::new();
-    wire::write_varint(&mut old, old_id_774(Direction::Clientbound, "set_time"));
+    wire::write_varint(&mut old, old_id(774, Direction::Clientbound, "set_time"));
     old.extend_from_slice(&12000u64.to_be_bytes()); // game time
     old.extend_from_slice(&6000u64.to_be_bytes()); // day time
     old.push(1); // tickDayTime
 
-    let ClientboundGamePacket::SetTime(p) = translate_and_decode_774(old) else {
+    let ClientboundGamePacket::SetTime(p) = translate_and_decode(774, old) else {
         panic!("wrong packet");
     };
     assert_eq!(p.game_time, 12000);
@@ -459,8 +452,8 @@ fn translate_set_time_774() {
 /// 1.21.11 reference).
 #[test]
 fn translate_attack_774() {
-    let frames = translation_774().translate_outbound_game_frame(wire::encode_attack(42));
-    let interact = old_id_774(Direction::Serverbound, "interact");
+    let frames = translation_for(774).translate_outbound_game_frame(wire::encode_attack(42));
+    let interact = old_id(774, Direction::Serverbound, "interact");
     assert_eq!(frames, [[interact as u8, 42, 1, 0]]);
 }
 
@@ -469,11 +462,11 @@ fn translate_attack_774() {
 #[test]
 fn translate_interact_774() {
     let location = DVec3::new(0.5, 1.25, -0.25);
-    let frames =
-        translation_774().translate_outbound_game_frame(wire::encode_interact(42, location, true));
+    let frames = translation_for(774)
+        .translate_outbound_game_frame(wire::encode_interact(42, location, true));
     assert_eq!(frames.len(), 2);
 
-    let interact = old_id_774(Direction::Serverbound, "interact") as u8;
+    let interact = old_id(774, Direction::Serverbound, "interact") as u8;
     let at = &frames[0];
     assert_eq!(at[..3], [interact, 42, 2]);
     let float_at = |i: usize| f32::from_be_bytes(at[3 + 4 * i..7 + 4 * i].try_into().unwrap());
@@ -497,7 +490,7 @@ fn suppress_unknown_outbound_774() {
     );
     frame.push(0);
     assert!(
-        translation_774()
+        translation_for(774)
             .translate_outbound_game_frame(frame)
             .is_empty()
     );
@@ -510,11 +503,74 @@ fn remap_outbound_ids_774() {
     let mut frame = Vec::new();
     wire::write_varint(&mut frame, table_id(Direction::Serverbound, "swing"));
     frame.push(0); // main hand
-    let frames = translation_774().translate_outbound_game_frame(frame);
+    let frames = translation_for(774).translate_outbound_game_frame(frame);
     assert_eq!(
         frames,
-        [[old_id_774(Direction::Serverbound, "swing") as u8, 0]]
+        [[old_id(774, Direction::Serverbound, "swing") as u8, 0]]
     );
+}
+
+// 1.21.10's game tables and layouts match 1.21.11's except clientbound 40
+// (`horse_screen_open`, which 1.21.11 renamed `mount_screen_open`) and the
+// serializer interleave, so the shared frame rewriters are covered by the
+// 774 tests above; the tests below pin what's 1.21.10-specific.
+
+/// The 1.21.10 serializer interleave: `sniffer_state` is 30 there (31 on
+/// 1.21.11, 35 on 26.2), past the `zombie_nautilus_variant` insertion the
+/// 1.21.11 map doesn't account for.
+#[test]
+fn translate_entity_data_773() {
+    let mut old = Vec::new();
+    wire::write_varint(
+        &mut old,
+        old_id(773, Direction::Clientbound, "set_entity_data"),
+    );
+    wire::write_varint(&mut old, 9); // entity id
+    old.extend_from_slice(&[0, 0, 2]); // index 0, serializer byte, value 2
+    old.extend_from_slice(&[17, 30, 2]); // index 17, sniffer_state, ordinal 2
+    old.push(0xFF);
+
+    let ClientboundGamePacket::SetEntityData(p) = translate_and_decode(773, old) else {
+        panic!("wrong packet");
+    };
+    let items = &p.packed_items.0;
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[1].index, 17);
+    assert!(matches!(
+        items[1].value,
+        azalea_entity::EntityDataValue::SnifferState(_)
+    ));
+}
+
+/// 1.21.11 renamed `horse_screen_open` -> `mount_screen_open` with identical
+/// fields (containerId, inventoryColumns varints, entityId int in both
+/// references); the name alias keeps the frame flowing under the new id.
+#[test]
+fn translate_horse_screen_open_773() {
+    let mut old = Vec::new();
+    wire::write_varint(
+        &mut old,
+        old_id(773, Direction::Clientbound, "horse_screen_open"),
+    );
+    old.push(1); // container id
+    old.push(3); // inventory columns
+    old.extend_from_slice(&42i32.to_be_bytes());
+
+    let ClientboundGamePacket::MountScreenOpen(p) = translate_and_decode(773, old) else {
+        panic!("wrong packet");
+    };
+    assert_eq!(p.container_id, 1);
+    assert_eq!(p.inventory_columns, 3);
+    assert_eq!(p.entity_id, MinecraftEntityId(42));
+}
+
+/// 1.21.10, like 1.21.11, has no serverbound `attack`; the same reroute to
+/// `interact` with the ATTACK action applies through its own id table.
+#[test]
+fn translate_attack_773() {
+    let frames = translation_for(773).translate_outbound_game_frame(wire::encode_attack(42));
+    let interact = old_id(773, Direction::Serverbound, "interact");
+    assert_eq!(frames, [[interact as u8, 42, 1, 0]]);
 }
 
 #[test]

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -32,10 +32,19 @@
 //!   hand and a low-precision hit location; 26.2-only serverbound packets
 //!   without an equivalent (`set_game_rule`, `spectator_action`) are suppressed
 //!
+//! 1.21.10 -> 26.2 wire changes (identical to 1.21.11's — the packet layouts
+//! didn't change between the two — except):
+//! - clientbound 40 is `horse_screen_open`, which 1.21.11 renamed
+//!   `mount_screen_open` with identical fields; the id match aliases the pair
+//! - `EntityDataSerializers` lacks 1.21.11's `zombie_nautilus_variant` (28) and
+//!   trailing `humanoid_arm`, so the serializer remap differs
+//!
 //! Known limitation (accepted): an inbound item stack carrying a data
 //! component at/after the first id the versions number differently (26.1:
 //! 78, where 26.2 inserted `sulfur_cube_content`; 1.21.11: 41, where 26.x
-//! inserted `additional_trade_cost`) decodes under the wrong 26.2 codec —
+//! inserted `additional_trade_cost`; 1.21.10: 5, where 1.21.11 inserted
+//! `use_effects` — so even `custom_name` and `enchantments` are affected
+//! there) decodes under the wrong 26.2 codec —
 //! usually a misparse that skips the packet via `skip_malformed_packet`,
 //! though a coincidentally parsable layout yields a silently wrong
 //! component. Common survival items only use earlier, unshifted components.
@@ -71,11 +80,15 @@ pub struct Translation {
 /// latest, plus the latest-space ids its frame rewrites dispatch on.
 struct GameIds {
     /// Wire-version clientbound id -> latest id; `None` drops the frame
-    /// (no latest equivalent — none exist for 1.21.11, kept for safety).
+    /// (no latest equivalent — none exist for 1.21.11/1.21.10, kept for
+    /// safety).
     inbound: Box<[Option<u32>]>,
     /// Latest serverbound id -> wire-version id; `None` suppresses the
     /// frame (the packet doesn't exist on the older version).
     outbound: Box<[Option<u32>]>,
+    /// The wire version's `EntityDataSerializers` interleave (the
+    /// registration order shifts between versions).
+    serializer_map: fn(u32) -> Option<u32>,
     set_entity_data_id: u32,
     level_chunk_id: u32,
     set_time_id: u32,
@@ -87,7 +100,7 @@ struct GameIds {
 /// Protocols the wire translation fully covers. A version with embedded
 /// tables but no entry here (the staging state while its translation is
 /// built) pings with the right version but stays un-joinable.
-const TRANSLATED: &[i32] = &[775, 774];
+const TRANSLATED: &[i32] = &[775, 774, 773];
 
 /// Whether a server speaking `protocol` can be joined: the native latest
 /// version, or an older one with a complete wire translation. Gates both
@@ -137,7 +150,7 @@ impl Translation {
             login_finished_id: id(Phase::Login, "login_finished"),
             game_login_id: id(Phase::Game, "login"),
             set_player_team_id: id(Phase::Game, "set_player_team"),
-            game_ids: GameIds::build(table, latest),
+            game_ids: GameIds::build(protocol, table, latest),
         })
     }
 
@@ -177,7 +190,7 @@ impl Translation {
             translate_team(id, payload)
         } else if let Some(ids) = &self.game_ids {
             if id == ids.set_entity_data_id {
-                translate_entity_data(id, payload)
+                translate_entity_data(id, payload, ids.serializer_map)
             } else if id == ids.level_chunk_id {
                 translate_chunk(id, payload)
             } else if id == ids.set_time_id {
@@ -343,18 +356,40 @@ impl Translation {
     }
 }
 
+/// Packets renamed between versions with identical fields; name matching
+/// treats each pair as the same packet.
+const RENAMED: &[(&str, &str)] = &[
+    // 1.21.11 renamed `horse_screen_open` (same containerId /
+    // inventoryColumns / entityId fields; `ClientboundHorseScreenOpenPacket`
+    // vs `ClientboundMountScreenOpenPacket` in the references).
+    ("horse_screen_open", "mount_screen_open"),
+];
+
 impl GameIds {
     /// Name-matched game-phase id tables between one wire version and the
     /// latest. `None` when translation-by-id is a no-op: every inbound id
     /// maps to itself and every outbound id maps to itself or to nothing
     /// (26.1's only divergence is 26.2's `spectate_entity` ->
     /// `spectator_action` rename, which pomme never sends).
-    fn build(table: &PacketTable, latest: &PacketTable) -> Option<GameIds> {
+    fn build(protocol: i32, table: &PacketTable, latest: &PacketTable) -> Option<GameIds> {
         use Direction::{Clientbound, Serverbound};
         let map = |from: &PacketTable, to: &PacketTable, dir| -> Box<[Option<u32>]> {
             (0..)
                 .map_while(|i| from.name_of(Phase::Game, dir, i))
-                .map(|name| to.id(Phase::Game, dir, name))
+                .map(|name| {
+                    to.id(Phase::Game, dir, name).or_else(|| {
+                        let alias = RENAMED.iter().find_map(|&(a, b)| {
+                            if name == a {
+                                Some(b)
+                            } else if name == b {
+                                Some(a)
+                            } else {
+                                None
+                            }
+                        })?;
+                        to.id(Phase::Game, dir, alias)
+                    })
+                })
                 .collect()
         };
         let inbound = map(table, latest, Clientbound);
@@ -374,6 +409,11 @@ impl GameIds {
         Some(GameIds {
             inbound,
             outbound,
+            serializer_map: match protocol {
+                774 => remap_serializer_774,
+                773 => remap_serializer_773,
+                p => panic!("no serializer map for protocol {p}"),
+            },
             set_entity_data_id: id(Clientbound, "set_entity_data"),
             level_chunk_id: id(Clientbound, "level_chunk_with_light"),
             set_time_id: id(Clientbound, "set_time"),
@@ -457,11 +497,11 @@ fn translate_interact(interact_old_id: u32, payload: &[u8]) -> Vec<Vec<u8>> {
     vec![at, plain]
 }
 
-/// The latest serializer id for an old `EntityDataSerializers` id: 26.x
+/// The latest serializer id for a 1.21.11 `EntityDataSerializers` id: 26.x
 /// interleaved `cat/cow/pig/chicken_sound_variant` at ids 22/24/29/31
 /// (line-checked against both versions' `EntityDataSerializers.java`
 /// registration blocks; anchored by tests in `azalea_compat`).
-fn remap_serializer(old: u32) -> Option<u32> {
+fn remap_serializer_774(old: u32) -> Option<u32> {
     Some(match old {
         0..=21 => old,
         22 => 23,
@@ -470,6 +510,19 @@ fn remap_serializer(old: u32) -> Option<u32> {
         28..=38 => old + 4,
         _ => return None,
     })
+}
+
+/// The latest serializer id for a 1.21.10 `EntityDataSerializers` id:
+/// 1.21.11 inserted `zombie_nautilus_variant` right above `chicken_variant`
+/// (27), shifting everything past it by one more slot; below that the
+/// 1.21.11 interleave applies unchanged (its trailing `humanoid_arm`
+/// addition shifts nothing).
+fn remap_serializer_773(old: u32) -> Option<u32> {
+    match old {
+        0..=27 => remap_serializer_774(old),
+        28..=36 => Some(old + 5),
+        _ => None,
+    }
 }
 
 /// Rewrites the game `login` payload: 26.2 added `onlineMode` before the
@@ -486,12 +539,17 @@ fn translate_game_login(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
 
 /// Rewrites `set_entity_data` (`entityId`, then `(u8 index, varint
 /// serializer, value)` entries terminated by `0xFF`) by remapping each
-/// entry's serializer id. Value layouts are identical between the versions
-/// (verified serializer by serializer); they're skipped, not decoded. An
-/// item-stack or particle value can't be skipped without full component /
-/// particle codecs — the remainder is copied verbatim, which is correct
-/// unless a shifted serializer follows one (no vanilla entity does that).
-fn translate_entity_data(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
+/// entry's serializer id through the wire version's `serializer_map`. Value
+/// layouts are identical between the versions (verified serializer by
+/// serializer); they're skipped, not decoded. An item-stack or particle
+/// value can't be skipped without full component / particle codecs — the
+/// remainder is copied verbatim, which is correct unless a shifted
+/// serializer follows one (no vanilla entity does that).
+fn translate_entity_data(
+    id: u32,
+    payload: &[u8],
+    serializer_map: fn(u32) -> Option<u32>,
+) -> Option<Vec<u8>> {
     let mut cur = Cursor::new(payload);
     varint_span(&mut cur)?; // entity id
 
@@ -505,10 +563,10 @@ fn translate_entity_data(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
             break;
         }
         let old = u32::azalea_read_var(&mut cur).ok()?;
-        let new = remap_serializer(old)?;
+        let new = serializer_map(old)?;
         wire::write_varint(&mut out, new);
         let value_at = cur.position() as usize;
-        if !skip_metadata_value(&mut cur, old)? {
+        if !skip_metadata_value(&mut cur, new)? {
             tracing::debug!("Copying entity data tail verbatim past serializer {old}");
             out.extend_from_slice(&payload[value_at..]);
             return Some(out);
@@ -519,19 +577,21 @@ fn translate_entity_data(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
     Some(out)
 }
 
-/// Advances past one entity-data value of the given old-version serializer.
-/// `Some(false)` means the value (and thus anything after it) can't be
-/// walked; `None` means the data is malformed.
+/// Advances past one entity-data value of the given latest-version
+/// serializer (the caller remaps first; value layouts are identical across
+/// the supported versions, verified serializer by serializer). `Some(false)`
+/// means the value (and thus anything after it) can't be walked; `None`
+/// means the data is malformed.
 fn skip_metadata_value(cur: &mut Cursor<&[u8]>, serializer: u32) -> Option<bool> {
     match serializer {
         0 | 8 => advance(cur, 1)?, // byte, boolean
         3 => advance(cur, 4)?,     // float
         9 => advance(cur, 12)?,    // rotations
         10 => advance(cur, 8)?,    // block_pos
-        35 => advance(cur, 12)?,   // vector3
-        36 => advance(cur, 16)?,   // quaternion
+        39 => advance(cur, 12)?,   // vector3
+        40 => advance(cur, 16)?,   // quaternion
         // varint-shaped: int, enums, registry/holder ids, optional ints
-        1 | 12 | 14 | 15 | 19 | 20 | 21 | 22..=28 | 31..=34 | 38 => {
+        1 | 12 | 14 | 15 | 19 | 20 | 21 | 22..=32 | 35..=38 | 42 => {
             varint_span(cur)?;
         }
         2 => {
@@ -548,14 +608,14 @@ fn skip_metadata_value(cur: &mut Cursor<&[u8]>, serializer: u32) -> Option<bool>
             varint_span(cur)?;
             varint_span(cur)?;
         }
-        29 => {
+        33 => {
             // optional global pos: dimension key + block pos
             skip_optional(cur, |c| {
                 skip_utf(c)?;
                 advance(c, 8)
             })?;
         }
-        30 => {
+        34 => {
             // painting variant holder: id + 1, or 0 followed by the direct
             // form (width, height, asset id, optional title/author)
             if u32::azalea_read_var(cur).ok()? == 0 {
@@ -566,7 +626,7 @@ fn skip_metadata_value(cur: &mut Cursor<&[u8]>, serializer: u32) -> Option<bool>
                 skip_optional(cur, skip_nbt)?;
             }
         }
-        // item stacks (7), particles (16/17) and resolvable profiles (37)
+        // item stacks (7), particles (16/17) and resolvable profiles (41)
         // need full value codecs to walk past
         _ => return Some(false),
     }

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -359,9 +359,8 @@ impl Translation {
 /// Packets renamed between versions with identical fields; name matching
 /// treats each pair as the same packet.
 const RENAMED: &[(&str, &str)] = &[
-    // 1.21.11 renamed `horse_screen_open` (same containerId /
-    // inventoryColumns / entityId fields; `ClientboundHorseScreenOpenPacket`
-    // vs `ClientboundMountScreenOpenPacket` in the references).
+    // `ClientboundHorseScreenOpenPacket` vs `ClientboundMountScreenOpenPacket`
+    // in the references, byte-identical write() bodies.
     ("horse_screen_open", "mount_screen_open"),
 ];
 
@@ -578,10 +577,9 @@ fn translate_entity_data(
 }
 
 /// Advances past one entity-data value of the given latest-version
-/// serializer (the caller remaps first; value layouts are identical across
-/// the supported versions, verified serializer by serializer). `Some(false)`
-/// means the value (and thus anything after it) can't be walked; `None`
-/// means the data is malformed.
+/// serializer (the caller remaps first). `Some(false)` means the value (and
+/// thus anything after it) can't be walked; `None` means the data is
+/// malformed.
 fn skip_metadata_value(cur: &mut Cursor<&[u8]>, serializer: u32) -> Option<bool> {
     match serializer {
         0 | 8 => advance(cur, 1)?, // byte, boolean

--- a/pomme-protocol/src/version.rs
+++ b/pomme-protocol/src/version.rs
@@ -17,8 +17,7 @@ pub const VERSIONS: &[ProtocolVersion] = &[
     v("26.1.1", 775),
     v("26.1", 775),
     v("1.21.11", 774),
-    // 1.21.10 (773) has embedded tables but no wire translation yet; it
-    // becomes launchable when the translation lands.
+    v("1.21.10", 773),
 ];
 
 /// The version the client speaks internally.
@@ -93,6 +92,8 @@ mod tests {
         assert_eq!(ProtocolVersion::from_protocol(775).unwrap().name, "26.1.2");
         assert_eq!(ProtocolVersion::from_name("1.21.11").unwrap().protocol, 774);
         assert_eq!(ProtocolVersion::from_protocol(774).unwrap().name, "1.21.11");
+        assert_eq!(ProtocolVersion::from_name("1.21.10").unwrap().protocol, 773);
+        assert_eq!(ProtocolVersion::from_protocol(773).unwrap().name, "1.21.10");
         assert!(ProtocolVersion::from_name("26.1.1-rc-1").is_none());
         assert!(ProtocolVersion::from_name("1.8.9").is_none());
     }


### PR DESCRIPTION
Wire translation for 1.21.10. Same as 1.21.11 except the horse_screen_open rename and its own entity data serializer table.