### PR TITLE
faster dev builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# linux (rust 1.90+) already links with lld and macos ships a fast linker;
+# msvc's link.exe is the slow one, so swap in the toolchain-bundled lld there.
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ azalea-block = { path = "pomme-block" }
 
 [profile.dev]
 opt-level = 1
+# Backtraces and profilers keep file:line; full local-variable debuginfo is
+# opt-in via CARGO_PROFILE_DEV_DEBUG=full.
+debug = "line-tables-only"
 
 [profile.dev.package."*"]
 opt-level = 2


### PR DESCRIPTION
line-tables-only dev debuginfo and lld linking on msvc, incremental rebuilds drop about a third