### PR TITLE
break speed from held tool

### DIFF
--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -5,7 +5,9 @@ use azalea_core::direction::Direction;
 use azalea_core::position::BlockPos;
 use azalea_entity::dimensions::EntityDimensions;
 use azalea_inventory::ItemStackData;
-use azalea_inventory::components::{Consumable, Food, ItemUseAnimation, UseEffects};
+use azalea_inventory::components::{
+    Consumable, Food, ItemUseAnimation, Tool, ToolRule, UseEffects,
+};
 use azalea_inventory::default_components::{DefaultableComponent, get_default_component};
 use azalea_protocol::packets::game::ServerboundGamePacket;
 use azalea_protocol::packets::game::s_interact::InteractionHand;
@@ -13,7 +15,9 @@ use azalea_protocol::packets::game::s_player_action::{Action, ServerboundPlayerA
 use azalea_protocol::packets::game::s_set_carried_item::ServerboundSetCarriedItem;
 use azalea_protocol::packets::game::s_use_item::ServerboundUseItem;
 use azalea_protocol::packets::game::s_use_item_on::{BlockHit, ServerboundUseItemOn};
-use azalea_registry::builtin::ItemKind;
+use azalea_registry::HolderSet;
+use azalea_registry::builtin::{BlockKind, ItemKind};
+use azalea_registry::identifier::Identifier;
 use glam::{DVec3, Vec3, dvec3};
 use pomme_protocol::wire;
 
@@ -875,7 +879,7 @@ impl InteractionState {
             return;
         }
 
-        let progress = destroy_progress(state, on_ground, creative);
+        let progress = destroy_progress(state, on_ground, creative, held_stack);
 
         if progress >= 1.0 {
             if self.is_destroying {
@@ -981,7 +985,7 @@ impl InteractionState {
             return;
         }
 
-        self.destroy_progress += destroy_progress(state, on_ground, creative);
+        self.destroy_progress += destroy_progress(state, on_ground, creative, held_stack);
         if self.destroy_ticks % 4.0 == 0.0 {
             play_hit_sound(audio, state, hit.block_pos);
         }
@@ -1075,7 +1079,15 @@ fn opens_menu(state: BlockState) -> bool {
         || id.ends_with("anvil")
 }
 
-fn destroy_progress(state: BlockState, on_ground: bool, creative: bool) -> f32 {
+/// Vanilla `BlockBehaviour.getDestroyProgress` with `Player.getDestroySpeed`
+/// as the numerator: the held tool's mining speed over hardness, divided by 30
+/// with the correct tool for drops and 100 without.
+fn destroy_progress(
+    state: BlockState,
+    on_ground: bool,
+    creative: bool,
+    held_stack: Option<&ItemStackData>,
+) -> f32 {
     if creative {
         return 1.0;
     }
@@ -1089,17 +1101,54 @@ fn destroy_progress(state: BlockState, on_ground: bool, creative: bool) -> f32 {
         return 1.0;
     }
 
-    let mut speed = 1.0_f32;
+    let tool = held_stack.and_then(stack_component::<Tool>);
+    let tool = tool.as_ref();
+    let kind = state.as_block_kind();
+
+    let mut speed = tool.map_or(1.0, |t| tool_mining_speed(t, kind));
+    // TODO: the `getDestroySpeed` modifier chain (mining efficiency, haste /
+    // mining fatigue, block break speed, submerged mining speed) needs
+    // attribute and mob-effect tracking.
     if !on_ground {
         speed /= 5.0;
     }
 
-    let divisor = if behavior.requires_correct_tool_for_drops {
-        100.0
-    } else {
-        30.0
-    };
+    let correct_tool = !behavior.requires_correct_tool_for_drops
+        || tool.is_some_and(|t| tool_correct_for_drops(t, kind));
+    let divisor = if correct_tool { 30.0 } else { 100.0 };
     speed / hardness / divisor
+}
+
+/// Vanilla `Tool.getMiningSpeed`: first rule with a speed that covers the
+/// block wins, else the default.
+fn tool_mining_speed(tool: &Tool, kind: BlockKind) -> f32 {
+    first_rule_value(tool, kind, |r| r.speed).unwrap_or(tool.default_mining_speed)
+}
+
+/// Vanilla `Tool.isCorrectForDrops`: first rule with a verdict that covers
+/// the block wins, else false.
+fn tool_correct_for_drops(tool: &Tool, kind: BlockKind) -> bool {
+    first_rule_value(tool, kind, |r| r.correct_for_drops).unwrap_or(false)
+}
+
+fn first_rule_value<T: Copy>(
+    tool: &Tool,
+    kind: BlockKind,
+    field: impl Fn(&ToolRule) -> Option<T>,
+) -> Option<T> {
+    tool.rules
+        .iter()
+        .find_map(|rule| field(rule).filter(|_| holder_set_contains(&rule.blocks, kind)))
+}
+
+/// `Named` sets reference a block tag whose contents aren't on the wire, and
+/// pomme keeps no synced tag data, so they conservatively match nothing
+/// (azalea's item defaults inline every tag as `Direct`).
+fn holder_set_contains(set: &HolderSet<BlockKind, Identifier>, kind: BlockKind) -> bool {
+    match set {
+        HolderSet::Direct { contents } => contents.contains(&kind),
+        HolderSet::Named { .. } => false,
+    }
 }
 
 /// Plays a block's mining hit sound, matching vanilla
@@ -1442,5 +1491,60 @@ mod tests {
         ));
         assert!(!same_item_same_components(Some(&a), None));
         assert!(same_item_same_components(None, None));
+    }
+
+    fn rule(blocks: Vec<BlockKind>, speed: Option<f32>, correct: Option<bool>) -> ToolRule {
+        ToolRule {
+            blocks: HolderSet::Direct { contents: blocks },
+            speed,
+            correct_for_drops: correct,
+        }
+    }
+
+    /// Vanilla rule resolution: the first matching rule with the queried
+    /// field wins, and each field resolves independently.
+    #[test]
+    fn tool_rules_first_match_per_field() {
+        let tool = Tool {
+            rules: vec![
+                rule(vec![BlockKind::Obsidian], None, Some(false)),
+                rule(
+                    vec![BlockKind::Stone, BlockKind::Obsidian],
+                    Some(4.0),
+                    Some(true),
+                ),
+            ],
+            default_mining_speed: 1.5,
+            ..Tool::new()
+        };
+        assert_eq!(tool_mining_speed(&tool, BlockKind::Stone), 4.0);
+        assert!(tool_correct_for_drops(&tool, BlockKind::Stone));
+        // The speedless first rule is skipped for speed but wins for drops.
+        assert_eq!(tool_mining_speed(&tool, BlockKind::Obsidian), 4.0);
+        assert!(!tool_correct_for_drops(&tool, BlockKind::Obsidian));
+        // No matching rule: default speed, not correct for drops.
+        assert_eq!(tool_mining_speed(&tool, BlockKind::Dirt), 1.5);
+        assert!(!tool_correct_for_drops(&tool, BlockKind::Dirt));
+    }
+
+    #[test]
+    fn named_holder_set_matches_nothing() {
+        let set = HolderSet::Named {
+            key: Identifier::new("minecraft:mineable/pickaxe"),
+            contents: vec![],
+        };
+        assert!(!holder_set_contains(&set, BlockKind::Stone));
+    }
+
+    /// The generated iron pickaxe default resolves like vanilla: fast and
+    /// correct on stone, default speed on dirt.
+    #[test]
+    fn iron_pickaxe_default_tool() {
+        let pickaxe = stack(ItemKind::IronPickaxe, 1);
+        let tool = stack_component::<Tool>(&pickaxe).expect("iron pickaxe has a tool component");
+        assert_eq!(tool_mining_speed(&tool, BlockKind::Stone), 6.0);
+        assert!(tool_correct_for_drops(&tool, BlockKind::Stone));
+        assert_eq!(tool_mining_speed(&tool, BlockKind::Dirt), 1.0);
+        assert!(!tool_correct_for_drops(&tool, BlockKind::Dirt));
     }
 }

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -106,6 +106,9 @@ pub struct InteractionState {
     pending_predictions: HashMap<BlockPos, ServerVerifiedState>,
     is_destroying: bool,
     destroy_pos: BlockPos,
+    /// Held stack captured when the break started, vanilla `destroyingItem`;
+    /// a mid-mine change of item or components restarts the break.
+    destroying_item: Option<ItemStackData>,
     destroy_progress: f32,
     destroy_ticks: f32,
     destroy_delay: u32,
@@ -136,6 +139,7 @@ impl InteractionState {
                 y: -1,
                 z: -1,
             },
+            destroying_item: None,
             destroy_progress: 0.0,
             destroy_ticks: 0.0,
             destroy_delay: 0,
@@ -376,6 +380,7 @@ impl InteractionState {
                 player_pos,
                 on_ground,
                 creative,
+                held_stack,
                 effects,
                 &mut dirty_chunks,
             );
@@ -389,6 +394,7 @@ impl InteractionState {
                 player_pos,
                 on_ground,
                 creative,
+                held_stack,
                 effects,
                 &mut dirty_chunks,
             );
@@ -459,6 +465,7 @@ impl InteractionState {
         player_pos: DVec3,
         on_ground: bool,
         creative: bool,
+        held_stack: Option<&ItemStackData>,
         effects: &mut BreakEffects,
         dirty_chunks: &mut Vec<BlockPos>,
     ) {
@@ -496,6 +503,7 @@ impl InteractionState {
             player_pos,
             on_ground,
             creative,
+            held_stack,
             effects,
             dirty_chunks,
         );
@@ -511,6 +519,7 @@ impl InteractionState {
         player_pos: DVec3,
         on_ground: bool,
         creative: bool,
+        held_stack: Option<&ItemStackData>,
         effects: &mut BreakEffects,
         dirty_chunks: &mut Vec<BlockPos>,
     ) {
@@ -539,6 +548,7 @@ impl InteractionState {
             player_pos,
             on_ground,
             creative,
+            held_stack,
             effects,
             dirty_chunks,
         );
@@ -855,6 +865,7 @@ impl InteractionState {
         player_pos: DVec3,
         on_ground: bool,
         creative: bool,
+        held_stack: Option<&ItemStackData>,
         effects: &mut BreakEffects,
         dirty_chunks: &mut Vec<BlockPos>,
     ) {
@@ -898,7 +909,7 @@ impl InteractionState {
             return;
         }
 
-        if self.is_destroying && self.destroy_pos == hit.block_pos {
+        if self.is_destroying && self.same_destroy_target(hit.block_pos, held_stack) {
             return;
         }
 
@@ -924,6 +935,7 @@ impl InteractionState {
 
         self.is_destroying = true;
         self.destroy_pos = hit.block_pos;
+        self.destroying_item = held_stack.cloned();
         self.destroy_progress = 0.0;
         self.destroy_ticks = 0.0;
     }
@@ -938,6 +950,7 @@ impl InteractionState {
         player_pos: DVec3,
         on_ground: bool,
         creative: bool,
+        held_stack: Option<&ItemStackData>,
         effects: &mut BreakEffects,
         dirty_chunks: &mut Vec<BlockPos>,
     ) {
@@ -946,7 +959,7 @@ impl InteractionState {
             return;
         }
 
-        if self.destroy_pos != hit.block_pos {
+        if !self.same_destroy_target(hit.block_pos, held_stack) {
             self.start_destroy_block(
                 hit,
                 chunks,
@@ -955,6 +968,7 @@ impl InteractionState {
                 player_pos,
                 on_ground,
                 creative,
+                held_stack,
                 effects,
                 dirty_chunks,
             );
@@ -1012,6 +1026,12 @@ impl InteractionState {
         }
     }
 
+    /// Vanilla `MultiPlayerGameMode.sameDestroyTarget`: still mining the same
+    /// block with the same item.
+    fn same_destroy_target(&self, pos: BlockPos, held: Option<&ItemStackData>) -> bool {
+        self.destroy_pos == pos && same_item_same_components(held, self.destroying_item.as_ref())
+    }
+
     fn stop_destroying(&mut self, sender: &PacketSender) {
         if self.is_destroying {
             send_action(
@@ -1024,6 +1044,16 @@ impl InteractionState {
             self.is_destroying = false;
             self.destroy_progress = 0.0;
         }
+    }
+}
+
+/// Vanilla `ItemStack.isSameItemSameComponents`: item type and components,
+/// never the count. `None` is the empty hand.
+fn same_item_same_components(a: Option<&ItemStackData>, b: Option<&ItemStackData>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some(a), Some(b)) => a.kind == b.kind && a.component_patch == b.component_patch,
+        _ => false,
     }
 }
 
@@ -1383,4 +1413,34 @@ pub(crate) fn send_swap_offhand(sender: &PacketSender) {
         Direction::Down,
         0,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stack(kind: ItemKind, count: i32) -> ItemStackData {
+        ItemStackData {
+            kind,
+            count,
+            component_patch: Default::default(),
+        }
+    }
+
+    /// Vanilla `isSameItemSameComponents`: count never matters, the item type
+    /// does, and the empty hand only matches itself.
+    #[test]
+    fn item_comparison_ignores_count() {
+        let a = stack(ItemKind::Stone, 1);
+        assert!(same_item_same_components(
+            Some(&a),
+            Some(&stack(ItemKind::Stone, 64))
+        ));
+        assert!(!same_item_same_components(
+            Some(&a),
+            Some(&stack(ItemKind::Dirt, 1))
+        ));
+        assert!(!same_item_same_components(Some(&a), None));
+        assert!(same_item_same_components(None, None));
+    }
 }

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1419,26 +1419,18 @@ pub(crate) fn send_swap_offhand(sender: &PacketSender) {
 mod tests {
     use super::*;
 
-    fn stack(kind: ItemKind, count: i32) -> ItemStackData {
-        ItemStackData {
-            kind,
-            count,
-            component_patch: Default::default(),
-        }
-    }
-
     /// Vanilla `isSameItemSameComponents`: count never matters, the item type
     /// does, and the empty hand only matches itself.
     #[test]
     fn item_comparison_ignores_count() {
-        let a = stack(ItemKind::Stone, 1);
+        let a = ItemStackData::new(ItemKind::Stone, 1);
         assert!(same_item_same_components(
             Some(&a),
-            Some(&stack(ItemKind::Stone, 64))
+            Some(&ItemStackData::new(ItemKind::Stone, 64))
         ));
         assert!(!same_item_same_components(
             Some(&a),
-            Some(&stack(ItemKind::Dirt, 1))
+            Some(&ItemStackData::new(ItemKind::Dirt, 1))
         ));
         assert!(!same_item_same_components(Some(&a), None));
         assert!(same_item_same_components(None, None));

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -15,9 +15,7 @@ use azalea_protocol::packets::game::s_player_action::{Action, ServerboundPlayerA
 use azalea_protocol::packets::game::s_set_carried_item::ServerboundSetCarriedItem;
 use azalea_protocol::packets::game::s_use_item::ServerboundUseItem;
 use azalea_protocol::packets::game::s_use_item_on::{BlockHit, ServerboundUseItemOn};
-use azalea_registry::HolderSet;
 use azalea_registry::builtin::{BlockKind, ItemKind};
-use azalea_registry::identifier::Identifier;
 use glam::{DVec3, Vec3, dvec3};
 use pomme_protocol::wire;
 
@@ -1138,17 +1136,7 @@ fn first_rule_value<T: Copy>(
 ) -> Option<T> {
     tool.rules
         .iter()
-        .find_map(|rule| field(rule).filter(|_| holder_set_contains(&rule.blocks, kind)))
-}
-
-/// `Named` sets reference a block tag whose contents aren't on the wire, and
-/// pomme keeps no synced tag data, so they conservatively match nothing
-/// (azalea's item defaults inline every tag as `Direct`).
-fn holder_set_contains(set: &HolderSet<BlockKind, Identifier>, kind: BlockKind) -> bool {
-    match set {
-        HolderSet::Direct { contents } => contents.contains(&kind),
-        HolderSet::Named { .. } => false,
-    }
+        .find_map(|rule| field(rule).filter(|_| rule.blocks.contains(kind)))
 }
 
 /// Plays a block's mining hit sound, matching vanilla
@@ -1466,6 +1454,9 @@ pub(crate) fn send_swap_offhand(sender: &PacketSender) {
 
 #[cfg(test)]
 mod tests {
+    use azalea_registry::HolderSet;
+    use azalea_registry::identifier::Identifier;
+
     use super::*;
 
     /// Vanilla `isSameItemSameComponents`: count never matters, the item type
@@ -1519,13 +1510,17 @@ mod tests {
         assert!(!tool_correct_for_drops(&tool, BlockKind::Dirt));
     }
 
+    /// Anchor on azalea's `HolderSet::contains`: `Named` sets reference a
+    /// block tag whose contents aren't on the wire and are never populated,
+    /// so tool rules sent with tags conservatively match nothing (azalea's
+    /// item defaults inline every tag as `Direct`).
     #[test]
     fn named_holder_set_matches_nothing() {
-        let set = HolderSet::Named {
+        let set: HolderSet<BlockKind, Identifier> = HolderSet::Named {
             key: Identifier::new("minecraft:mineable/pickaxe"),
             contents: vec![],
         };
-        assert!(!holder_set_contains(&set, BlockKind::Stone));
+        assert!(!set.contains(BlockKind::Stone));
     }
 
     /// The generated iron pickaxe default resolves like vanilla: fast and

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1052,7 +1052,7 @@ impl InteractionState {
 fn same_item_same_components(a: Option<&ItemStackData>, b: Option<&ItemStackData>) -> bool {
     match (a, b) {
         (None, None) => true,
-        (Some(a), Some(b)) => a.kind == b.kind && a.component_patch == b.component_patch,
+        (Some(a), Some(b)) => a.is_same_item_and_components(b),
         _ => false,
     }
 }

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1532,7 +1532,7 @@ mod tests {
     /// correct on stone, default speed on dirt.
     #[test]
     fn iron_pickaxe_default_tool() {
-        let pickaxe = stack(ItemKind::IronPickaxe, 1);
+        let pickaxe = ItemStackData::new(ItemKind::IronPickaxe, 1);
         let tool = stack_component::<Tool>(&pickaxe).expect("iron pickaxe has a tool component");
         assert_eq!(tool_mining_speed(&tool, BlockKind::Stone), 6.0);
         assert!(tool_correct_for_drops(&tool, BlockKind::Stone));


### PR DESCRIPTION
Use the held item's tool component for mining speed and the correct tool divisor. Stacked on #404, retarget to master once it merges.